### PR TITLE
Play Generation 1 music, effects and cries through its own driver

### DIFF
--- a/game/audio/gen1_sound_engine.gd
+++ b/game/audio/gen1_sound_engine.gd
@@ -1,0 +1,1141 @@
+class_name Gen1SoundEngine
+extends RefCounted
+
+## The Generation 1 sound driver, ported from `audio/engine_1.asm`.
+##
+## [method update_music] is one `Audio1_UpdateMusic`, run once per LCD frame: it
+## walks each of the eight channel streams and writes the hardware registers, and
+## [PokeApu] turns those writes into samples. The three near-identical copies of
+## the driver differ only in what [member audio_rom_bank] selects, so one port
+## carries all of them and reads that bank's own header table, effects, wave
+## instruments and music.
+
+const NUM_CHANNELS: int = 8
+const NUM_MUSIC_CHANS: int = 4
+const CHAN3: int = 2
+const CHAN4: int = 3
+const CHAN5: int = 4
+const CHAN7: int = 6
+const CHAN8: int = 7
+
+## The two sixteen-bit tables, as bases into [member _pointers].
+const CMD_POINTERS: int = 0
+const RETURN_ADDRESSES: int = 8
+
+## `wram.asm`'s per-channel arrays after those two tables, in address order, as
+## bases into [member _wram]. `.stopAllAudio`'s flat fill walks exactly this.
+const SOUND_IDS: int = 0
+const FLAGS1: int = 8
+const FLAGS2: int = 16
+const DUTY_CYCLES: int = 24
+const DUTY_CYCLE_PATTERNS: int = 32
+const VIBRATO_DELAY: int = 40
+const VIBRATO_EXTENTS: int = 48
+const VIBRATO_RATES: int = 56
+const FREQUENCY_LOW: int = 64
+const VIBRATO_RELOAD: int = 72
+const SLIDE_LENGTH_MOD: int = 80
+const SLIDE_STEPS: int = 88
+const SLIDE_STEPS_FRACTION: int = 96
+const SLIDE_CURRENT_FRACTION: int = 104
+const SLIDE_CURRENT_HIGH: int = 112
+const SLIDE_CURRENT_LOW: int = 120
+const SLIDE_TARGET_HIGH: int = 128
+const SLIDE_TARGET_LOW: int = 136
+const NOTE_DELAY: int = 144
+const LOOP_COUNTERS: int = 152
+const NOTE_SPEEDS: int = 160
+const NOTE_DELAY_FRACTION: int = 168
+const OCTAVES: int = 176
+const VOLUMES: int = 184
+const WRAM_SLOTS: int = 192
+## Where the pointer tables end, so the two flat fills below count in bytes.
+const POINTER_BYTES: int = 32
+
+const BIT_PERFECT_PITCH: int = 1 << 0
+const BIT_SOUND_CALL: int = 1 << 1
+const BIT_NOISE_OR_SFX: int = 1 << 2
+const BIT_VIBRATO_DIRECTION: int = 1 << 3
+const BIT_PITCH_SLIDE_ON: int = 1 << 4
+const BIT_PITCH_SLIDE_DECREASING: int = 1 << 5
+const BIT_ROTATE_DUTY_CYCLE: int = 1 << 6
+const BIT_EXECUTE_MUSIC: int = 1 << 0
+const BIT_MUTE_AUDIO: int = 1 << 7
+const BIT_LOW_HEALTH_ALARM: int = 1 << 7
+const LOW_HEALTH_TIMER_MASK: int = 0x7F
+const DISABLE_LOW_HEALTH_ALARM: int = 0xFF
+
+const SOUND_RET_CMD: int = 0xFF
+const SOUND_CALL_CMD: int = 0xFD
+const SOUND_LOOP_CMD: int = 0xFE
+const NOTE_TYPE_CMD: int = 0xD0
+const OCTAVE_CMD: int = 0xE0
+const SFX_NOTE_CMD: int = 0x20
+const PITCH_SWEEP_CMD: int = 0x10
+const PITCH_SLIDE_CMD: int = 0xEB
+const DRUM_NOTE_CMD: int = 0xB0
+const REST_CMD: int = 0xC0
+
+## The commands that take no time, keyed by the whole byte. `Audio1_octave` takes
+## what is left of $e0 to $ef and `Audio1_note` everything else.
+const COMMANDS: Dictionary = {
+	0xE8: &"_toggle_perfect_pitch",
+	0xEA: &"_vibrato",
+	0xEC: &"_duty_cycle",
+	0xED: &"_tempo",
+	0xEE: &"_stereo_panning",
+	0xEF: &"_unknown_ef",
+	0xF0: &"_volume",
+	0xF8: &"_execute_music",
+	0xFC: &"_duty_cycle_pattern",
+}
+
+const SFX_STOP_ALL_MUSIC: int = 0xFF
+## `music_const` numbering, the same on all three cartridges: ids below
+## [constant NOISE_INSTRUMENTS_END] are the nineteen drum instruments, and a cry
+## runs from [constant CRY_SFX_START] to one below [constant CRY_SFX_END].
+const NOISE_INSTRUMENTS_END: int = 20
+const CRY_SFX_START: int = 20
+const CRY_SFX_END: int = 134
+const BATTLE_SFX_START: int = 157
+const BATTLE_SFX_END: int = 234
+## Each audio bank opens with its own header table, three bytes per id, whose
+## first entry is $ff $ff $ff padding.
+const HEADER_TABLE_ADDRESS: int = 0x4000
+const HEADER_ENTRY_SIZE: int = 3
+
+const REG_DUTY_SOUND_LEN: int = 1
+const REG_VOLUME_ENVELOPE: int = 2
+const REG_FREQUENCY_LO: int = 3
+## `Audio1_HWChannelBaseAddresses`: channels 2 and 4 are pinned one below their
+## length register, so [constant REG_DUTY_SOUND_LEN] lands on it.
+const HW_CHANNEL_BASE: Array[int] = [0x10, 0x15, 0x1A, 0x1F, 0x10, 0x15, 0x1A, 0x1F]
+const HW_ENABLE_MASK: Array[int] = [0x11, 0x22, 0x44, 0x88, 0x11, 0x22, 0x44, 0x88]
+
+const RAUDVOL: int = 0xFF24
+const RAUDTERM: int = 0xFF25
+const RAUDENA: int = 0xFF26
+const RAUD1SWEEP: int = 0xFF10
+const RAUD3ENA: int = 0xFF1A
+const RAUD3LEVEL: int = 0xFF1C
+const AUD3ENA_ON: int = 0x80
+const AUD1SWEEP_DOWN: int = 0x08
+const AUD1HIGH_LENGTH_ON: int = 0x40
+const WAVE_RAM: int = 0xFF30
+const WAVE_RAM_SIZE: int = 16
+const MAX_VOLUME: int = 0x77
+const DEFAULT_TEMPO: int = 0x100
+
+## `audio/notes.asm`, read rather than derived: `Audio1_CalculateFrequency`
+## shifts these arithmetically, so every entry keeps its top bit.
+const PITCHES: Array[int] = [
+	0xF82C, 0xF89D, 0xF907, 0xF96B, 0xF9CA, 0xFA23,
+	0xFA77, 0xFAC7, 0xFB12, 0xFB58, 0xFB9B, 0xFBDA,
+]
+
+## A stream that jumps without reaching a note hangs the cartridge; bounding the
+## walk leaves a silent channel instead of a frozen game.
+const MAX_PARSE_STEPS: int = 4096
+
+var apu: PokeApu = null
+
+## Listening levels, 1.0 being the cartridge's own output. They weigh the mix
+## only, so a register trace reads the same whatever these are set to.
+var music_gain: float = 1.0
+var sfx_gain: float = 1.0
+
+## `wAudioROMBank`: which copy of the driver is running, and so which header
+## table, effect data and wave instruments an id names.
+var audio_rom_bank: int = 0
+
+var music_wave_instrument: int = 0
+var sfx_wave_instrument: int = 0
+var music_tempo: int = DEFAULT_TEMPO
+var sfx_tempo: int = DEFAULT_TEMPO
+var stereo_panning: int = 0xFF
+var sound_id: int = 0
+var saved_volume: int = 0
+var disable_channel_output_when_sfx_ends: int = 0
+var mute_audio_and_pause_music: int = 0
+var unused_music_byte: int = 0
+var frequency_modifier: int = 0
+var tempo_modifier: int = 0x80
+var low_health_alarm: int = 0
+
+## `wAudioFadeOutControl` and the two counters `FadeOutAudio` runs off.
+var fade_out_control: int = 0
+var fade_out_counter: int = 0
+var fade_out_reload: int = 0
+var saved_rom_bank: int = 0
+## `wStatusFlags2`'s BIT_NO_AUDIO_FADE_OUT, the one thing that stops
+## `FadeOutAudio` writing full volume on a frame nothing is fading.
+var no_audio_fade_out: bool = false
+
+## `wOptions & SOUND_MASK` shifted right once, which is what only Yellow reads:
+## it offsets straight into `Audio1_ApplyMonoStereo`'s four enable-mask rows, and
+## zero is MONO, the setting a cartridge starts on.
+var mono_stereo_offset: int = 0
+var yellow: bool = false
+
+var _pointers := PackedInt32Array()
+var _wram := PackedInt32Array()
+var _banks: Dictionary = {}
+
+
+func _init(shared_apu: PokeApu = null) -> void:
+	apu = shared_apu if shared_apu != null else PokeApu.new()
+	_pointers.resize(NUM_CHANNELS * 2)
+	_wram.resize(WRAM_SLOTS)
+
+
+## `wChannelSoundIDs`, which is what says a channel is playing anything.
+func channel_sound_id(channel: int) -> int:
+	return _wram[SOUND_IDS + channel]
+
+
+func channel_command_pointer(channel: int) -> int:
+	return _pointers[CMD_POINTERS + channel]
+
+
+## The audio banks as [Gen1Importer] wrote them: a whole ROM bank each, with its
+## own header table, effects, wave instruments and music.
+func set_assets(assets: Dictionary) -> void:
+	var banks: Variant = assets.get("audio_banks", [])
+	if not banks is Array:
+		return
+	for entry: Variant in banks as Array:
+		if entry is Dictionary:
+			register_bank(entry as Dictionary)
+
+
+func register_bank(entry: Dictionary) -> bool:
+	var bank: int = int(entry.get("bank", -1))
+	if bank < 0:
+		return false
+	if _banks.has(bank):
+		return true
+	var bytes: PackedByteArray = _to_bytes(entry.get("bytes", []))
+	if bytes.is_empty():
+		return false
+	_banks[bank] = {
+		"bytes": bytes,
+		"origin": int(entry.get("data_address", HEADER_TABLE_ADDRESS)),
+		"wave_pointers": int(entry.get("wave_pointers", 0)),
+		"max_sfx_id": int(entry.get("max_sfx_id", 0xFD)),
+	}
+	if audio_rom_bank == 0:
+		audio_rom_bank = bank
+	return true
+
+
+func registered_bank_count() -> int:
+	return _banks.size()
+
+
+func bank_is_registered(bank: int) -> bool:
+	return _banks.has(bank)
+
+
+
+## `PlayMusic`: the bank is chosen first, then the id runs through `PlaySound`.
+func play_music(bank: int, id: int) -> bool:
+	if not _banks.has(bank):
+		return false
+	fade_out_control = 0
+	audio_rom_bank = bank
+	saved_rom_bank = bank
+	play_sound(id)
+	return true
+
+
+## `Audio<N>_PlaySound` for whichever copy of the driver [member audio_rom_bank]
+## names. An id above that bank's own `MAX_SFX_ID` is a piece of music and clears
+## the four music channels first; anything at or below it is an effect.
+func play_sound(id: int) -> void:
+	if not _banks.has(audio_rom_bank):
+		return
+	sound_id = id & 0xFF
+	if sound_id == SFX_STOP_ALL_MUSIC:
+		_stop_all_audio()
+		return
+	if sound_id > _max_sfx_id():
+		_init_music_variables()
+	elif not _claim_sfx_channels():
+		return
+	_play_sound_common()
+
+
+## `.playSfx`'s channel loop, which walks the header's channels from the last to
+## the first and is also the gate that refuses a request while a higher-priority
+## effect holds one. False is its own `ret`, which drops the whole request with
+## the channels it has already cleared left cleared.
+func _claim_sfx_channels() -> bool:
+	var header: int = _header_address(sound_id)
+	var index: int = (_bank_byte(audio_rom_bank, header) >> 6) & 0x03
+	while true:
+		var entry: int = header + index * HEADER_ENTRY_SIZE
+		var channel: int = _bank_byte(audio_rom_bank, entry) & 0x0F
+		var existing: int = _wram[SOUND_IDS + channel]
+		if existing != 0 and not _sfx_may_take_channel(channel, existing):
+			return false
+		_init_sfx_variables(channel)
+		if index == 0:
+			return true
+		index -= 1
+	return true
+
+
+## A noise instrument never interrupts a busy noise channel, and nothing else
+## interrupts a lower-numbered effect.
+func _sfx_may_take_channel(channel: int, existing: int) -> bool:
+	if channel != CHAN8:
+		return sound_id <= existing
+	if sound_id < NOISE_INSTRUMENTS_END:
+		return false
+	return existing <= NOISE_INSTRUMENTS_END or sound_id <= existing
+
+
+## `.playSoundCommon`: the header's channel pointers into `wChannelCommandPointers`,
+## then the four sound ids and the wave-channel rewrite a cry gets.
+func _play_sound_common() -> void:
+	var header: int = _header_address(sound_id)
+	var count: int = ((_bank_byte(audio_rom_bank, header) >> 6) & 0x03) + 1
+	for index: int in count:
+		var entry: int = header + index * HEADER_ENTRY_SIZE
+		var channel: int = _bank_byte(audio_rom_bank, entry) & 0x0F
+		_pointers[CMD_POINTERS + channel] = _bank_byte(audio_rom_bank, entry + 1) \
+			| (_bank_byte(audio_rom_bank, entry + 2) << 8)
+		_wram[SOUND_IDS + channel] = sound_id
+		if channel >= CHAN4:
+			_wram[FLAGS1 + channel] |= BIT_NOISE_OR_SFX
+	if not _is_cry_id(sound_id):
+		return
+	for channel: int in range(CHAN5, NUM_CHANNELS):
+		_wram[SOUND_IDS + channel] = sound_id
+	_pointers[CMD_POINTERS + CHAN7] = _cry_ret_address()
+	if saved_volume != 0:
+		return
+	saved_volume = apu.read(RAUDVOL)
+	apu.write(RAUDVOL, MAX_VOLUME)
+
+
+## `Audio<N>_CryRet` is one `sound_ret` byte, and the pointer at it is only ever
+## read and rewound onto itself, so the header table's own $ff padding answers
+## for it without a fourth symbol to pin per bank.
+func _cry_ret_address() -> int:
+	return HEADER_TABLE_ADDRESS + 1
+
+
+func _is_cry_id(id: int) -> bool:
+	return id >= CRY_SFX_START and id < CRY_SFX_END
+
+
+## `Audio2_IsBattleSFX`, which only the battle copy of the driver has: the two
+## effect sound ids are read as one OR. Yellow's copy takes the closing id in as
+## well, where Red and Blue's stops one below it.
+func _battle_sfx_applies() -> bool:
+	if audio_rom_bank != Gen1Layout.AUDIO_BANK_ROM[1]:
+		return false
+	var combined: int = _wram[SOUND_IDS + CHAN5] | _wram[SOUND_IDS + CHAN8]
+	if combined < BATTLE_SFX_START:
+		return false
+	return combined <= BATTLE_SFX_END if yellow else combined < BATTLE_SFX_END
+
+
+## A cry, or a battle effect in the copy of the driver that knows about them.
+func _cry_or_battle_sfx() -> bool:
+	return _is_cry_id(_wram[SOUND_IDS + CHAN5]) or _battle_sfx_applies()
+
+
+func _max_sfx_id() -> int:
+	return int((_banks[audio_rom_bank] as Dictionary)["max_sfx_id"])
+
+
+func _header_address(id: int) -> int:
+	return HEADER_TABLE_ADDRESS + id * HEADER_ENTRY_SIZE
+
+
+## `.playMusic`'s own clear, which reaches the four music channels alone so an
+## effect on the other four keeps playing over the new piece. The note-delay
+## fractions, the octaves and the volumes are not in it.
+func _init_music_variables() -> void:
+	unused_music_byte = 0
+	disable_channel_output_when_sfx_ends = 0
+	music_wave_instrument = 0
+	sfx_wave_instrument = 0
+	music_tempo = DEFAULT_TEMPO
+	for index: int in NUM_MUSIC_CHANS:
+		_pointers[CMD_POINTERS + index] = 0
+		_pointers[RETURN_ADDRESSES + index] = 0
+		_clear_channel(index)
+	stereo_panning = 0xFF
+	apu.write(RAUDVOL, 0)
+	apu.write(RAUD1SWEEP, AUD1SWEEP_DOWN)
+	apu.write(RAUDTERM, 0)
+	apu.write(RAUD3ENA, 0)
+	apu.write(RAUD3ENA, AUD3ENA_ON)
+	apu.write(RAUDVOL, MAX_VOLUME)
+
+
+## Every array the two clears zero, plus the three they set to one. The delay
+## fraction, the octave and the volume are deliberately outside it.
+func _clear_channel(channel: int) -> void:
+	for base: int in [
+		SOUND_IDS, FLAGS1, FLAGS2, DUTY_CYCLES, DUTY_CYCLE_PATTERNS, VIBRATO_DELAY,
+		VIBRATO_EXTENTS, VIBRATO_RATES, FREQUENCY_LOW, VIBRATO_RELOAD,
+		SLIDE_LENGTH_MOD, SLIDE_STEPS, SLIDE_STEPS_FRACTION, SLIDE_CURRENT_FRACTION,
+		SLIDE_CURRENT_HIGH, SLIDE_CURRENT_LOW, SLIDE_TARGET_HIGH, SLIDE_TARGET_LOW,
+	]:
+		_wram[base + channel] = 0
+	_wram[LOOP_COUNTERS + channel] = 1
+	_wram[NOTE_DELAY + channel] = 1
+	_wram[NOTE_SPEEDS + channel] = 1
+
+
+## `.playChannel`, the same clear over one channel with the sweep switched off
+## when that channel is the first effect channel.
+func _init_sfx_variables(channel: int) -> void:
+	_pointers[CMD_POINTERS + channel] = 0
+	_pointers[RETURN_ADDRESSES + channel] = 0
+	_clear_channel(channel)
+	if channel == CHAN5:
+		apu.write(RAUD1SWEEP, AUD1SWEEP_DOWN)
+
+
+## `.stopAllAudio`. Its flat fill stops after 160 bytes, short of the two
+## pitch-slide target arrays and of the octaves and volumes; Yellow fills 176 and
+## takes the targets with it.
+func _stop_all_audio() -> void:
+	apu.write(RAUDENA, AUD3ENA_ON)
+	apu.write(RAUD3ENA, AUD3ENA_ON)
+	apu.write(RAUDTERM, 0)
+	apu.write(RAUD3LEVEL, 0)
+	apu.write(RAUD1SWEEP, AUD1SWEEP_DOWN)
+	apu.write(0xFF12, AUD1SWEEP_DOWN)
+	apu.write(0xFF17, AUD1SWEEP_DOWN)
+	apu.write(0xFF21, AUD1SWEEP_DOWN)
+	apu.write(0xFF14, AUD1HIGH_LENGTH_ON)
+	apu.write(0xFF19, AUD1HIGH_LENGTH_ON)
+	apu.write(0xFF23, AUD1HIGH_LENGTH_ON)
+	apu.write(RAUDVOL, MAX_VOLUME)
+	unused_music_byte = 0
+	disable_channel_output_when_sfx_ends = 0
+	mute_audio_and_pause_music = 0
+	music_wave_instrument = 0
+	sfx_wave_instrument = 0
+	music_tempo = DEFAULT_TEMPO
+	sfx_tempo = DEFAULT_TEMPO
+	_fill_channel_block(176 if yellow else 160)
+	for index: int in NUM_CHANNELS:
+		_wram[NOTE_DELAY + index] = 1
+		_wram[LOOP_COUNTERS + index] = 1
+		_wram[NOTE_SPEEDS + index] = 1
+	stereo_panning = 0xFF
+
+
+func _fill_channel_block(bytes: int) -> void:
+	for index: int in mini(bytes, POINTER_BYTES) / 2:
+		_pointers[index] = 0
+	for index: int in mini(maxi(bytes - POINTER_BYTES, 0), WRAM_SLOTS):
+		_wram[index] = 0
+
+
+## `FadeOutAudio`, which VBlank runs in front of the driver. Nothing fading is
+## still a write: full volume every frame unless the no-fade flag is up.
+func fade_out_audio() -> void:
+	if fade_out_control == 0:
+		if not no_audio_fade_out:
+			apu.write(RAUDVOL, MAX_VOLUME)
+		return
+	if fade_out_counter != 0:
+		fade_out_counter -= 1
+		return
+	fade_out_counter = fade_out_reload
+	var volume: int = apu.read(RAUDVOL)
+	if volume == 0:
+		_finish_fade_out()
+		return
+	var low: int = (volume & 0x0F) - 1
+	var high: int = ((volume >> 4) & 0x0F) - 1
+	apu.write(RAUDVOL, ((high & 0x0F) << 4) | (low & 0x0F))
+
+
+func _finish_fade_out() -> void:
+	var queued: int = fade_out_control
+	fade_out_control = 0
+	play_sound(SFX_STOP_ALL_MUSIC)
+	audio_rom_bank = saved_rom_bank
+	play_sound(queued)
+
+
+## `PlaySound`'s `.fadeOut`: a frame count per volume step and the id to start
+## once the volume reaches zero.
+func start_fade(frames: int, queued_id: int, queued_bank: int) -> void:
+	fade_out_control = queued_id & 0xFF
+	fade_out_counter = frames & 0xFF
+	fade_out_reload = frames & 0xFF
+	saved_rom_bank = queued_bank if queued_bank > 0 else audio_rom_bank
+
+
+## `Music_DoLowHealthAlarm`, which the battle loop runs beside the driver rather
+## than inside it. The tone it writes stays on channel 1 until it is changed.
+func do_low_health_alarm() -> void:
+	if low_health_alarm == DISABLE_LOW_HEALTH_ALARM:
+		low_health_alarm = 0
+		_wram[SOUND_IDS + CHAN5] = 0
+		_write_alarm_tone(0x00, 0x00, 0x8000)
+		return
+	if (low_health_alarm & BIT_LOW_HEALTH_ALARM) == 0:
+		return
+	var timer: int = low_health_alarm & LOW_HEALTH_TIMER_MASK
+	if timer == 0:
+		_write_alarm_tone(0xA0, 0xE2, 0x8750)
+		low_health_alarm = 30 | BIT_LOW_HEALTH_ALARM
+		return
+	if timer == 20:
+		_write_alarm_tone(0xB0, 0xE2, 0x86EE)
+	_wram[SOUND_IDS + CHAN5] = CRY_SFX_END
+	low_health_alarm = ((timer - 1) & LOW_HEALTH_TIMER_MASK) | BIT_LOW_HEALTH_ALARM
+
+
+## `.playTone` clears the sweep and then copies four bytes, so the five registers
+## land as zero, length, envelope, frequency low and frequency high.
+func _write_alarm_tone(length: int, envelope: int, frequency: int) -> void:
+	apu.write(RAUD1SWEEP, 0)
+	apu.write(0xFF11, length)
+	apu.write(0xFF12, envelope)
+	apu.write(0xFF13, frequency & 0xFF)
+	apu.write(0xFF14, (frequency >> 8) & 0xFF)
+
+
+## `Music_PokeFluteInBattle`: the caught-mon effect is started and its three
+## channel pointers are overwritten at once with the flute's own.
+func play_poke_flute_in_battle(pointers: Array) -> void:
+	play_sound(Gen1Layout.SFX_CAUGHT_MON)
+	for index: int in mini(pointers.size(), 3):
+		_pointers[CMD_POINTERS + CHAN5 + index] = int(pointers[index]) & 0xFFFF
+
+
+## Overwrites the channel pointers a piece has just loaded, which is what the two
+## alternate `MeetRival` starts and `Music_Cities1AlternateTempo` do.
+func overwrite_channel_pointers(pointers: Array) -> void:
+	for index: int in mini(pointers.size(), NUM_MUSIC_CHANS):
+		_pointers[CMD_POINTERS + index] = int(pointers[index]) & 0xFFFF
+
+
+func music_channels_active() -> bool:
+	for index: int in NUM_MUSIC_CHANS:
+		if _wram[SOUND_IDS + index] != 0:
+			return true
+	return false
+
+
+## `WaitForSoundToFinish` waits on the four effect channels alone.
+func sfx_active() -> bool:
+	for index: int in range(NUM_MUSIC_CHANS, NUM_CHANNELS):
+		if _wram[SOUND_IDS + index] != 0:
+			return true
+	return false
+
+
+func any_channel_active() -> bool:
+	return music_channels_active() or sfx_active()
+
+
+
+## `Audio<N>_UpdateMusic`, one LCD frame of the driver.
+func update_music() -> void:
+	for channel: int in NUM_CHANNELS:
+		if _wram[SOUND_IDS + channel] == 0:
+			continue
+		if channel >= CHAN5 or mute_audio_and_pause_music == 0:
+			_apply_music_affects(channel)
+			continue
+		if (mute_audio_and_pause_music & BIT_MUTE_AUDIO) != 0:
+			continue
+		mute_audio_and_pause_music |= BIT_MUTE_AUDIO
+		apu.write(RAUDTERM, 0)
+		apu.write(RAUD3ENA, 0)
+		apu.write(RAUD3ENA, AUD3ENA_ON)
+	_apply_output_gain()
+
+
+## The two listening levels, pushed to the hardware channels by which stream owns
+## each one. A hardware channel an effect has taken carries the effect level for
+## as long as its sound id stands.
+func _apply_output_gain() -> void:
+	for hardware: int in NUM_MUSIC_CHANS:
+		apu.channel_gain[hardware] = (
+			sfx_gain if _wram[SOUND_IDS + hardware + NUM_MUSIC_CHANS] != 0 else music_gain
+		)
+
+
+## `Audio1_ApplyMusicAffects`: the delay counter first, then the duty pattern,
+## the pitch slide and the vibrato, none of which run on a frame a note starts.
+func _apply_music_affects(c: int) -> void:
+	if _wram[NOTE_DELAY + c] == 1:
+		_play_next_note(c)
+		return
+	_wram[NOTE_DELAY + c] = (_wram[NOTE_DELAY + c] - 1) & 0xFF
+	if c < CHAN5 and _wram[SOUND_IDS + c + NUM_MUSIC_CHANS] != 0:
+		return
+	if (_wram[FLAGS1 + c] & BIT_ROTATE_DUTY_CYCLE) != 0:
+		_apply_duty_cycle_pattern(c)
+	if (_wram[FLAGS2 + c] & BIT_EXECUTE_MUSIC) == 0 \
+		and (_wram[FLAGS1 + c] & BIT_NOISE_OR_SFX) != 0:
+		return
+	if (_wram[FLAGS1 + c] & BIT_PITCH_SLIDE_ON) != 0:
+		_apply_pitch_slide(c)
+		return
+	if _wram[VIBRATO_DELAY + c] != 0:
+		_wram[VIBRATO_DELAY + c] -= 1
+		return
+	_apply_vibrato(c)
+
+
+## The direction bit is set and reset nowhere else, so the swing alternates by
+## itself; the counter reloads out of its own high nibble.
+func _apply_vibrato(c: int) -> void:
+	var extent: int = _wram[VIBRATO_EXTENTS + c]
+	if extent == 0:
+		return
+	if (_wram[VIBRATO_RATES + c] & 0x0F) != 0:
+		_wram[VIBRATO_RATES + c] -= 1
+		return
+	var rate: int = _wram[VIBRATO_RATES + c]
+	_wram[VIBRATO_RATES + c] = (rate | (((rate << 4) | (rate >> 4)) & 0xFF)) & 0xFF
+	var pitch: int = _wram[FREQUENCY_LOW + c]
+	var value: int = 0
+	if (_wram[FLAGS1 + c] & BIT_VIBRATO_DIRECTION) != 0:
+		_wram[FLAGS1 + c] &= ~BIT_VIBRATO_DIRECTION
+		var below: int = extent & 0x0F
+		value = 0 if below > pitch else pitch - below
+	else:
+		_wram[FLAGS1 + c] |= BIT_VIBRATO_DIRECTION
+		var above: int = (extent & 0xF0) >> 4
+		value = 0xFF if pitch + above > 0xFF else pitch + above
+	apu.write(_register(REG_FREQUENCY_LO, c), value)
+
+
+## `Audio1_PlayNextNote`: the vibrato delay is reloaded, the slide is cleared and
+## the stream is walked until something takes time.
+func _play_next_note(c: int) -> void:
+	_wram[VIBRATO_DELAY + c] = _wram[VIBRATO_RELOAD + c]
+	_wram[FLAGS1 + c] &= ~(BIT_PITCH_SLIDE_ON | BIT_PITCH_SLIDE_DECREASING)
+	## Yellow holds the first effect channel still while the alarm owns it,
+	## re-enabling its output rather than reading another command.
+	if yellow and c == CHAN5 and (low_health_alarm & BIT_LOW_HEALTH_ALARM) != 0:
+		_enable_channel_output(c)
+		return
+	var steps: int = 0
+	while _run_command(c, _get_next_music_byte(c)):
+		steps += 1
+		if steps > MAX_PARSE_STEPS:
+			_wram[SOUND_IDS + c] = 0
+			push_warning("Gen1SoundEngine: channel %d read %d commands without a note."
+				% [c, MAX_PARSE_STEPS])
+			return
+
+
+## `Audio1_sound_ret` down to `Audio1_note_pitch`, in the source's own order.
+## True carries on to the next command; false is one of its `ret`s.
+func _run_command(c: int, d: int) -> bool:
+	if d == SOUND_RET_CMD:
+		return _sound_ret(c)
+	if d == SOUND_CALL_CMD:
+		return _sound_call(c)
+	if d == SOUND_LOOP_CMD:
+		return _sound_loop(c)
+	if (d & 0xF0) == NOTE_TYPE_CMD:
+		_note_type(c, d)
+		return true
+	if d == PITCH_SLIDE_CMD:
+		_pitch_slide(c)
+		return false
+	if COMMANDS.has(d):
+		return call(StringName(COMMANDS[d]), c)
+	if (d & 0xF0) == OCTAVE_CMD:
+		_wram[OCTAVES + c] = d & 0x0F
+		return true
+	var free_of_music: bool = (_wram[FLAGS2 + c] & BIT_EXECUTE_MUSIC) == 0
+	if (d & 0xF0) == SFX_NOTE_CMD and c >= CHAN4 and free_of_music:
+		_sfx_note(c, d)
+		return false
+	if c >= CHAN5 and d == PITCH_SWEEP_CMD and free_of_music:
+		apu.write(RAUD1SWEEP, _get_next_music_byte(c))
+		return true
+	_note(c, d)
+	return false
+
+
+## `sound_ret` outside a `sound_call`: the channel stops, its output is disabled
+## and a cry hands the saved volume back on the way out.
+func _sound_ret(c: int) -> bool:
+	if (_wram[FLAGS1 + c] & BIT_SOUND_CALL) != 0:
+		_wram[FLAGS1 + c] &= ~BIT_SOUND_CALL
+		_pointers[CMD_POINTERS + c] = _pointers[RETURN_ADDRESSES + c]
+		return true
+	if _disable_on_sound_ret(c):
+		apu.write(RAUDTERM, apu.read(RAUDTERM) & (~HW_ENABLE_MASK[c] & 0xFF))
+	if _is_cry_id(_wram[SOUND_IDS + CHAN5]):
+		## Every cry channel but the first rewinds onto its own `sound_ret` and
+		## keeps its id, so it idles there until the first one ends.
+		if c != CHAN5:
+			_pointers[CMD_POINTERS + c] = (_pointers[CMD_POINTERS + c] - 1) & 0xFFFF
+			return false
+		apu.write(RAUDVOL, saved_volume)
+		saved_volume = 0
+	_wram[SOUND_IDS + c] = 0
+	return false
+
+
+func _disable_on_sound_ret(c: int) -> bool:
+	if c < CHAN4:
+		return true
+	_wram[FLAGS1 + c] &= ~BIT_NOISE_OR_SFX
+	_wram[FLAGS2 + c] &= ~BIT_EXECUTE_MUSIC
+	if c != CHAN7:
+		return false
+	apu.write(RAUD3ENA, 0)
+	apu.write(RAUD3ENA, AUD3ENA_ON)
+	if disable_channel_output_when_sfx_ends == 0:
+		return false
+	disable_channel_output_when_sfx_ends = 0
+	return true
+
+
+func _sound_call(c: int) -> bool:
+	var target: int = _get_next_music_byte(c)
+	target |= _get_next_music_byte(c) << 8
+	_pointers[RETURN_ADDRESSES + c] = _pointers[CMD_POINTERS + c]
+	_pointers[CMD_POINTERS + c] = target
+	_wram[FLAGS1 + c] |= BIT_SOUND_CALL
+	return true
+
+
+## `sound_loop`: the counter counts up to the operand, and a zero operand is the
+## infinite loop nearly every piece ends on.
+func _sound_loop(c: int) -> bool:
+	var wanted: int = _get_next_music_byte(c)
+	if wanted != 0:
+		if _wram[LOOP_COUNTERS + c] == wanted:
+			_wram[LOOP_COUNTERS + c] = 1
+			_get_next_music_byte(c)
+			_get_next_music_byte(c)
+			return true
+		_wram[LOOP_COUNTERS + c] = (_wram[LOOP_COUNTERS + c] + 1) & 0xFF
+	var target: int = _get_next_music_byte(c)
+	_pointers[CMD_POINTERS + c] = target | (_get_next_music_byte(c) << 8)
+	return true
+
+
+## `note_type`, which is `drum_speed` on the noise channel: the low nibble is the
+## note speed, and the two wave channels split their parameter into an instrument
+## index and an output level.
+func _note_type(c: int, d: int) -> void:
+	_wram[NOTE_SPEEDS + c] = d & 0x0F
+	if c == CHAN4:
+		return
+	var parameter: int = _get_next_music_byte(c)
+	if c == CHAN3 or c == CHAN7:
+		if c == CHAN3:
+			music_wave_instrument = parameter & 0x0F
+		else:
+			sfx_wave_instrument = parameter & 0x0F
+		parameter = ((parameter & 0x30) << 1) & 0xFF
+	_wram[VOLUMES + c] = parameter
+
+
+func _toggle_perfect_pitch(c: int) -> bool:
+	_wram[FLAGS1 + c] ^= BIT_PERFECT_PITCH
+	return true
+
+
+## `vibrato`: the extent is split so the swing above the note rounds away from
+## zero and the swing below it rounds toward it.
+func _vibrato(c: int) -> bool:
+	var delay: int = _get_next_music_byte(c)
+	_wram[VIBRATO_DELAY + c] = delay
+	_wram[VIBRATO_RELOAD + c] = delay
+	var shape: int = _get_next_music_byte(c)
+	var extent: int = (shape & 0xF0) >> 4
+	_wram[VIBRATO_EXTENTS + c] = (((extent >> 1) + (extent & 1)) << 4) | (extent >> 1)
+	var rate: int = shape & 0x0F
+	_wram[VIBRATO_RATES + c] = (rate << 4) | rate
+	return true
+
+
+## `pitch_slide` reads its own length and target and then falls into the note
+## length, so the note byte behind it is what times the slide.
+func _pitch_slide(c: int) -> void:
+	_wram[SLIDE_LENGTH_MOD + c] = _get_next_music_byte(c)
+	var target: int = _get_next_music_byte(c)
+	var frequency: int = _calculate_frequency(target & 0x0F, (target & 0xF0) >> 4)
+	_wram[SLIDE_TARGET_HIGH + c] = (frequency >> 8) & 0xFF
+	_wram[SLIDE_TARGET_LOW + c] = frequency & 0xFF
+	_wram[FLAGS1 + c] |= BIT_PITCH_SLIDE_ON
+	var note: int = _get_next_music_byte(c)
+	_note_length(c, note)
+	if not _note_length_returns(c):
+		_note_pitch(c, note)
+
+
+func _duty_cycle(c: int) -> bool:
+	var value: int = _get_next_music_byte(c)
+	_wram[DUTY_CYCLES + c] = ((value >> 2) | (value << 6)) & 0xC0
+	return true
+
+
+## `tempo`, which the four effect channels keep apart from the four music ones.
+## Each half clears its own note-delay fractions.
+func _tempo(c: int) -> bool:
+	var value: int = _get_next_music_byte(c) << 8
+	value |= _get_next_music_byte(c)
+	var base: int = NUM_MUSIC_CHANS if c >= CHAN5 else 0
+	if c >= CHAN5:
+		sfx_tempo = value
+	else:
+		music_tempo = value
+	for index: int in NUM_MUSIC_CHANS:
+		_wram[NOTE_DELAY_FRACTION + base + index] = 0
+	return true
+
+
+func _stereo_panning(c: int) -> bool:
+	stereo_panning = _get_next_music_byte(c)
+	return true
+
+
+## `unknownmusic0xef`, which no shipped stream reaches: it plays the id it reads
+## and moves the noise channel's own id into the disable flag.
+func _unknown_ef(c: int) -> bool:
+	play_sound(_get_next_music_byte(c))
+	if disable_channel_output_when_sfx_ends == 0:
+		disable_channel_output_when_sfx_ends = _wram[SOUND_IDS + CHAN8]
+		_wram[SOUND_IDS + CHAN8] = 0
+	return true
+
+
+func _duty_cycle_pattern(c: int) -> bool:
+	var pattern: int = _get_next_music_byte(c)
+	_wram[DUTY_CYCLE_PATTERNS + c] = pattern
+	_wram[DUTY_CYCLES + c] = pattern & 0xC0
+	_wram[FLAGS1 + c] |= BIT_ROTATE_DUTY_CYCLE
+	return true
+
+
+func _volume(c: int) -> bool:
+	apu.write(RAUDVOL, _get_next_music_byte(c))
+	return true
+
+
+func _execute_music(c: int) -> bool:
+	_wram[FLAGS2 + c] |= BIT_EXECUTE_MUSIC
+	return true
+
+
+## `square_note` and `noise_note`, the effect channels' own note: a length, a
+## volume envelope and either a two-byte frequency or the noise channel's one.
+func _sfx_note(c: int, d: int) -> void:
+	var length: int = _note_length(c, d)
+	apu.write(_register(REG_DUTY_SOUND_LEN, c), length | _wram[DUTY_CYCLES + c])
+	apu.write(_register(REG_VOLUME_ENVELOPE, c), _get_next_music_byte(c))
+	var low: int = _get_next_music_byte(c)
+	var high: int = 0
+	if c != CHAN8:
+		high = _get_next_music_byte(c)
+	_apply_duty_cycle_and_sound_length(c)
+	_enable_channel_output(c)
+	_apply_wave_pattern_and_frequency(c, low, high)
+
+
+## `Audio1_note`: on the music noise channel a `drum_note` plays its instrument
+## as a sound of its own before the length is counted.
+func _note(c: int, d: int) -> void:
+	var length_byte: int = d
+	if c == CHAN4 and (d & 0xF0) <= DRUM_NOTE_CMD:
+		var instrument: int = d >> 4
+		length_byte = d & 0x0F
+		if (d & 0xF0) == DRUM_NOTE_CMD:
+			instrument = _get_next_music_byte(c)
+		if disable_channel_output_when_sfx_ends == 0:
+			play_sound(instrument)
+	_note_length(c, length_byte)
+	if _note_length_returns(c):
+		return
+	_note_pitch(c, length_byte)
+
+
+## The one place `Audio1_note_length` returns to its caller rather than falling
+## into `Audio1_note_pitch`, which is every effect channel and the music noise
+## channel outside `execute_music`.
+func _note_length_returns(c: int) -> bool:
+	return (_wram[FLAGS2 + c] & BIT_EXECUTE_MUSIC) == 0 \
+		and (_wram[FLAGS1 + c] & BIT_NOISE_OR_SFX) != 0
+
+
+## `Audio1_note_length`: the delay is the note length times the note speed times
+## the tempo, carried in a byte of fraction.
+func _note_length(c: int, d: int) -> int:
+	var product: int = _multiply_add(_wram[NOTE_SPEEDS + c], (d & 0x0F) + 1, 0)
+	var tempo: int = music_tempo
+	if c >= CHAN5:
+		tempo = DEFAULT_TEMPO
+		if c != CHAN8:
+			_set_sfx_tempo()
+			tempo = sfx_tempo
+	var total: int = _multiply_add(product & 0xFF, tempo, _wram[NOTE_DELAY_FRACTION + c])
+	_wram[NOTE_DELAY_FRACTION + c] = total & 0xFF
+	_wram[NOTE_DELAY + c] = (total >> 8) & 0xFF
+	return _wram[NOTE_DELAY + c]
+
+
+## `Audio1_note_pitch`: a rest silences the channel, anything else is a
+## frequency, an envelope and a restart.
+func _note_pitch(c: int, d: int) -> void:
+	if (d & 0xF0) == REST_CMD:
+		_rest(c)
+		return
+	var frequency: int = _calculate_frequency(d >> 4, _wram[OCTAVES + c])
+	if (_wram[FLAGS1 + c] & BIT_PITCH_SLIDE_ON) != 0:
+		_init_pitch_slide_vars(c, frequency)
+	if c < CHAN5 and _wram[SOUND_IDS + CHAN5 + c] != 0:
+		return
+	apu.write(_register(REG_VOLUME_ENVELOPE, c), _wram[VOLUMES + c])
+	_apply_duty_cycle_and_sound_length(c)
+	_enable_channel_output(c)
+	var low: int = frequency & 0xFF
+	if (_wram[FLAGS1 + c] & BIT_PERFECT_PITCH) != 0:
+		low = (low + 1) & 0xFF
+	_wram[FREQUENCY_LOW + c] = low
+	_apply_wave_pattern_and_frequency(c, low, (frequency >> 8) & 0xFF)
+
+
+## A rest on either wave channel drops its output bit; on the others it sets the
+## envelope to a fade-in and restarts the channel.
+func _rest(c: int) -> void:
+	if c < CHAN5 and _wram[SOUND_IDS + CHAN5 + c] != 0:
+		return
+	if c == CHAN3 or c == CHAN7:
+		apu.write(RAUDTERM, apu.read(RAUDTERM) & (~HW_ENABLE_MASK[c] & 0xFF))
+		return
+	apu.write(_register(REG_VOLUME_ENVELOPE, c), 0x08)
+	apu.write(_register(REG_FREQUENCY_LO, c) + 1, 0x80)
+
+
+## `Audio1_EnableChannelOutput`: this channel's two bits go up, and the panning
+## byte narrows them for the noise channel and for a music channel no effect has
+## taken. One write, however the value was reached.
+func _enable_channel_output(c: int) -> void:
+	var enable: int = _enable_mask(c)
+	var value: int = apu.read(RAUDTERM) | enable
+	if c == CHAN8 or (c < CHAN5 and _wram[SOUND_IDS + CHAN5 + c] == 0):
+		value = (apu.read(RAUDTERM) & (~HW_ENABLE_MASK[c] & 0xFF)) | (stereo_panning & enable)
+	apu.write(RAUDTERM, value)
+
+
+## Yellow reads the SOUND option here, which picks one of four enable-mask rows;
+## the other two cartridges have the mono row alone.
+func _enable_mask(c: int) -> int:
+	if not yellow:
+		return HW_ENABLE_MASK[c]
+	return int(Gen1Layout.YELLOW_ENABLE_MASKS[mono_stereo_offset + c])
+
+
+## `Audio1_ApplyDutyCycleAndSoundLength`: the note delay doubles as the sound
+## length, with the duty cycle in the top two bits everywhere but channel 3.
+func _apply_duty_cycle_and_sound_length(c: int) -> void:
+	var value: int = _wram[NOTE_DELAY + c]
+	if c != CHAN3 and c != CHAN7:
+		value = (value & 0x3F) | _wram[DUTY_CYCLES + c]
+	apu.write(_register(REG_DUTY_SOUND_LEN, c), value)
+
+
+## `Audio1_ApplyWavePatternAndFrequency`: the wave channels reload all sixteen
+## bytes of wave RAM first, and every channel ends on the two frequency bytes.
+func _apply_wave_pattern_and_frequency(c: int, low: int, high: int) -> void:
+	if c == CHAN3 or c == CHAN7:
+		_load_wave_pattern(music_wave_instrument if c == CHAN3 else sfx_wave_instrument)
+	var value: int = (high | 0x80) & 0xC7
+	apu.write(_register(REG_FREQUENCY_LO, c), low)
+	apu.write(_register(REG_FREQUENCY_LO, c) + 1, value)
+	## The battle copy of the driver and Yellow's single copy leave the music
+	## channels alone here; Red and Blue's first and third copies do not.
+	if c < CHAN5 and (yellow or audio_rom_bank == Gen1Layout.AUDIO_BANK_ROM[1]):
+		return
+	_apply_frequency_modifier(c, low, value)
+
+
+## `.loop` copies the instrument over wave RAM with the channel stopped, then
+## starts it again.
+func _load_wave_pattern(instrument: int) -> void:
+	var bank: int = _wave_bank()
+	if not _banks.has(bank):
+		return
+	var entry: int = int((_banks[bank] as Dictionary)["wave_pointers"]) + instrument * 2
+	var source: int = _bank_byte(bank, entry) | (_bank_byte(bank, entry + 1) << 8)
+	apu.write(RAUD3ENA, 0)
+	for index: int in WAVE_RAM_SIZE:
+		apu.write(WAVE_RAM + index, _bank_byte(bank, source + index))
+	apu.write(RAUD3ENA, AUD3ENA_ON)
+
+
+## Yellow keeps one `Audio1_WavePointers`, in the first audio bank, so every copy
+## of the driver reads the same instruments and the same garbage sixth one.
+func _wave_bank() -> int:
+	return Gen1Layout.AUDIO_BANK_ROM[0] if yellow else audio_rom_bank
+
+
+## `Audio1_ApplyFrequencyModifier`: a cry, and a battle effect in the copy of the
+## driver that knows them, adds `wFrequencyModifier` to what was just written.
+func _apply_frequency_modifier(c: int, low: int, high: int) -> void:
+	if not _cry_or_battle_sfx():
+		return
+	var value: int = low + frequency_modifier
+	apu.write(_register(REG_FREQUENCY_LO, c), value & 0xFF)
+	apu.write(_register(REG_FREQUENCY_LO, c) + 1, (high + (1 if value > 0xFF else 0)) & 0xFF)
+
+
+## `Audio1_SetSfxTempo`: a cry runs at `wTempoModifier` biased by $80, and
+## everything else at one.
+func _set_sfx_tempo() -> void:
+	sfx_tempo = (tempo_modifier + 0x80) & 0xFFFF if _cry_or_battle_sfx() else DEFAULT_TEMPO
+
+
+## `Audio1_ApplyDutyCyclePattern`: the stored pattern rotates two bits a frame,
+## so the duty cycle changes at the driver's rate rather than the note's.
+func _apply_duty_cycle_pattern(c: int) -> void:
+	var pattern: int = _wram[DUTY_CYCLE_PATTERNS + c]
+	pattern = ((pattern << 2) | (pattern >> 6)) & 0xFF
+	_wram[DUTY_CYCLE_PATTERNS + c] = pattern
+	var register: int = _register(REG_DUTY_SOUND_LEN, c)
+	apu.write(register, (apu.read(register) & 0x3F) | (pattern & 0xC0))
+
+
+## `Audio1_ApplyPitchSlide`, the frame-by-frame walk toward the target.
+func _apply_pitch_slide(c: int) -> void:
+	var current: int = (_wram[SLIDE_CURRENT_HIGH + c] << 8) | _wram[SLIDE_CURRENT_LOW + c]
+	var target: int = (_wram[SLIDE_TARGET_HIGH + c] << 8) | _wram[SLIDE_TARGET_LOW + c]
+	var next: int = 0
+	if (_wram[FLAGS1 + c] & BIT_PITCH_SLIDE_DECREASING) != 0:
+		var doubled: int = _wram[SLIDE_STEPS_FRACTION + c] * 2
+		_wram[SLIDE_STEPS_FRACTION + c] = doubled & 0xFF
+		next = (current - _wram[SLIDE_STEPS + c] - (1 if doubled > 0xFF else 0)) & 0xFFFF
+		if next < target:
+			_stop_pitch_slide(c)
+			return
+	else:
+		var fraction: int = _wram[SLIDE_CURRENT_FRACTION + c] + _wram[SLIDE_STEPS_FRACTION + c]
+		_wram[SLIDE_CURRENT_FRACTION + c] = fraction & 0xFF
+		next = (current + _wram[SLIDE_STEPS + c] + (1 if fraction > 0xFF else 0)) & 0xFFFF
+		if target < next:
+			_stop_pitch_slide(c)
+			return
+	_wram[SLIDE_CURRENT_LOW + c] = next & 0xFF
+	_wram[SLIDE_CURRENT_HIGH + c] = (next >> 8) & 0xFF
+	apu.write(_register(REG_FREQUENCY_LO, c), next & 0xFF)
+	apu.write(_register(REG_FREQUENCY_LO, c) + 1, (next >> 8) & 0xFF)
+
+
+func _stop_pitch_slide(c: int) -> void:
+	_wram[FLAGS1 + c] &= ~(BIT_PITCH_SLIDE_ON | BIT_PITCH_SLIDE_DECREASING)
+
+
+## `Audio1_InitPitchSlideVars`. The length modifier becomes the divisor, and the
+## borrow the source takes from the current frequency rather than from the target
+## is the cartridge's own bug: an upward slide whose low byte has wrapped starts
+## $200 further away than it should.
+func _init_pitch_slide_vars(c: int, frequency: int) -> void:
+	_wram[SLIDE_CURRENT_HIGH + c] = (frequency >> 8) & 0xFF
+	_wram[SLIDE_CURRENT_LOW + c] = frequency & 0xFF
+	var divisor: int = _wram[NOTE_DELAY + c] - _wram[SLIDE_LENGTH_MOD + c]
+	divisor = 1 if divisor < 0 else divisor
+	_wram[SLIDE_LENGTH_MOD + c] = divisor
+	var low: int = (frequency & 0xFF) - _wram[SLIDE_TARGET_LOW + c]
+	var high: int = ((frequency >> 8) & 0xFF) - (1 if low < 0 else 0) \
+		- _wram[SLIDE_TARGET_HIGH + c]
+	if high >= 0:
+		_wram[FLAGS1 + c] |= BIT_PITCH_SLIDE_DECREASING
+	else:
+		low = _wram[SLIDE_TARGET_LOW + c] - (frequency & 0xFF)
+		var wrapped: int = (((frequency >> 8) & 0xFF) - (1 if low < 0 else 0)) & 0xFF
+		high = _wram[SLIDE_TARGET_HIGH + c] - wrapped
+		_wram[FLAGS1 + c] &= ~BIT_PITCH_SLIDE_DECREASING
+	_divide_pitch_slide(c, high & 0xFF, low & 0xFF, divisor)
+
+
+## `.divideLoop`, whose count includes the borrowing pass: the stored step is the
+## quotient plus one and the stored fraction the remainder less the divisor.
+func _divide_pitch_slide(c: int, high: int, low: int, divisor: int) -> void:
+	if divisor == 0:
+		## The cartridge subtracts zero forever here and locks the console up, so
+		## no shipped stream reaches it.
+		_wram[SLIDE_STEPS + c] = 0
+		_wram[SLIDE_STEPS_FRACTION + c] = 0
+		_wram[SLIDE_CURRENT_FRACTION + c] = 0
+		return
+	var quotient: int = 0
+	while true:
+		quotient += 1
+		low -= divisor
+		if low >= 0:
+			continue
+		if high == 0:
+			break
+		high -= 1
+		low &= 0xFF
+	_wram[SLIDE_STEPS + c] = quotient & 0xFF
+	_wram[SLIDE_STEPS_FRACTION + c] = (low + divisor) & 0xFF
+	_wram[SLIDE_CURRENT_FRACTION + c] = (low + divisor) & 0xFF
+
+
+## `Audio1_MultiplyAdd`: hl = l + a * de, sixteen bits wide.
+func _multiply_add(multiplier: int, value: int, addend: int) -> int:
+	return (addend + multiplier * value) & 0xFFFF
+
+
+## `Audio1_CalculateFrequency`: the table entry shifted right arithmetically once
+## per octave above the lowest, with eight added to the high byte.
+func _calculate_frequency(note: int, octave: int) -> int:
+	if note < 0 or note >= PITCHES.size():
+		return 0
+	var value: int = PITCHES[note] - 0x10000
+	var shifts: int = (7 - octave) & 0xFF
+	while shifts > 0:
+		value >>= 1
+		shifts -= 1
+	return (((((value >> 8) & 0xFF) + 8) & 0xFF) << 8) | (value & 0xFF)
+
+
+func _register(register: int, c: int) -> int:
+	return 0xFF00 | ((HW_CHANNEL_BASE[c] + register) & 0xFF)
+
+
+func _get_next_music_byte(c: int) -> int:
+	var address: int = _pointers[CMD_POINTERS + c]
+	_pointers[CMD_POINTERS + c] = (address + 1) & 0xFFFF
+	return _bank_byte(audio_rom_bank, address)
+
+
+func _bank_byte(bank: int, address: int) -> int:
+	var entry: Variant = _banks.get(bank, null)
+	if entry == null:
+		return 0xFF
+	var bytes: PackedByteArray = (entry as Dictionary)["bytes"]
+	var at: int = address - int((entry as Dictionary)["origin"])
+	if at < 0 or at >= bytes.size():
+		return 0xFF
+	return bytes[at]
+
+
+static func _to_bytes(value: Variant) -> PackedByteArray:
+	if value is PackedByteArray:
+		return value
+	if not value is Array:
+		return PackedByteArray()
+	var raw: Array = value as Array
+	var out := PackedByteArray()
+	out.resize(raw.size())
+	for index: int in out.size():
+		out[index] = int(raw[index]) & 0xFF
+	return out

--- a/game/audio/gen1_sound_engine.gd.uid
+++ b/game/audio/gen1_sound_engine.gd.uid
@@ -1,0 +1,1 @@
+uid://lejwtnjgoqdr

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -56,6 +56,11 @@ var _playback: AudioStreamGeneratorPlayback = null
 ## [method timeline_updates].
 var _timeline_updates: int = 0
 var _engine: Gen2SoundEngine = null
+## The Generation 1 driver, which shares the APU: a cache written by either
+## generation reaches the same four hardware channels through its own engine, and
+## the record the caller hands over is what says which.
+var _gen1: Gen1SoundEngine = null
+var _generation: int = RomRegistry.GEN2
 var _apu: PokeApu = null
 var _music_key: String = ""
 ## What a SOUND change restarts.
@@ -92,6 +97,7 @@ func _init() -> void:
 	_apu = PokeApu.new()
 	_engine = Gen2SoundEngine.new(_apu)
 	_engine.init_sound()
+	_gen1 = Gen1SoundEngine.new(_apu)
 	_buffer.resize(PokeApu.SAMPLES_PER_FRAME)
 
 
@@ -141,6 +147,8 @@ func _apply_settings() -> void:
 		_engine.music_gain = music
 	if not is_equal_approx(sfx, _engine.sfx_gain):
 		_engine.sfx_gain = sfx
+	_gen1.music_gain = music
+	_gen1.sfx_gain = sfx
 
 
 ## Plays one imported audio record. Music continues when the source asks for the
@@ -156,6 +164,8 @@ func play_record(
 		return {"ok": true, "played": fade_out(int(record.get("fade_time", 0)))}
 	if record.is_empty():
 		return {"ok": false, "played": false, "reason": &"audio_data_unavailable"}
+	if int(assets.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1:
+		return _play_gen1_record(record, request_kind, assets, restart)
 	_engine.set_assets(assets)
 	_engine.stereo = stereo
 
@@ -216,6 +226,77 @@ func play_record(
 	}
 
 
+## `PlaySound` for a Generation 1 cache: the id is all an effect needs, since it
+## plays out of whichever copy of the driver the game is on, and a piece of music
+## names the bank `PlayMusic` switches to first.
+func _play_gen1_record(
+	record: Dictionary, request_kind: StringName, assets: Dictionary, restart: bool
+) -> Dictionary:
+	_generation = RomRegistry.GEN1
+	_gen1.set_assets(assets)
+	_gen1.yellow = bool(assets.get("yellow", _gen1.yellow))
+	var id: int = int(record.get("sound_id", -1))
+	var bank: int = int(record.get("bank", -1))
+	if id <= 0:
+		return {"ok": false, "played": false, "reason": &"audio_record_unplayable"}
+	if _is_music(request_kind):
+		return _play_gen1_music(record, bank, id, assets, restart)
+	if request_kind in [&"cry", &"cries", &"mon_cry"]:
+		_gen1.frequency_modifier = int(record.get("cry_pitch", 0)) & 0xFF
+		_gen1.tempo_modifier = int(record.get("cry_length", 0x80)) & 0xFF
+	_start_stream()
+	_gen1.play_sound(id)
+	return _gen1_result(request_kind, bank, id)
+
+
+func _play_gen1_music(
+	record: Dictionary, bank: int, id: int, assets: Dictionary, restart: bool
+) -> Dictionary:
+	if id == Gen1SoundEngine.SFX_STOP_ALL_MUSIC:
+		_gen1.play_sound(id)
+		_forget_music()
+		return {"ok": true, "played": true, "stopped": true}
+	var key: String = "%d:%d" % [bank, id]
+	if not restart and key == _music_key:
+		return {"ok": true, "played": false, "continued": true}
+	_start_stream()
+	if not _gen1.play_music(bank, id):
+		return {"ok": false, "played": false, "reason": &"audio_record_unplayable"}
+	_music_key = key
+	_music_record = record
+	_music_assets = assets
+	return _gen1_result(&"music", bank, id)
+
+
+func _gen1_result(request_kind: StringName, bank: int, id: int) -> Dictionary:
+	return {
+		"ok": true,
+		"played": true,
+		"ready": true,
+		"request_kind": request_kind,
+		"index": id,
+		"bank": bank,
+		"address": Gen1SoundEngine.HEADER_TABLE_ADDRESS
+			+ id * Gen1SoundEngine.HEADER_ENTRY_SIZE,
+	}
+
+
+## One LCD frame of whichever driver is live. Generation 1's VBlank runs
+## `FadeOutAudio` in front of `Audio<N>_UpdateMusic`, and that is where the fade
+## and the full-volume write on every other frame come from.
+func _advance_driver() -> void:
+	if _generation == RomRegistry.GEN1:
+		_gen1.fade_out_audio()
+		_gen1.update_music()
+		return
+	_engine.update_sound()
+
+
+func _any_channel_active() -> bool:
+	return _gen1.any_channel_active() if _generation == RomRegistry.GEN1 \
+		else _engine.any_channel_active()
+
+
 func _forget_music() -> void:
 	_music_key = ""
 	_music_record = {}
@@ -237,6 +318,8 @@ func stop_effects() -> void:
 ## `FadeMusic`: a frame count per volume step. Zero stops at once, which is what
 ## the source's own zero-length fades do.
 func fade_out(frames: int = 0) -> bool:
+	if _generation == RomRegistry.GEN1:
+		return _fade_out_gen1(frames)
 	if frames <= 0:
 		if not _engine.any_channel_active():
 			return false
@@ -248,6 +331,21 @@ func fade_out(frames: int = 0) -> bool:
 	return true
 
 
+## `PlaySound`'s `.fadeOut` with nothing queued behind it, which is what
+## `wAudioFadeOutControl` of $ff spells: the volume walks down and the music
+## stops. A zero count is `StopAllMusic`.
+func _fade_out_gen1(frames: int) -> bool:
+	if not _gen1.any_channel_active():
+		return false
+	if frames <= 0:
+		_gen1.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
+		_forget_music()
+		return true
+	_gen1.start_fade(frames, Gen1SoundEngine.SFX_STOP_ALL_MUSIC, _gen1.audio_rom_bank)
+	_forget_music()
+	return true
+
+
 ## `FadeToMapMusic`: the same `wMusicFade`, with `wMusicFadeID` behind it, so the
 ## new track starts when the fade reaches zero rather than over the old one.
 ## Answers false when there is nothing playing to fade, which is the source's own
@@ -255,6 +353,8 @@ func fade_out(frames: int = 0) -> bool:
 func fade_to(record: Dictionary, frames: int, assets: Dictionary = {}) -> bool:
 	if record.is_empty():
 		return false
+	if int(assets.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1:
+		return _fade_to_gen1(record, frames, assets)
 	_engine.set_assets(assets)
 	_engine.stereo = stereo
 	var key: String = "%d:%d" % [int(record.get("bank", -1)), int(record.get("address", -1))]
@@ -270,8 +370,29 @@ func fade_to(record: Dictionary, frames: int, assets: Dictionary = {}) -> bool:
 	return true
 
 
+## `PlaySound`'s `.fadeOut` with the new piece queued in `wAudioFadeOutControl`,
+## which is how every map change hands one track to the next.
+func _fade_to_gen1(record: Dictionary, frames: int, assets: Dictionary) -> bool:
+	_gen1.set_assets(assets)
+	_generation = RomRegistry.GEN1
+	var bank: int = int(record.get("bank", -1))
+	var id: int = int(record.get("sound_id", -1))
+	var key: String = "%d:%d" % [bank, id]
+	if key == _music_key or id <= 0:
+		return false
+	if not _gen1.any_channel_active():
+		return bool(play_record(record, &"map_music", assets).get("played", false))
+	_start_stream()
+	_gen1.start_fade(frames, id, bank)
+	_music_key = key
+	_music_record = record
+	_music_assets = assets
+	return true
+
+
 func stop_all() -> void:
 	_engine.init_sound()
+	_gen1.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
 	_forget_music()
 	if _player != null:
 		_player.stop()
@@ -283,6 +404,12 @@ func stop_all() -> void:
 ## otherwise; `StopDangerSound` and `CleanUpBattleRAM` zero the byte whole,
 ## which is what clearing it here does, timer and all.
 func set_low_health_alarm(on: bool) -> void:
+	if _generation == RomRegistry.GEN1:
+		## `Music_DoLowHealthAlarm` clears the byte through $ff rather than zero,
+		## so the silencing tone is written on the frame it is switched off.
+		_gen1.low_health_alarm = Gen1SoundEngine.BIT_LOW_HEALTH_ALARM if on \
+			else Gen1SoundEngine.DISABLE_LOW_HEALTH_ALARM
+		return
 	if on:
 		_engine.low_health_alarm |= 1 << Gen2SoundEngine.DANGER_ON_BIT
 		return
@@ -290,6 +417,8 @@ func set_low_health_alarm(on: bool) -> void:
 
 
 func low_health_alarm() -> bool:
+	if _generation == RomRegistry.GEN1:
+		return (_gen1.low_health_alarm & Gen1SoundEngine.BIT_LOW_HEALTH_ALARM) != 0
 	return (_engine.low_health_alarm & (1 << Gen2SoundEngine.DANGER_ON_BIT)) != 0
 
 
@@ -297,12 +426,13 @@ func low_health_alarm() -> bool:
 ## for as long as its screen is up checks each frame. Separate from
 ## [method audio_status] because that builds a dictionary.
 func music_playing() -> bool:
-	return _engine.music_channels_active()
+	return _gen1.music_channels_active() if _generation == RomRegistry.GEN1 \
+		else _engine.music_channels_active()
 
 
 ## `_CheckSFX`, which is what `waitsfx` and the battle screen wait on.
 func effect_playing() -> bool:
-	return _engine.sfx_active()
+	return _gen1.sfx_active() if _generation == RomRegistry.GEN1 else _engine.sfx_active()
 
 
 ## How many driver frames this player has actually rendered. The engine only
@@ -319,12 +449,15 @@ func timeline_updates() -> int:
 func audio_status() -> Dictionary:
 	var active: Array[int] = []
 	for index: int in Gen2SoundEngine.NUM_CHANNELS:
-		if _engine.channels[index].channel_on:
+		var on: bool = _gen1.channel_sound_id(index) != 0 \
+			if _generation == RomRegistry.GEN1 else _engine.channels[index].channel_on
+		if on:
 			active.append(index + 1)
 	return {
 		"active_channels": active,
-		"sfx_active": _engine.sfx_active(),
-		"music_active": _engine.music_channels_active(),
+		"sfx_active": effect_playing(),
+		"music_active": music_playing(),
+		"generation": _generation,
 		"volume": _engine.volume,
 		"music_gain": _engine.music_gain,
 		"sfx_gain": _engine.sfx_gain,
@@ -397,7 +530,7 @@ func _service_timeline(delta: float = 0.0) -> void:
 		# over live music, which is what a host that stopped its stream and then
 		# asked for the same piece again used to leave behind. The output
 		# follows the driver rather than the other way round.
-		if not _engine.any_channel_active():
+		if not _any_channel_active():
 			_starved_seconds = 0.0
 			return
 		_start_stream()
@@ -424,7 +557,7 @@ func _service_timeline(delta: float = 0.0) -> void:
 	var pushed: int = 0
 	while available >= PokeApu.SAMPLES_PER_FRAME and _capacity - available < target:
 		_timeline_updates += 1
-		_engine.update_sound()
+		_advance_driver()
 		_apu.render_frame(_buffer)
 		_playback.push_buffer(_buffer)
 		available = _playback.get_frames_available()
@@ -439,7 +572,7 @@ func _service_timeline(delta: float = 0.0) -> void:
 ## what the queue does is the only honest evidence: a live one consumes 59.7
 ## driver frames a second whatever the host's frame rate.
 func _watch_for_a_dead_output(delta: float, pushed: int) -> void:
-	if pushed > 0 or not _engine.any_channel_active():
+	if pushed > 0 or not _any_channel_active():
 		_starved_seconds = 0.0
 		return
 	_starved_seconds += delta

--- a/game/audio/poke_audio_render.gd
+++ b/game/audio/poke_audio_render.gd
@@ -19,6 +19,8 @@ static func render(
 ) -> Dictionary:
 	if record.is_empty():
 		return {"ok": false, "reason": &"audio_data_unavailable"}
+	if int(assets.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1:
+		return render_gen1(record, assets, frames, trace)
 	var apu := PokeApu.new()
 	var engine := Gen2SoundEngine.new(apu)
 	engine.stereo = stereo
@@ -45,6 +47,47 @@ static func render(
 	for frame: int in maxi(frames, 1):
 		apu.trace_frame = frame
 		engine.update_sound()
+		var block: PackedInt32Array = apu.render_frame_pcm()
+		for index: int in block.size():
+			pcm[cursor + index] = block[index]
+		cursor += block.size()
+	return {
+		"ok": true,
+		"pcm": pcm,
+		"trace": "\n".join(apu.trace_lines) + "\n" if trace else "",
+		"frames": maxi(frames, 1),
+	}
+
+
+## The same render for a Generation 1 record. `PlaySound $ff` runs first so both
+## sides of a parity diff start from the same registers and the same channel
+## block, and the trace is the engine bank's writes alone: `FadeOutAudio` is
+## VBlank's, one bank away, and belongs to the live path rather than to this one.
+static func render_gen1(
+	record: Dictionary, assets: Dictionary, frames: int, trace: bool = false
+) -> Dictionary:
+	var apu := PokeApu.new()
+	var engine := Gen1SoundEngine.new(apu)
+	engine.yellow = bool(assets.get("yellow", false))
+	engine.set_assets(assets)
+	var bank: int = int(record.get("bank", -1))
+	var id: int = int(record.get("sound_id", -1))
+	if bank <= 0:
+		bank = Gen1Layout.AUDIO_BANK_ROM[0]
+	if not engine.bank_is_registered(bank) or id <= 0:
+		return {"ok": false, "reason": &"audio_record_unplayable"}
+	engine.audio_rom_bank = bank
+	engine.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
+	engine.frequency_modifier = int(record.get("cry_pitch", 0)) & 0xFF
+	engine.tempo_modifier = int(record.get("cry_length", 0x80)) & 0xFF
+	apu.tracing = trace
+	engine.play_sound(id)
+	var pcm := PackedInt32Array()
+	pcm.resize(maxi(frames, 1) * PokeApu.SAMPLES_PER_FRAME * 2)
+	var cursor: int = 0
+	for frame: int in maxi(frames, 1):
+		apu.trace_frame = frame
+		engine.update_music()
 		var block: PackedInt32Array = apu.render_frame_pcm()
 		for index: int in block.size():
 			pcm[cursor + index] = block[index]

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2510,12 +2510,7 @@ func _play_hit_sound() -> void:
 
 
 func _audio_assets() -> Dictionary:
-	if _data == null:
-		return {}
-	return {
-		"wave_samples": _data.world_audio_asset(&"wave_samples"),
-		"drumkits": _data.world_audio_asset(&"drumkits"),
-	}
+	return {} if _data == null else _data.audio_assets()
 
 
 ## The two pictures put back where a battle draws them, which every send-out and

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -527,8 +527,84 @@ func world_phone_script(kind: StringName) -> Dictionary:
 	return _coerce_service_dictionary(metadata.get(key, {}))
 
 
+## One audio record by the number the caller spells it with. A Generation 2 cache
+## is indexed directly; a Generation 1 cache takes the same number as a role and
+## answers with the sound id that plays it, which is the one seam every
+## Crystal-numbered request in the tree passes through.
 func world_audio(kind: StringName, index: int) -> Dictionary:
+	if generation == RomRegistry.GEN1:
+		return _gen1_role(kind, index)
 	return _service_row(_audio().get(String(kind), []), index, _blob("audio"))
+
+
+func _gen1_role(kind: StringName, index: int) -> Dictionary:
+	if kind == &"music":
+		## Crystal's MUSIC_NONE is `_InitSound`, which is `PlaySound $ff` here.
+		if index == 0:
+			return {"index": 0, "bank": -1, "sound_id": Gen1SoundEngine.SFX_STOP_ALL_MUSIC}
+		var role: Array = Gen1Layout.music_role(index)
+		return {} if role.is_empty() else gen1_sound(int(role[0]), int(role[1]))
+	var sound_id: int = Gen1Layout.sfx_role(index)
+	return {} if sound_id < 0 else gen1_sound(-1, sound_id)
+
+
+## One Generation 1 sound, named the way `PlaySound` names it. A bank below zero
+## is `wAudioROMBank`: an effect plays out of whichever copy of the driver the
+## game is already on, which is why the same request sounds different in battle.
+func gen1_sound(bank: int, sound_id: int) -> Dictionary:
+	if sound_id <= 0:
+		return {}
+	var row: Dictionary = _gen1_audio_row(bank, sound_id)
+	if row.is_empty():
+		return {}
+	row["sound_id"] = sound_id
+	row["bank"] = bank
+	return row
+
+
+## Every Generation 1 record of one kind, in the order the header tables walk:
+## what a corpus sweep and the parity harness both iterate.
+func gen1_audio_rows(kind: StringName) -> Array:
+	var rows: Variant = _audio().get(String(kind), [])
+	if not rows is Array:
+		return []
+	var out: Array = []
+	for value: Variant in rows as Array:
+		if value is Dictionary:
+			out.append((value as Dictionary).duplicate(true))
+	return out
+
+
+func _gen1_audio_row(bank: int, sound_id: int) -> Dictionary:
+	for kind: String in ["music", "sfx"]:
+		var rows: Variant = _audio().get(kind, [])
+		if not rows is Array:
+			continue
+		for value: Variant in rows as Array:
+			if not value is Dictionary \
+				or int((value as Dictionary).get("index", -1)) != sound_id:
+				continue
+			if bank >= 0 and int((value as Dictionary).get("bank", -1)) != bank:
+				continue
+			return (value as Dictionary).duplicate(true)
+	return {}
+
+
+## The audio banks a Generation 1 driver reads, or the wave samples and drum kits
+## a Generation 2 one does. Every host that plays a record hands these across.
+func audio_assets() -> Dictionary:
+	if generation == RomRegistry.GEN1:
+		return {
+			"generation": RomRegistry.GEN1,
+			"yellow": id == RomRegistry.YELLOW,
+			"audio_banks": _coerce_service_value(
+				_audio().get("audio_banks", []), _blob("audio")
+			),
+		}
+	return {
+		"wave_samples": world_audio_asset(&"wave_samples"),
+		"drumkits": world_audio_asset(&"drumkits"),
+	}
 
 
 func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionary:
@@ -565,7 +641,11 @@ func species_cry(number: int) -> Dictionary:
 	var row: Dictionary = mon_cry(number)
 	if row.is_empty():
 		return {}
-	var record: Dictionary = world_audio(&"cries", int(row["index"]))
+	## `GetCryData`: the cry column counts cries, and the id is `CRY_SFX_START`
+	## plus three times it because every cry header is three channels long.
+	var record: Dictionary = gen1_sound(
+		-1, Gen1Layout.AUDIO_CRY_FIRST_ID + int(row["index"]) * 3
+	) if generation == RomRegistry.GEN1 else world_audio(&"cries", int(row["index"]))
 	if record.is_empty():
 		return {}
 	record["cry_pitch"] = int(row["pitch"])

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -866,6 +866,18 @@ func import_rom(
 		result["message"] = "Could not write the battle animations."
 		return result
 	await _breathe(yield_ms)
+	var audio: Dictionary = read_audio(rom, layout)
+	if not bool(audio["ok"]):
+		result["message"] = String(audio["message"])
+		return result
+	if not RomCache.write_section(
+		RomCache.world_audio_path(directory),
+		RomCache.blob_path(RomCache.world_audio_path(directory)),
+		audio["data"]
+	):
+		result["message"] = "Could not write the audio banks."
+		return result
+	await _breathe(yield_ms)
 
 	var sections: Dictionary = {
 		RomCache.species_path(directory): species,
@@ -899,6 +911,9 @@ func import_rom(
 		"overworld_sprite_count": int(world["sprites"]),
 		"encounter_count": int(world["encounters"]),
 		"battle_anim_count": int(anims["anims"]),
+		"audio_bank_count": (audio["data"]["audio_banks"] as Array).size(),
+		"audio_record_count": (audio["data"]["music"] as Array).size()
+			+ (audio["data"]["sfx"] as Array).size(),
 		"atlases": pics,
 		"tiles": tiles,
 		"bar_palettes": _import_bar_palettes(rom, layout),
@@ -2095,3 +2110,136 @@ func _bank_u16(bank: PackedByteArray, address: int) -> int:
 
 static func _in_bank(address: int) -> bool:
 	return address >= BANK_BASE and address < BANK_BASE + RomFile.BANK_SIZE
+
+
+## `SFX_Headers_1` to `_3`, and `_4` on Yellow, with the whole bank behind each:
+## one copy of the sound driver, its effects, its wave instruments and its music.
+## An id above the bank's own `MAX_SFX_ID` is a piece of music and everything at
+## or below it an effect, which is the only division `PlaySound` makes.
+static func read_audio(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var banks: Array = []
+	var music: Array = []
+	var sfx: Array = []
+	var counts: Array[int] = Gen1Layout.audio_record_counts(rom.id)
+	for index: int in Gen1Layout.audio_bank_count(rom.id):
+		var bank: int = Gen1Layout.AUDIO_BANK_ROM[index]
+		var walk: Dictionary = _walk_audio_headers(rom, bank, index)
+		if not bool(walk["ok"]):
+			return walk
+		var rows: Array = walk["rows"]
+		if rows.size() != counts[index]:
+			return _fail("Audio bank %d holds %d records, expected %d." % [
+				bank, rows.size(), counts[index],
+			])
+		banks.append(_audio_bank_row(rom, index, bank, rows.size()))
+		for row: Dictionary in rows:
+			var into: Array = music if int(row["index"]) > Gen1Layout.AUDIO_MAX_SFX_ID[index] \
+				else sfx
+			into.append(row)
+	var cries: Dictionary = _read_cry_headers(rom)
+	if not bool(cries["ok"]):
+		return cries
+	return {
+		"ok": true,
+		"data": {
+			"generation": RomRegistry.GEN1,
+			"audio_banks": banks,
+			"music": music,
+			"sfx": sfx,
+			"cries": cries["rows"],
+			"mon_cries": _read_mon_cries(rom, layout),
+		},
+	}
+
+
+static func _audio_bank_row(rom: RomFile, index: int, bank: int, records: int) -> Dictionary:
+	var start: int = bank * RomFile.BANK_SIZE
+	return {
+		"index": index,
+		"bank": bank,
+		"address": Gen1Layout.AUDIO_HEADER_TABLE,
+		"data_address": Gen1Layout.AUDIO_HEADER_TABLE,
+		"offset": start,
+		"wave_pointers": Gen1Layout.audio_wave_pointers(rom.id, index),
+		"max_sfx_id": Gen1Layout.AUDIO_MAX_SFX_ID[index],
+		"record_count": records,
+		"bytes": Array(rom.slice(start, RomFile.BANK_SIZE)),
+		"byte_count": RomFile.BANK_SIZE,
+	}
+
+
+## The table walks itself: id 0 is `db $ff, $ff, $ff` padding, every entry names
+## its own channel count, and the table ends exactly where the lowest channel
+## pointer in it begins. Nothing in the cartridge records its length.
+static func _walk_audio_headers(rom: RomFile, bank: int, index: int) -> Dictionary:
+	var start: int = bank * RomFile.BANK_SIZE
+	if not rom.in_bounds(start, RomFile.BANK_SIZE):
+		return _fail("Audio bank %d is outside the cartridge." % bank)
+	var rows: Array = []
+	var lowest: int = BANK_BASE + RomFile.BANK_SIZE
+	var id: int = 1
+	while Gen1Layout.AUDIO_HEADER_TABLE + id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE < lowest:
+		var entry: int = start + id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE
+		var count: int = ((rom.u8(entry) >> 6) & 0x03) + 1
+		var channels: Array = []
+		for slot: int in count:
+			var at: int = entry + slot * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE
+			var address: int = rom.u16le(at + 1)
+			if not _in_bank(address):
+				return _fail("Audio bank %d id %d points outside the bank." % [bank, id])
+			lowest = mini(lowest, address)
+			channels.append({"channel": rom.u8(at) & 0x0F, "address": address})
+		rows.append({
+			"index": id,
+			"bank": bank,
+			"audio_bank": index,
+			"address": Gen1Layout.AUDIO_HEADER_TABLE + id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE,
+			"offset": entry,
+			"channels": channels,
+			"data_address": Gen1Layout.AUDIO_HEADER_TABLE,
+			"byte_count": RomFile.BANK_SIZE,
+		})
+		id += count
+	var end: int = Gen1Layout.AUDIO_HEADER_TABLE + id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE
+	if end != lowest:
+		return _fail("Audio bank %d table ends at $%04X, its data at $%04X." % [
+			bank, end, lowest,
+		])
+	return {"ok": true, "rows": rows}
+
+
+## The thirty-eight cries, which every copy of the driver numbers the same way.
+## A cry names no bank of its own: `PlayCry` runs on whichever one the game is
+## already on, which is why the same cry sounds different in a battle.
+static func _read_cry_headers(rom: RomFile) -> Dictionary:
+	var rows: Array = []
+	for index: int in Gen1Layout.AUDIO_CRY_COUNT:
+		var id: int = Gen1Layout.AUDIO_CRY_FIRST_ID + index * 3
+		var entry: int = Gen1Layout.AUDIO_BANK_ROM[0] * RomFile.BANK_SIZE \
+			+ id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE
+		if (((rom.u8(entry) >> 6) & 0x03) + 1) != 3:
+			return _fail("Cry %d is not three channels long." % index)
+		rows.append({
+			"index": index,
+			"sound_id": id,
+			"bank": -1,
+			"address": Gen1Layout.AUDIO_HEADER_TABLE + id * Gen1Layout.AUDIO_HEADER_ENTRY_SIZE,
+			"data_address": Gen1Layout.AUDIO_HEADER_TABLE,
+			"byte_count": RomFile.BANK_SIZE,
+		})
+	return {"ok": true, "rows": rows}
+
+
+## `CryData`, read into dex order: the table is indexed by the internal slot, and
+## its three bytes are the cry, `wFrequencyModifier` and `wTempoModifier`.
+static func _read_mon_cries(rom: RomFile, layout: Dictionary) -> Array:
+	var slots: PackedInt32Array = Gen1Layout.index_of_dex(rom, layout)
+	var rows: Array = []
+	for dex: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
+		var at: int = Gen1Layout.cry_offset(layout, slots[dex])
+		rows.append({
+			"index": rom.u8(at),
+			"pitch": rom.u8(at + 1),
+			"length": rom.u8(at + 2),
+		})
+	return rows

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -2876,3 +2876,159 @@ static func cell_tile_index(cell_x: int, cell_y: int) -> int:
 ## in rather than its bottom left, which is why a left shore rolls on grass.
 static func cell_encounter_tile_index(cell_x: int, cell_y: int) -> int:
 	return cell_tile_index(cell_x, cell_y) + 1
+
+
+## The four copies of the sound driver, as the ROM banks they and their data live
+## in. Yellow alone has a fourth; the other three are the same banks on all three
+## cartridges, and so is every sound id.
+const AUDIO_BANK_ROM: Array[int] = [0x02, 0x08, 0x1F, 0x20]
+const AUDIO_BANK_COUNT_RED_BLUE: int = 3
+const AUDIO_BANK_COUNT_YELLOW: int = 4
+## `MAX_SFX_ID_1` to `_4`: an id above its bank's own is a piece of music, which
+## is what makes `PlaySound` clear the four music channels first.
+const AUDIO_MAX_SFX_ID: Array[int] = [185, 233, 194, 152]
+## `Audio<N>_WavePointers`. Red and Blue keep one per bank at the same address;
+## Yellow keeps a single table and every copy of the driver reads it.
+const AUDIO_WAVE_POINTERS_RED_BLUE: int = 0x4361
+const AUDIO_WAVE_POINTERS_YELLOW: int = 0x5A16
+## Where a bank's header table starts, and how many ids the corpus walk finds in
+## each: an entry names its own channel count, so the walk steps by it and stops
+## where the first channel pointer begins.
+const AUDIO_HEADER_TABLE: int = 0x4000
+const AUDIO_HEADER_ENTRY_SIZE: int = 3
+const AUDIO_RECORD_COUNT_RED_BLUE: Array[int] = [115, 126, 121]
+const AUDIO_RECORD_COUNT_YELLOW: Array[int] = [115, 126, 121, 74]
+## `CryData`'s first column counts cries rather than sound ids: the id is
+## `CRY_SFX_START` plus three times the index, every cry header being three
+## channels long.
+const AUDIO_CRY_COUNT: int = 38
+const AUDIO_CRY_FIRST_ID: int = 20
+
+## `Audio1_HWChannelEnableMasks`, which Yellow alone reads through
+## `Audio1_ApplyMonoStereo`: the mono row, then the three earphone rows the SOUND
+## option picks between. `wOptions & SOUND_MASK` shifted right once is the offset.
+const YELLOW_ENABLE_MASKS: Array[int] = [
+	0x11, 0x22, 0x44, 0x88, 0x11, 0x22, 0x44, 0x88,
+	0x01, 0x20, 0x44, 0x88, 0x11, 0x22, 0x44, 0x88,
+	0x01, 0x20, 0x04, 0x80, 0x01, 0x20, 0x04, 0x80,
+	0x01, 0x02, 0x40, 0x80, 0x01, 0x02, 0x40, 0x80,
+]
+const YELLOW_SOUND_OPTION_MASK: int = 0x30
+
+## The effects a Generation 1 path names directly. `Music_PokeFluteInBattle`
+## starts the first and overwrites its three channel pointers at once.
+const SFX_CAUGHT_MON: int = 154
+const SFX_GO_INSIDE: int = 173
+const SFX_GO_OUTSIDE: int = 181
+
+## The one seam every Crystal-numbered effect request reaches: a role spelled as
+## Crystal's own number, answered with the Generation 1 sound id that plays it.
+## An unlisted number belongs to a screen no Generation 1 cartridge opens.
+const SFX_ROLES: Dictionary = {
+	0x01: 134, ## SFX_ITEM, which is SFX_Get_Item1_1
+	0x02: 154, ## SFX_CAUGHT_MON, the battle bank's own
+	0x08: 144, ## SFX_READ_TEXT_2 is SFX_PRESS_AB
+	0x0B: 151, ## SFX_POISON is SFX_POISONED
+	0x0D: 153, ## SFX_BOOT_PC is SFX_TURN_ON_PC
+	0x0E: 154, ## SFX_SHUT_DOWN_PC is SFX_TURN_OFF_PC
+	0x0F: 155, ## SFX_CHOOSE_PC_OPTION is SFX_ENTER_PC
+	0x13: 173, ## SFX_WARP_TO is SFX_GO_INSIDE
+	0x15: 144, ## SFX_CHANGE_DEX_MODE is SFX_PRESS_AB
+	0x16: 162, ## SFX_JUMP_OVER_LEDGE is SFX_LEDGE
+	0x18: 164, ## SFX_FLY
+	0x19: 165, ## SFX_WRONG is SFX_DENIED
+	0x1F: 173, ## SFX_ENTER_DOOR is SFX_GO_INSIDE
+	0x20: 157, ## SFX_SWITCH_POKEMON is SFX_SWITCH
+	0x22: 178, ## SFX_TRANSACTION is SFX_PURCHASE
+	0x23: 181, ## SFX_EXIT_BUILDING is SFX_GO_OUTSIDE
+	0x24: 180, ## SFX_BUMP is SFX_COLLISION
+	0x25: 182, ## SFX_SAVE
+	0x28: 145, ## SFX_THROW_BALL is SFX_BALL_TOSS
+	0x29: 147, ## SFX_BALL_POOF
+	0x2E: 165, ## the move tutor's own SFX_WRONG
+	0x5E: 233, ## SFX_SHINE is SFX_TRAINER_APPEARED
+	0x62: 157, ## SFX_SWITCH_POCKETS is SFX_SWITCH
+	0x8C: 140, ## SFX_EXP_BAR is SFX_TINK
+	0xA4: 137, ## SFX_EVOLVED is SFX_GET_ITEM_2
+	0xAB: 167, ## SFX_NOT_VERY_EFFECTIVE
+	0xAC: 166, ## SFX_DAMAGE
+	0xAD: 176, ## SFX_SUPER_EFFECTIVE
+	0xB6: 140, ## SFX_HIT_END_OF_EXP_BAR is SFX_TINK
+}
+
+## The other half of the seam: a Crystal track number answered with the bank and
+## id that play the piece here. `MapSongBanks` carries both bytes itself, so only
+## the pieces a screen names by constant are listed.
+const MUSIC_ROLES: Dictionary = {
+	0x01: [0x1F, 195], ## MUSIC_TITLE is Music_TitleScreen
+	0x06: [0x08, 234], ## MUSIC_KANTO_GYM_LEADER_BATTLE
+	0x07: [0x08, 237], ## MUSIC_KANTO_TRAINER_BATTLE
+	0x08: [0x08, 240], ## MUSIC_KANTO_WILD_BATTLE
+	0x0D: [0x02, 232], ## MUSIC_HEAL is Music_PkmnHealed
+	0x12: [0x1F, 217], ## MUSIC_GAME_CORNER
+	0x13: [0x1F, 210], ## MUSIC_BICYCLE is Music_BikeRiding
+	0x14: [0x1F, 202], ## MUSIC_HALL_OF_FAME
+	0x21: [0x1F, 214], ## MUSIC_SURF is Music_Surfing
+	0x24: [0x1F, 199], ## MUSIC_CREDITS
+	0x29: [0x08, 240], ## MUSIC_JOHTO_WILD_BATTLE
+	0x2A: [0x08, 237], ## MUSIC_JOHTO_TRAINER_BATTLE
+	0x2B: [0x1F, 205], ## MUSIC_ROUTE_30 is Music_OaksLab, the speech's own piece
+	0x2E: [0x08, 234], ## MUSIC_JOHTO_GYM_LEADER_BATTLE
+	0x2F: [0x08, 243], ## MUSIC_CHAMPION_BATTLE is Music_FinalBattle
+	0x30: [0x08, 237], ## MUSIC_RIVAL_BATTLE
+	0x31: [0x08, 237], ## MUSIC_ROCKET_BATTLE
+	0x4A: [0x08, 240], ## MUSIC_JOHTO_WILD_BATTLE_NIGHT
+}
+
+## `PlayBattleMusic`'s own choice, as the bank and id each branch reaches. Lance
+## takes the gym leader piece and the rival's third battle the champion's.
+const BATTLE_MUSIC_GYM_LEADER: Array[int] = [0x08, 234]
+const BATTLE_MUSIC_TRAINER: Array[int] = [0x08, 237]
+const BATTLE_MUSIC_WILD: Array[int] = [0x08, 240]
+const BATTLE_MUSIC_FINAL: Array[int] = [0x08, 243]
+## `OPP_ID_OFFSET`, and the two opponents `PlayBattleMusic` names.
+const OPP_ID_OFFSET: int = 200
+const OPP_RIVAL3: int = 200 + 0x43
+const OPP_LANCE: int = 200 + 0x2E
+
+
+## How many copies of the driver a cartridge ships.
+static func audio_bank_count(id: StringName) -> int:
+	return AUDIO_BANK_COUNT_YELLOW if id == RomRegistry.YELLOW \
+		else AUDIO_BANK_COUNT_RED_BLUE
+
+
+static func audio_record_counts(id: StringName) -> Array[int]:
+	return AUDIO_RECORD_COUNT_YELLOW if id == RomRegistry.YELLOW \
+		else AUDIO_RECORD_COUNT_RED_BLUE
+
+
+## Where the copy of the driver in [param index] reads its wave instruments.
+## Yellow's later copies read the first one's table, which is a bank away.
+static func audio_wave_pointers(id: StringName, index: int) -> int:
+	if id != RomRegistry.YELLOW:
+		return AUDIO_WAVE_POINTERS_RED_BLUE
+	return AUDIO_WAVE_POINTERS_YELLOW if index == 0 else 0
+
+
+## The sound id a Crystal-numbered effect plays here, or -1 for a role no
+## Generation 1 cartridge has.
+static func sfx_role(crystal_number: int) -> int:
+	return int(SFX_ROLES.get(crystal_number, -1))
+
+
+## The bank and id a Crystal-numbered track plays here, or an empty array.
+static func music_role(crystal_track: int) -> Array:
+	return MUSIC_ROLES.get(crystal_track, [])
+
+
+## `PlayBattleMusic`: the gym leader flag first, then a wild battle, then the two
+## opponents that take a piece of their own.
+static func battle_music(gym_leader: bool, opponent: int) -> Array[int]:
+	if gym_leader or opponent == OPP_LANCE:
+		return BATTLE_MUSIC_GYM_LEADER
+	if opponent < OPP_ID_OFFSET:
+		return BATTLE_MUSIC_WILD
+	if opponent == OPP_RIVAL3:
+		return BATTLE_MUSIC_FINAL
+	return BATTLE_MUSIC_TRAINER

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -747,6 +747,7 @@ static func _read_map(
 		"number": map_id,
 		"tileset": tileset_number,
 		"music": rom.u8(Gen1Layout.map_song_offset(layout, map_id)),
+		"music_bank": rom.u8(Gen1Layout.map_song_offset(layout, map_id) + 1),
 		"border_block": events["border_block"],
 		"width_blocks": width,
 		"height_blocks": height,

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 124
+const FORMAT_VERSION: int = 125
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/launcher/title_backdrop.gd
+++ b/game/launcher/title_backdrop.gd
@@ -128,10 +128,7 @@ func _hold_music() -> void:
 ## The two blobs [Gen2SoundEngine] reads outside a record, the same pair the
 ## opening's own screen passes.
 func _audio_assets() -> Dictionary:
-	return {
-		"wave_samples": _data.world_audio_asset(&"wave_samples"),
-		"drumkits": _data.world_audio_asset(&"drumkits"),
-	}
+	return _data.audio_assets()
 
 
 ## Removes only the title lettering from the launcher copy. The real title page

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -730,7 +730,4 @@ func _play_intro_cry() -> void:
 
 
 func _audio_assets() -> Dictionary:
-	return {
-		"wave_samples": _data.world_audio_asset(&"wave_samples"),
-		"drumkits": _data.world_audio_asset(&"drumkits"),
-	}
+	return _data.audio_assets()

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -318,10 +318,7 @@ func _play_music(music: int, restart: bool) -> void:
 ## The two blobs `Gen2SoundEngine` reads outside a record: `WaveSamples` and the
 ## drumkits, which every request here shares.
 func _audio_assets() -> Dictionary:
-	return {
-		"wave_samples": _data.world_audio_asset(&"wave_samples"),
-		"drumkits": _data.world_audio_asset(&"drumkits"),
-	}
+	return _data.audio_assets()
 
 
 ## `ClearTilemap` leaves the blank tile everywhere, which through this palette

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -604,7 +604,33 @@ func map_music_track() -> int:
 	## branch is unreferenced.
 	if movement_mode == MOVEMENT_BIKE:
 		return Gen2WorldFieldMove.MUSIC_BICYCLE
+	if data != null and data.generation == RomRegistry.GEN1:
+		return 0 if current_map == null else current_map.music
 	return _map_header_music()
+
+
+## `MapSongBanks`' second byte, which `PlayDefaultMusicCommon` puts into
+## `wAudioROMBank` before the id. Riding and surfing take their own piece out of
+## the third copy of the driver rather than the map's.
+func map_music_bank() -> int:
+	if data == null or data.generation != RomRegistry.GEN1:
+		return 0
+	if movement_mode == MOVEMENT_SURF or movement_mode == MOVEMENT_BIKE:
+		var role: Array = Gen1Layout.music_role(map_music_track())
+		return int(role[0]) if not role.is_empty() else 0
+	return 0 if current_map == null else current_map.music_bank
+
+
+## The record the map's own music resolves to, which is the one place a
+## Generation 1 track carries its bank across.
+func map_music_record() -> Dictionary:
+	if data == null:
+		return {}
+	if data.generation != RomRegistry.GEN1:
+		return data.world_audio(&"music", map_music_track())
+	if movement_mode == MOVEMENT_SURF or movement_mode == MOVEMENT_BIKE:
+		return data.world_audio(&"music", map_music_track())
+	return data.gen1_sound(map_music_bank(), map_music_track())
 
 
 func _is_national_park_gate() -> bool:

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -465,7 +465,7 @@ static func audio_for_request(world: Gen2WorldAPI, request: Dictionary) -> Dicti
 			if world.current_map == null:
 				return {}
 			## `GetMapMusic_MaybeSpecial`, never the raw header byte.
-			return data.world_audio(&"music", world.map_music_track())
+			return world.map_music_record()
 	return {}
 
 

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -14,6 +14,9 @@ var tileset: int = 0
 var environment: int = 0
 var location: int = 0
 var music: int = 0
+## `MapSongBanks`' second byte, which is Generation 1's only: the copy of the
+## sound driver the piece lives in. Zero on a Generation 2 map.
+var music_bank: int = 0
 var phone_flag: int = 0
 var palette: int = 0
 var fish_group: int = 0
@@ -50,6 +53,7 @@ static func from_cache(value: Dictionary) -> Gen2WorldMap:
 	out.environment = int(value.get("environment", 0))
 	out.location = int(value.get("location", 0))
 	out.music = int(value.get("music", 0))
+	out.music_bank = int(value.get("music_bank", 0))
 	out.phone_flag = int(value.get("phone_flag", 0))
 	out.palette = int(value.get("palette", 0))
 	out.fish_group = int(value.get("fish_group", 0))

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -8629,10 +8629,7 @@ func _skip_audio_request(reason: StringName) -> Array:
 
 
 func _audio_assets() -> Dictionary:
-	return {
-		"wave_samples": _data.world_audio_asset(&"wave_samples") if _data != null else {},
-		"drumkits": _data.world_audio_asset(&"drumkits") if _data != null else {},
-	}
+	return {} if _data == null else _data.audio_assets()
 
 
 ## `FadeToMapMusic`, which is what a map entered through a warp arrives behind:
@@ -8644,8 +8641,7 @@ func _fade_to_map_music() -> void:
 		or _world.current_map == null:
 		return
 	_audio_player.fade_to(
-		_data.world_audio(&"music", _world.state.map_music()),
-		WARP_MUSIC_FADE_FRAMES, _audio_assets(),
+		_world.map_music_record(), WARP_MUSIC_FADE_FRAMES, _audio_assets(),
 	)
 
 
@@ -8668,8 +8664,7 @@ func _play_music_track(index: int) -> void:
 func _play_current_map_music() -> void:
 	if _audio_player == null or _data == null or _world == null or _world.current_map == null:
 		return
-	var track: int = _world.state.map_music()
-	var record: Dictionary = _data.world_audio(&"music", track)
+	var record: Dictionary = _world.map_music_record()
 	if record.is_empty():
 		return
 	_audio_player.play_record(record, &"map_music", _audio_assets())

--- a/tests/unit/test_gen1_sound_engine.gd
+++ b/tests/unit/test_gen1_sound_engine.gd
@@ -1,0 +1,258 @@
+extends GutTest
+
+## The Generation 1 driver's own decisions, watched through the registers it
+## writes. Every fixture is a real channel stream: a header at `id * 3` from the
+## table start, then commands from `macros/scripts/audio.asm`.
+
+const ORIGIN: int = Gen1SoundEngine.HEADER_TABLE_ADDRESS
+const BANK: int = 0x02
+const MAX_SFX_ID: int = 100
+const NR11: int = 0xFF11
+const NR12: int = 0xFF12
+const NR13: int = 0xFF13
+const NR14: int = 0xFF14
+const NR50: int = 0xFF24
+const NR51: int = 0xFF25
+## Where a fixture's streams are laid, clear of every header the tests define.
+const STREAMS_AT: int = 0x200
+
+
+## One bank, `{id: [[channel, [bytes]], ...]}`. $ff pads it, which is
+## `sound_ret`, so an id no fixture defines stops on its first byte.
+func _bank(sounds: Dictionary, max_sfx_id: int = MAX_SFX_ID) -> Dictionary:
+	var bytes := PackedByteArray()
+	bytes.resize(0x1000)
+	bytes.fill(Gen1SoundEngine.SOUND_RET_CMD)
+	var at: int = STREAMS_AT
+	for id: int in sounds:
+		var streams: Array = sounds[id]
+		var header: int = id * Gen1SoundEngine.HEADER_ENTRY_SIZE
+		for index: int in streams.size():
+			var stream: Array = streams[index]
+			var first: int = ((streams.size() - 1) << 6) | int(stream[0])
+			bytes[header + index * 3] = first if index == 0 else int(stream[0])
+			bytes[header + index * 3 + 1] = (ORIGIN + at) & 0xFF
+			bytes[header + index * 3 + 2] = ((ORIGIN + at) >> 8) & 0xFF
+			for value: int in stream[1] as Array:
+				bytes[at] = value
+				at += 1
+	return {
+		"bank": BANK, "bytes": bytes, "data_address": ORIGIN,
+		"wave_pointers": ORIGIN + 0xF00, "max_sfx_id": max_sfx_id,
+	}
+
+
+func _engine(sounds: Dictionary, max_sfx_id: int = MAX_SFX_ID) -> Gen1SoundEngine:
+	var engine := Gen1SoundEngine.new()
+	engine.register_bank(_bank(sounds, max_sfx_id))
+	engine.audio_rom_bank = BANK
+	engine.apu.tracing = true
+	return engine
+
+
+## Register writes as `[frame, address, value]`, the traffic the request itself
+## produced and not the power-on before it.
+func _writes(engine: Gen1SoundEngine, frames: int) -> Array:
+	engine.apu.trace_lines = PackedStringArray()
+	var out: Array = []
+	for frame: int in frames:
+		engine.apu.trace_frame = frame
+		engine.update_music()
+	for line: String in engine.apu.trace_lines:
+		var parts: PackedStringArray = line.split(" ")
+		out.append([int(parts[0]), parts[1].hex_to_int(), parts[2].hex_to_int()])
+	return out
+
+
+func _values(writes: Array, address: int) -> Array:
+	var out: Array = []
+	for write: Array in writes:
+		if int(write[1]) == address:
+			out.append(int(write[2]))
+	return out
+
+
+func _stream_address(index: int) -> int:
+	return ORIGIN + STREAMS_AT + index
+
+
+func _frames_of(writes: Array, address: int) -> Array:
+	var out: Array = []
+	for write: Array in writes:
+		if int(write[1]) == address:
+			out.append(int(write[0]))
+	return out
+
+
+func test_a_header_hands_each_channel_its_own_stream() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [0xFF]], [1, [0xFF]]]})
+	assert_true(engine.play_music(BANK, 200))
+	assert_eq(engine.channel_sound_id(0), 200)
+	assert_eq(engine.channel_sound_id(1), 200)
+	assert_eq(engine.channel_sound_id(2), 0, "a channel the header misses is untouched")
+	assert_eq(engine.channel_command_pointer(0), _stream_address(0))
+	assert_eq(engine.channel_command_pointer(1), _stream_address(1))
+
+
+## `.playSfx` against `.playMusic`: only an id above the bank's own MAX_SFX_ID
+## clears the four music channels, which is why an effect plays over a piece.
+func test_an_id_above_the_banks_max_sfx_id_is_the_only_one_that_clears_music() -> void:
+	var engine: Gen1SoundEngine = _engine({
+		200: [[0, [0xFF]]], 50: [[4, [0xFF]]], 201: [[0, [0xFF]]],
+	})
+	assert_true(engine.play_music(BANK, 200))
+	engine.play_sound(50)
+	assert_eq(engine.channel_sound_id(0), 200, "an effect leaves the music channel")
+	assert_eq(engine.channel_sound_id(4), 50)
+	engine.play_sound(201)
+	assert_eq(engine.channel_sound_id(0), 201, "a second piece takes the music channel")
+
+
+## `.playSfx` walks the header's channels and refuses the whole request while a
+## lower-numbered effect still holds one of them.
+func test_a_lower_numbered_effect_keeps_the_channel_it_holds() -> void:
+	var engine: Gen1SoundEngine = _engine({40: [[4, [0xFF]]], 60: [[4, [0xFF]]]})
+	engine.play_sound(40)
+	engine.play_sound(60)
+	assert_eq(engine.channel_sound_id(4), 40, "60 cannot take 40's channel")
+	engine.play_sound(40)
+	assert_eq(engine.channel_sound_id(4), 40)
+
+
+## `Audio1_note_pitch` through `Audio1_CalculateFrequency`: octave 7 is the
+## pitch table unshifted, so C_ is $F82C with 8 added to its high byte.
+func test_a_note_writes_the_frequency_the_pitch_table_gives() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7, 0x01, 0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	var writes: Array = _writes(engine, 1)
+	var value: int = Gen1SoundEngine.PITCHES[0] - 0x10000
+	var low: int = value & 0xFF
+	var high: int = ((((value >> 8) & 0xFF) + 8) & 0xFF)
+	assert_eq(_values(writes, NR13), [low], "the low frequency byte")
+	assert_eq(_values(writes, NR14), [(high | 0x80) & 0xC7], "the high byte with the restart")
+
+
+## `Audio1_note_length`: the delay is note speed times length times tempo, and
+## the note that follows is not read until it runs out.
+func test_note_delay_is_speed_times_length_times_tempo() -> void:
+	# note_type 8, octave 7, note C_ length 4 -> 8 * 4 * $100 >> 8 = 32 frames.
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7, 0x03, 0x03, 0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	var writes: Array = _writes(engine, 40)
+	assert_eq(_frames_of(writes, NR13), [0, 32], "the second note starts 32 frames on")
+
+
+## `sound_loop` counts up to its operand and then steps past the address. The
+## jump goes back onto the note itself, which is the stream's fourth byte.
+func test_a_loop_runs_its_count_and_then_falls_through() -> void:
+	var note: int = _stream_address(3)
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7,
+		0x00,
+		0xFE, 0x02, note & 0xFF, (note >> 8) & 0xFF,
+		0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	## Two notes of eight frames each, and the `sound_ret` behind them.
+	var writes: Array = _writes(engine, 24)
+	assert_eq(_values(writes, NR13).size(), 2, "the note plays twice and the loop ends")
+	assert_eq(engine.channel_sound_id(0), 0, "the stream reaches its sound_ret")
+
+
+## `sound_call` remembers the byte after its operand and `sound_ret` goes back to
+## it rather than stopping the channel.
+func test_sound_call_returns_to_the_byte_after_it() -> void:
+	var call_target: int = _stream_address(8)
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7,
+		0xFD, call_target & 0xFF, (call_target >> 8) & 0xFF,
+		0x00,
+		0xFF,
+		0x00,
+		0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	var writes: Array = _writes(engine, 16)
+	assert_eq(_values(writes, NR13).size(), 2, "the called note and the one after the return")
+
+
+## A stream that jumps without ever reaching a note hangs the cartridge. Bounding
+## the walk leaves a silent channel instead of a frozen frame.
+func test_a_stream_that_never_reaches_a_note_stops_instead_of_hanging() -> void:
+	var here: int = _stream_address(0)
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xFE, 0x00, here & 0xFF, (here >> 8) & 0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	engine.update_music()
+	assert_eq(engine.channel_sound_id(0), 0, "the channel gives up rather than spinning")
+
+
+## `FadeOutAudio` writes full volume on every frame nothing is fading, which is
+## what BIT_NO_AUDIO_FADE_OUT exists to stop.
+func test_the_fade_writes_full_volume_until_the_flag_stops_it() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [0xFF]]]})
+	engine.apu.trace_lines = PackedStringArray()
+	engine.fade_out_audio()
+	assert_eq(_trace(engine, NR50), [Gen1SoundEngine.MAX_VOLUME])
+	engine.no_audio_fade_out = true
+	engine.apu.trace_lines = PackedStringArray()
+	engine.fade_out_audio()
+	assert_eq(_trace(engine, NR50), [], "the flag leaves the register alone")
+
+
+func _trace(engine: Gen1SoundEngine, address: int) -> Array:
+	var out: Array = []
+	for line: String in engine.apu.trace_lines:
+		var parts: PackedStringArray = line.split(" ")
+		if parts[1].hex_to_int() == address:
+			out.append(parts[2].hex_to_int())
+	return out
+
+
+## `PlaySound`'s `.fadeOut`: a frame count per volume step, and the queued id
+## starts out of the bank it was queued with once the volume reaches zero.
+func test_a_fade_that_reaches_zero_starts_the_queued_id() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [0xFF]]], 201: [[1, [0xFF]]]})
+	assert_true(engine.play_music(BANK, 200))
+	engine.start_fade(1, 201, BANK)
+	for _frame: int in 64:
+		engine.fade_out_audio()
+	assert_eq(engine.fade_out_control, 0, "the fade finished")
+	assert_eq(engine.channel_sound_id(1), 201, "the queued piece took over")
+
+
+## `Audio1_ApplyMonoStereo`, which Yellow alone reads: the SOUND option offsets
+## into four enable-mask rows and zero is the mono row every cartridge starts on.
+func test_only_yellow_narrows_the_enable_mask_by_the_sound_option() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7, 0x01, 0xFF,
+	]]]})
+	assert_true(engine.play_music(BANK, 200))
+	assert_eq(_values(_writes(engine, 1), NR51), [Gen1SoundEngine.HW_ENABLE_MASK[0]])
+	var yellow: Gen1SoundEngine = _engine({200: [[0, [
+		0xD8, 0x00, 0xE7, 0x01, 0xFF,
+	]]]})
+	yellow.yellow = true
+	yellow.mono_stereo_offset = 16
+	assert_true(yellow.play_music(BANK, 200))
+	assert_eq(
+		_values(_writes(yellow, 1), NR51),
+		[int(Gen1Layout.YELLOW_ENABLE_MASKS[16])], "the third row"
+	)
+
+
+## `PlaySound $ff` is `_InitSound`: every channel drops its id, so nothing the
+## driver was playing survives it.
+func test_the_stop_id_clears_every_channel() -> void:
+	var engine: Gen1SoundEngine = _engine({200: [[0, [0xFF]]], 50: [[4, [0xFF]]]})
+	assert_true(engine.play_music(BANK, 200))
+	engine.play_sound(50)
+	engine.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
+	for channel: int in Gen1SoundEngine.NUM_CHANNELS:
+		assert_eq(engine.channel_sound_id(channel), 0, "channel %d" % channel)
+	assert_false(engine.any_channel_active())

--- a/tests/unit/test_gen1_sound_engine.gd.uid
+++ b/tests/unit/test_gen1_sound_engine.gd.uid
@@ -1,0 +1,1 @@
+uid://dwmdryit215e8

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1667 lines of it, and
-## Generation 1 has added 2260 more to the shared code, the largest of them 152
-## the region map, 150 the battle animation engine, 140 the transition, 131 the
-## field moves, 130 the Pokedex, 108 the three PCs, 103 the movement a map
-## script runs, 97 the bicycle, 95 the trainer card, 74 those scripts.
-const MAX_COMMENT_LINES: int = 41596
+## files cost: `game/gen1`, its neighbours, the 157 of the sound driver and the
+## 23 of its check are 1847 lines of it, and Generation 1 has added 2351 more to
+## the shared code, the largest of them 152 the region map, 150 the battle
+## animation engine, 140 the transition, 131 the field moves, 130 the Pokedex,
+## 108 the three PCs, 103 the movement a map script runs, 97 the bicycle.
+const MAX_COMMENT_LINES: int = 41867
 
 ## What no comment block ever ends on. A pass that meets the ceiling above trims
 ## the second line of a two-line block and leaves the first mid-sentence, which

--- a/tools/checks/gen1_audio.gd
+++ b/tools/checks/gen1_audio.gd
@@ -1,0 +1,154 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the Generation 1 sound driver against freshly imported real caches on
+## all three cartridges. Every record every header table names is played, so a
+## stream that never reaches a note is a failure rather than silence, and every
+## number the rest of the tree spells a sound with is resolved: each map's own
+## track and bank, every species cry, and both role tables.
+
+## Enough frames for the slowest header to reach its first note and write a
+## register. A stream writing nothing in this many never started.
+const FRAMES: int = 24
+
+var _engine: Gen1SoundEngine = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game_of(RomRegistry.GEN1, func() -> void:
+		_engine = Gen1SoundEngine.new()
+		_engine.yellow = _r.game_id == RomRegistry.YELLOW
+		_engine.apu.tracing = true
+		_verify_the_banks()
+		_verify_every_record_plays()
+		_verify_every_map_track()
+		_verify_every_cry()
+		_verify_the_role_tables()
+	)
+
+
+## `SFX_Headers_1` to `_3`, and `_4` on Yellow: the cache carries a whole ROM
+## bank each, and an unregistered one is every id in it gone.
+func _verify_the_banks() -> void:
+	var assets: Dictionary = _r.data.audio_assets()
+	_engine.set_assets(assets)
+	var wanted: int = Gen1Layout.audio_bank_count(_r.game_id)
+	_r.check(_engine.registered_bank_count() == wanted,
+		"the cache registers %d audio banks, not %d." % [
+			_engine.registered_bank_count(), wanted,
+		])
+	for index: int in wanted:
+		var bank: int = Gen1Layout.AUDIO_BANK_ROM[index]
+		_r.check(_engine.bank_is_registered(bank), "audio bank $%02X is missing." % bank)
+
+
+## Every id both header tables name, played through the driver. The counts are
+## `Gen1Layout`'s own pins, so a table that walks short is caught before the
+## records are.
+func _verify_every_record_plays() -> void:
+	var counts: Array[int] = Gen1Layout.audio_record_counts(_r.game_id)
+	var wanted: int = 0
+	for count: int in counts:
+		wanted += count
+	var music: Array = _r.data.gen1_audio_rows(&"music")
+	var sfx: Array = _r.data.gen1_audio_rows(&"sfx")
+	_r.check(music.size() + sfx.size() == wanted,
+		"the cache holds %d records, not the %d the tables walk." % [
+			music.size() + sfx.size(), wanted,
+		])
+	var silent: Array[String] = []
+	for row: Dictionary in music:
+		if not _plays(int(row["bank"]), int(row["index"]), true):
+			silent.append("music $%02X:%d" % [int(row["bank"]), int(row["index"])])
+	for row: Dictionary in sfx:
+		if not _plays(int(row["bank"]), int(row["index"]), false):
+			silent.append("sfx $%02X:%d" % [int(row["bank"]), int(row["index"])])
+	_r.note("audio: %d music and %d effects over %d banks." % [
+		music.size(), sfx.size(), counts.size(),
+	])
+	_r.check(silent.is_empty(), "%d records write no register: %s." % [
+		silent.size(), ", ".join(silent.slice(0, 8)),
+	])
+
+
+## One record, from `PlaySound` to the registers it reaches. The stop in front is
+## the sweep's own: `.playSfx` refuses a request while a lower-numbered effect
+## still holds one of its channels, so a run in id order would report the
+## cartridge's own priority as silence.
+func _plays(bank: int, id: int, is_music: bool) -> bool:
+	_engine.audio_rom_bank = bank
+	_engine.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
+	_engine.apu.trace_lines = PackedStringArray()
+	if is_music:
+		if not _engine.play_music(bank, id):
+			return false
+	else:
+		_engine.play_sound(id)
+	if not _engine.any_channel_active():
+		return false
+	for _frame: int in FRAMES:
+		_engine.update_music()
+	return not _engine.apu.trace_lines.is_empty()
+
+
+## `MapSongBanks` over the whole map list: two bytes a map, and a wrong second
+## one is a piece playing out of the wrong copy of the driver.
+func _verify_every_map_track() -> void:
+	var missing: Array[String] = []
+	var banks: Dictionary = {}
+	for map: Gen2WorldMap in _r.data.world_maps():
+		banks[map.music_bank] = int(banks.get(map.music_bank, 0)) + 1
+		if _r.data.gen1_sound(map.music_bank, map.music).is_empty():
+			missing.append("map %d wants $%02X:%d" % [map.number, map.music_bank, map.music])
+	var rows: Array = banks.keys()
+	rows.sort()
+	_r.note("map music: %d maps over banks %s." % [_r.data.world_maps().size(), str(rows)])
+	_r.check(missing.is_empty(), "%d maps name no record: %s." % [
+		missing.size(), ", ".join(missing.slice(0, 8)),
+	])
+	for bank: int in rows:
+		_r.check(Gen1Layout.AUDIO_BANK_ROM.has(bank),
+			"a map names audio bank $%02X, which is not one of the driver's." % bank)
+
+
+## `GetCryData`: every species reaches a cry, and the id it reaches is the one
+## the three-channel stride puts it at.
+func _verify_every_cry() -> void:
+	var missing: Array[String] = []
+	for number: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
+		var row: Dictionary = _r.data.mon_cry(number)
+		if row.is_empty():
+			missing.append("species %d has no cry row" % number)
+			continue
+		var record: Dictionary = _r.data.species_cry(number)
+		var wanted: int = Gen1Layout.AUDIO_CRY_FIRST_ID + int(row["index"]) * 3
+		if record.is_empty() or int(record.get("sound_id", -1)) != wanted:
+			missing.append("species %d wants id %d" % [number, wanted])
+	_r.note("cries: %d species over %d headers." % [
+		Gen1Layout.SPECIES_COUNT, Gen1Layout.AUDIO_CRY_COUNT,
+	])
+	_r.check(missing.is_empty(), "%d cries do not resolve: %s." % [
+		missing.size(), ", ".join(missing.slice(0, 8)),
+	])
+
+
+## The two tables that answer a Crystal number with a Generation 1 sound. Every
+## row has to reach a record, since an unlisted number is what stands for "no
+## screen here" and a listed one that resolves to nothing is silence in play.
+func _verify_the_role_tables() -> void:
+	for number: Variant in Gen1Layout.SFX_ROLES:
+		var record: Dictionary = _r.data.world_audio(&"sfx", int(number))
+		_r.check(not record.is_empty(),
+			"SFX role $%02X resolves to nothing." % int(number))
+	for track: Variant in Gen1Layout.MUSIC_ROLES:
+		var role: Array = Gen1Layout.music_role(int(track))
+		var record: Dictionary = _r.data.gen1_sound(int(role[0]), int(role[1]))
+		_r.check(not record.is_empty(),
+			"music role $%02X wants $%02X:%d, which is not in the cache." % [
+				int(track), int(role[0]), int(role[1]),
+			])
+	_r.note("roles: %d effects and %d tracks." % [
+		Gen1Layout.SFX_ROLES.size(), Gen1Layout.MUSIC_ROLES.size(),
+	])

--- a/tools/checks/gen1_audio.gd.uid
+++ b/tools/checks/gen1_audio.gd.uid
@@ -1,0 +1,1 @@
+uid://di1y5xt7gr5nm

--- a/tools/render_audio.gd
+++ b/tools/render_audio.gd
@@ -1,18 +1,19 @@
 extends SceneTree
 
 ## Renders one imported audio record through the sound engine and the APU, and
-## writes a WAV plus the per-frame hardware-register trace beside it. The trace is
-## the parity artefact: any faithful implementation of the same driver writes the
-## same registers in the same order on the same frames. Kinds are `music`, `sfx`,
+## writes a WAV plus the per-frame register trace beside it. The trace is the
+## parity artefact: a faithful implementation of the driver writes the same
+## registers in the same order on the same frames. Kinds are `music`, `sfx`,
 ## `stereo_sfx`, `cry` and `mon_cry`; the id is the record index, the species for
-## `mon_cry`, or `all` to sweep. The last argument is `wStereoPanningMask`.
+## `mon_cry`, `<bank>:<id>` on a Generation 1 cache, or `all`. Last is the panning.
 ##   ... -s res://tools/render_audio.gd -- crystal music 1 600 /tmp/out
+##   ... -s res://tools/render_audio.gd -- red music 2:186 600 /tmp/out
 
 
 func _initialize() -> void:
 	var arguments: PackedStringArray = OS.get_cmdline_user_args()
 	if arguments.size() < 5:
-		printerr("usage: render_audio.gd -- <game> <music|sfx|stereo_sfx|cry> <id|all> <frames> <out-prefix> [stereo] [panning]")
+		printerr("usage: render_audio.gd -- <game> <music|sfx|stereo_sfx|cry> <id|bank:id|all> <frames> <out-prefix> [stereo] [panning]")
 		quit(1)
 		return
 	var game: StringName = StringName(arguments[0])
@@ -31,33 +32,17 @@ func _initialize() -> void:
 		quit(1)
 		return
 
-	var assets: Dictionary = {
-		"wave_samples": data.world_audio_asset(&"wave_samples"),
-		"drumkits": data.world_audio_asset(&"drumkits"),
-	}
+	var assets: Dictionary = data.audio_assets()
 	if arguments[2] == "all":
-		var index: int = 1 if kind == &"mon_cry" else 0
-		while true:
-			var swept: Dictionary = _record(data, kind, index)
-			if swept.is_empty():
-				break
-			_report(kind, index, swept)
-			if not _render(
-				swept, kind, assets, frames, stereo, panning, "%s_%d" % [prefix, index]
-			):
-				quit(1)
-				return
-			index += 1
-		print("Rendered %s records up to %d into %s_*" % [kind, index - 1, prefix])
-		quit(0)
+		quit(_sweep(data, kind, assets, frames, stereo, panning, prefix))
 		return
 
-	var entry: Dictionary = _record(data, kind, int(arguments[2]))
+	var entry: Dictionary = _record(data, kind, arguments[2])
 	if entry.is_empty():
 		printerr("No %s entry %s in the %s cache." % [kind, arguments[2], game])
 		quit(1)
 		return
-	_report(kind, int(arguments[2]), entry)
+	_report(kind, arguments[2], entry)
 	if not _render(entry, kind, assets, frames, stereo, panning, prefix):
 		quit(1)
 		return
@@ -65,19 +50,58 @@ func _initialize() -> void:
 	quit(0)
 
 
-func _record(data: GameData, kind: StringName, index: int) -> Dictionary:
+## Every record the cache holds of that kind. A Generation 1 sweep is named by
+## bank and id, so a file per record keeps the two spaces apart.
+func _sweep(
+	data: GameData, kind: StringName, assets: Dictionary, frames: int,
+	stereo: bool, panning: int, prefix: String
+) -> int:
+	if data.generation == RomRegistry.GEN1:
+		return _sweep_gen1(data, kind, assets, frames, prefix)
+	var index: int = 1 if kind == &"mon_cry" else 0
+	while true:
+		var swept: Dictionary = _record(data, kind, str(index))
+		if swept.is_empty():
+			break
+		_report(kind, str(index), swept)
+		if not _render(swept, kind, assets, frames, stereo, panning, "%s_%d" % [prefix, index]):
+			return 1
+		index += 1
+	print("Rendered %s records up to %d into %s_*" % [kind, index - 1, prefix])
+	return 0
+
+
+func _sweep_gen1(
+	data: GameData, kind: StringName, assets: Dictionary, frames: int, prefix: String
+) -> int:
+	var rows: Array = data.gen1_audio_rows(&"sfx" if kind != &"music" else &"music")
+	for row: Dictionary in rows:
+		var record: Dictionary = data.gen1_sound(int(row["bank"]), int(row["index"]))
+		var name: String = "%s_%02X_%d" % [prefix, int(row["bank"]), int(row["index"])]
+		if not _render(record, kind, assets, frames, false, 0, name):
+			return 1
+	print("Rendered %d %s records into %s_*" % [rows.size(), kind, prefix])
+	return 0
+
+
+func _record(data: GameData, kind: StringName, id: String) -> Dictionary:
 	if kind == &"mon_cry":
-		return data.species_cry(index)
-	return data.world_audio(_table(kind), index)
+		return data.species_cry(int(id))
+	if data.generation == RomRegistry.GEN1:
+		var parts: PackedStringArray = id.split(":")
+		if parts.size() != 2:
+			return {}
+		return data.gen1_sound(int(parts[0]), int(parts[1]))
+	return data.world_audio(_table(kind), int(id))
 
 
-## `mon_cry` resolves through `PokemonCries`, so the parameters it picked are
+## `mon_cry` resolves through the cry table, so the parameters it picked are
 ## worth printing: a parity run has to hand the same two to the other side.
-func _report(kind: StringName, index: int, entry: Dictionary) -> void:
+func _report(kind: StringName, id: String, entry: Dictionary) -> void:
 	if kind != &"mon_cry":
 		return
-	print("species %d: cry index %d pitch %d length %d" % [
-		index, int(entry.get("index", -1)),
+	print("species %s: cry index %d pitch %d length %d" % [
+		id, int(entry.get("sound_id", entry.get("index", -1))),
 		int(entry.get("cry_pitch", 0)), int(entry.get("cry_length", 0)),
 	])
 

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -46,7 +46,8 @@ const GROUPS: Dictionary = {
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 	&"gen1": [
 		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
-		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers", &"pokedex",
+		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers", &"gen1_audio",
+		&"pokedex",
 	],
 }
 


### PR DESCRIPTION
`Gen1SoundEngine` is a port of `audio/engine_1.asm`: one `Audio<N>_UpdateMusic` per LCD frame over the eight channel streams, with the command set, note lengths and pitches, vibrato, pitch slides, the duty-cycle rotation, `sound_call` and `sound_loop`, cries through `GetCryData`'s pitch and length, the low health alarm and `FadeOutAudio`. The three copies of the driver differ only in the bank `wAudioROMBank` selects, so one port reads all of them; Yellow's fourth copy and its `Audio1_ApplyMonoStereo` enable-mask rows come with it.

The importer writes a whole ROM bank per copy, with its header table, effects, wave instruments and music. `MapSongBanks`' second byte is kept on the map so a piece plays out of the copy the cartridge names, `GameData.audio_assets` is now the single place a host asks for whichever generation's blobs it needs, and `SFX_ROLES` and `MUSIC_ROLES` answer a Crystal-numbered request with the Generation 1 sound id that plays it, which is the seam every existing call site already reaches.

## Numbers

| | Red | Blue | Yellow |
|---|---|---|---|
| Audio banks | 3 | 3 | 4 |
| Music records | 45 | 45 | 49 |
| Effect records | 317 | 317 | 387 |
| Maps resolving a track and bank | 226 | 226 | 227 |
| Cries | 151 | 151 | 151 |

## Verification

`tools/checks/gen1_audio.gd` sweeps all three cartridges: every record is played and required to reach the hardware registers, every map's own track and bank resolves, all 151 cries resolve to the id the three-channel stride puts them at, and both role tables reach a record. `tools/render_audio.gd` now takes a `<bank>:<id>` and sweeps a Generation 1 cache, so the per-frame register trace stays the parity artefact.

`tests/unit/test_gen1_sound_engine.gd` adds 12 cases on the driver's own decisions, watched through the registers it writes: header channel counts, the MAX_SFX_ID split between music and an effect, effect priority, the pitch table, note delay, `sound_loop`, `sound_call`, the fade, Yellow's enable masks, and a stream that never reaches a note stopping instead of hanging.

| Check | Result |
|---|---|
| `validate.gd -- all` on six freshly imported cartridges | 94 topics PASS |
| Editor warning scan | 0 warnings, 637 scripts |
| Integration tier | 33 scripts, 618/618 |
| Unit scripts touched (gen1, audio, world, rom, save, battle, launcher) | 2303/2303 |
| Boot smoke, release gates | pass |

## Cache format

`FORMAT_VERSION` moves to 125. A Generation 1 cache written before this holds no audio section and no map music bank, so it is re-imported rather than migrated. All six cartridges re-imported here and reported `layout: Layout verified.`