### PR TITLE
Run the Safari game from its gate's fee to the PA that ends it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -435,8 +435,13 @@ const BATTLETYPE_TREE: int = 8
 const BATTLETYPE_TRAP: int = 9
 const BATTLETYPE_CELEBI: int = 11
 const BATTLETYPE_SUICUNE: int = 12
+## Generation 1's `BATTLE_TYPE_SAFARI`, whose own byte is 2 and which Crystal
+## has no row for at all.
+const BATTLETYPE_SAFARI: int = 13
 ## The two lists it reads them against, in source order.
-const ALWAYS_ESCAPES: Array[int] = [BATTLETYPE_DEBUG, BATTLETYPE_CONTEST]
+const ALWAYS_ESCAPES: Array[int] = [
+	BATTLETYPE_DEBUG, BATTLETYPE_CONTEST, BATTLETYPE_SAFARI,
+]
 const NEVER_ESCAPES: Array[int] = [
 	BATTLETYPE_TRAP, BATTLETYPE_CELEBI, BATTLETYPE_FORCESHINY, BATTLETYPE_SUICUNE,
 ]
@@ -481,6 +486,11 @@ var player_id: int = -1
 
 ## `wBattleType`, set by `loadvar VAR_BATTLETYPE` before `startbattle`.
 var battle_type: int = BATTLETYPE_NORMAL
+
+## `wSafariBaitFactor`, `wSafariEscapeFactor` and `wEnemyMonActualCatchRate`.
+var safari_bait_factor: int = 0
+var safari_escape_factor: int = 0
+var safari_catch_rate: int = 0
 
 ## Earned player badges as source-order bits. Zero is the battle-safe default
 ## for wild fixtures and development matchups without a world save.
@@ -1001,6 +1011,56 @@ func run_odds(runner_speed: int = -1) -> Dictionary:
 		"outcome": &"roll", "odds": odds, "attempts": attempts,
 		"range": FLEE_ODDS_RANGE,
 	}
+
+
+## `ItemUseBait` and `ItemUseRock`: the other side's factor is zeroed and the
+## chosen one grows by `.randomLoop`'s own 1 to 5.
+func throw_bait_or_rock(bait: bool, rolls: Callable) -> void:
+	if bait:
+		safari_catch_rate >>= 1
+		safari_escape_factor = 0
+	else:
+		safari_catch_rate = mini(safari_catch_rate * 2, 0xFF)
+		safari_bait_factor = 0
+	var grown: int = int(rolls.call()) & Gen1Layout.SAFARI_FACTOR_MASK
+	while grown >= Gen1Layout.SAFARI_FACTOR_LIMIT:
+		grown = int(rolls.call()) & Gen1Layout.SAFARI_FACTOR_MASK
+	grown += 1
+	if bait:
+		safari_bait_factor = mini(safari_bait_factor + grown, 0xFF)
+	else:
+		safari_escape_factor = mini(safari_escape_factor + grown, 0xFF)
+
+
+## `PrintSafariZoneBattleText`: the bait counter first, then the escape one,
+## whose last turn puts `wMonHCatchRate` back.
+func safari_battle_text(base_catch_rate: int) -> String:
+	if safari_bait_factor > 0:
+		safari_bait_factor -= 1
+		return SAFARI_EATING_TEXT
+	if safari_escape_factor <= 0:
+		return ""
+	safari_escape_factor -= 1
+	if safari_escape_factor == 0:
+		safari_catch_rate = base_catch_rate
+	return SAFARI_ANGRY_TEXT
+
+
+## `.notOutOfSafariBalls`' roll: twice the low byte of the enemy's Speed,
+## quartered eating and doubled angry, a carry out of it taking the enemy away.
+func safari_enemy_runs(rolls: Callable) -> bool:
+	var doubled: int = (mon(ENEMY).stat("speed") & 0xFF) * 2
+	if doubled > 0xFF:
+		return true
+	if safari_bait_factor != 0:
+		doubled >>= 2
+	if safari_escape_factor != 0:
+		doubled = mini(doubled * 2, 0xFF)
+	return int(rolls.call()) < doubled
+
+
+const SAFARI_EATING_TEXT: String = "eating"
+const SAFARI_ANGRY_TEXT: String = "angry"
 
 
 ## The held effect of whatever [param battler] is carrying, or zero. The item's

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -91,6 +91,31 @@ const CONTEST_SPACING: int = 12
 const CONTEST_OPTIONS: Array[String] = ["FIGHT", "PKMN", "PARKBALL×", "RUN"]
 const CONTEST_BALLS_AT := Vector2i(13, 16)
 
+## `text_box_text SAFARI_BATTLE_MENU_TEMPLATE, 0, 12, 19, 17, ..., 2, 14`, with
+## `.safariLeftColumn`'s own count beside the first row.
+const SAFARI_LEFT: int = 0
+const SAFARI_BALLS_AT := Vector2i(7, 14)
+
+
+static func safari_box() -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		SAFARI_LEFT, MAIN_TOP, MAIN_RIGHT, MAIN_BOTTOM, MAIN_FLAGS
+	)
+	box.columns = MAIN_COLUMNS
+	box.column_spacing = Gen1Layout.SAFARI_MENU_COLUMN
+	return box
+
+
+## `SafariZoneBattleMenuText`'s two rows split at the second word's own column.
+static func safari_options(top: String, bottom: String) -> Array[String]:
+	var out: Array[String] = []
+	for row: String in [top, bottom]:
+		for column: int in MAIN_COLUMNS:
+			out.append(row.substr(
+				column * Gen1Layout.SAFARI_MENU_COLUMN, Gen1Layout.SAFARI_MENU_COLUMN
+			).rstrip(" "))
+	return out
+
 
 static func main_box(contest: bool = false) -> Gen2MenuBox:
 	var box: Gen2MenuBox = Gen2MenuBox.from_coords(

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -371,6 +371,7 @@ var _capture_terminal: bool = false
 ## comes once, before the switch question, and the question is asked again on
 ## every pump until it is answered.
 var _contest_already_caught_said: bool = false
+var _safari_pending: bool = false
 ## Whether this capture's experience award has already run. See
 ## [method _spend_capture_experience].
 var _capture_experience_spent: bool = false
@@ -1222,6 +1223,10 @@ func _begin_world_battle(prepared: Dictionary, save: Gen2SaveData) -> void:
 	_enemy_trainer_index = int(prepared.get("trainer_index", 0))
 	_battle = prepared["battle"]
 	_battle.time_of_day = _time_of_day
+	if _battle.battle_type == Gen2Battle.BATTLETYPE_SAFARI:
+		_battle.safari_catch_rate = int(_data.species(
+			(prepared["enemy_party"] as Gen2Party).active_mon().species
+		).get("catch_rate", 0))
 	## `GetWorldMapLocation`, the same reading [method _play_battle_music] uses:
 	## `LevelUpHappinessMod` compares it against the winner's caught location.
 	_battle.landmark = _world_context.landmark if _world_context != null \
@@ -3120,6 +3125,10 @@ func capture_thrower() -> Gen2BattleMon:
 	return _battle.player if _is_wild_battle() and _battle != null else null
 
 
+func capture_safari_catch_rate() -> int:
+	return _battle.safari_catch_rate if _is_safari_battle() else -1
+
+
 ## `wBattleType`, which `PokeBallEffect` reads once the catch has landed: a
 ## BATTLETYPE_CELEBI catch is the one that raises BATTLERESULT_CAUGHT_CELEBI.
 func capture_battle_type() -> int:
@@ -3188,6 +3197,7 @@ func _throw_ball(ball: int, origin: StringName = &"capture") -> Dictionary:
 		return _capture_failure(&"capture_selection_not_active")
 	_capture_origin = origin
 	_capture_waiting = true
+	_safari_pending = _is_safari_battle()
 	_capture_spent_turn = Gen2Battle.use_item(ball)
 	show_message(_item_used_text(ball))
 	capture_requested.emit(ball)
@@ -3439,6 +3449,22 @@ func _is_wild_battle() -> bool:
 ## contest's own and the ball a Park Ball.
 func _is_bug_contest_battle() -> bool:
 	return _battle != null and _battle.battle_type == Gen2Battle.BATTLETYPE_CONTEST
+
+
+## `wBattleType` being BATTLE_TYPE_SAFARI, which offers no move and no bag row.
+func _is_safari_battle() -> bool:
+	return _battle != null and _battle.battle_type == Gen2Battle.BATTLETYPE_SAFARI
+
+
+const SAFARI_BATTLE_RUN: String = "safari_battle"
+const SAFARI_ITEM_RUN: String = "safari_item"
+const SAFARI_LABEL_RUN: String = "safari_labels"
+
+
+func _safari_base_catch_rate() -> int:
+	if _data == null or _battle == null:
+		return 0
+	return int(_data.species(_battle.mon(Gen2Battle.ENEMY).species).get("catch_rate", 0))
 
 
 ## The screen the fight draws on, for an overlay the world opens over it.
@@ -3972,6 +3998,8 @@ func _continue_after_messages() -> void:
 		return
 	if _replace_the_fallen():
 		return
+	if _resolve_safari_turn():
+		return
 	if _battle != null and _battle.is_over():
 		_finish_battle()
 		return
@@ -4425,6 +4453,61 @@ func _answer_menu(button: int) -> void:
 			_open_move_menu()
 
 
+func _safari_menu_options() -> Array[String]:
+	if _data == null:
+		return []
+	return Gen2BattleMenu.safari_options(
+		_data.special_text(SAFARI_LABEL_RUN, "menu_top"),
+		_data.special_text(SAFARI_LABEL_RUN, "menu_bottom")
+	)
+
+
+## `.handleMenuSelection` and `PartyMenuOrRockOrRun`, in the box's reading order.
+func _choose_safari_menu() -> void:
+	_close_battle_menu()
+	match _menu_position:
+		Gen2BattleMenu.FIGHT:
+			if bool(begin_capture().get("ok", false)):
+				throw_capture_ball()
+		Gen2BattleMenu.PKMN:
+			_throw_bait_or_rock(true)
+		Gen2BattleMenu.PACK:
+			_throw_bait_or_rock(false)
+		Gen2BattleMenu.RUN:
+			run_from_battle()
+
+
+func _throw_bait_or_rock(bait: bool) -> void:
+	if _battle == null or _battle.is_over():
+		return
+	_battle.throw_bait_or_rock(bait, Callable(_rng, "randi_range").bind(0, 0xFF))
+	show_message(_gen1_item_text(
+		"bait" if bait else "rock", "", SAFARI_ITEM_RUN
+	))
+	_safari_pending = true
+
+
+## `.displaySafariZoneBattleMenu`'s tail, run after each of the four actions:
+## the last ball ends the fight and the roll behind the box may end it too.
+func _resolve_safari_turn() -> bool:
+	if not _safari_pending:
+		return false
+	_safari_pending = false
+	if _battle == null or _battle.is_over():
+		return false
+	if _capture_quantity(Gen1Layout.SAFARI_BALL_ITEM) <= 0:
+		show_message(_gen1_item_text("out_of_balls", "", SAFARI_LABEL_RUN))
+		_battle.force_out(Gen2Battle.ENEMY)
+		return true
+	var box: String = _battle.safari_battle_text(_safari_base_catch_rate())
+	if _battle.safari_enemy_runs(Callable(_rng, "randi_range").bind(0, 0xFF)):
+		_battle.force_out(Gen2Battle.ENEMY)
+	if box.is_empty():
+		return false
+	show_message(_gen1_item_text(box, "", SAFARI_BATTLE_RUN))
+	return true
+
+
 ## `BattleMenu.loop`: the cursor moves, A picks, and B is disabled by the
 ## header's own STATICMENU_DISABLE_B.
 func _answer_battle_menu(button: int) -> void:
@@ -4440,6 +4523,9 @@ func _answer_battle_menu(button: int) -> void:
 
 
 func _choose_battle_menu() -> void:
+	if _is_safari_battle():
+		_choose_safari_menu()
+		return
 	match _menu_position:
 		Gen2BattleMenu.FIGHT:
 			_open_move_menu()
@@ -5083,8 +5169,16 @@ func _draw_battle_menu() -> void:
 	if _menu_page == null:
 		return
 	var contest: bool = _is_bug_contest_battle()
-	var box: Gen2MenuBox = Gen2BattleMenu.main_box(contest)
+	var safari: bool = _is_safari_battle()
+	var box: Gen2MenuBox = Gen2BattleMenu.safari_box() if safari \
+		else Gen2BattleMenu.main_box(contest)
 	var extras: Array = []
+	if safari:
+		## `.safariLeftColumn`'s `PrintNumber`, beside the row rather than in it.
+		extras.append({
+			"text": "%2d" % _capture_quantity(Gen1Layout.SAFARI_BALL_ITEM),
+			"at": Gen2BattleMenu.SAFARI_BALLS_AT,
+		})
 	if contest:
 		## `.PrintParkBallsRemaining`, which prints the count beside the row
 		## rather than inside it.
@@ -5095,8 +5189,9 @@ func _draw_battle_menu() -> void:
 	_show_layer_image(
 		_battle_menu_layer,
 		_menu_page.render(
-			box, Gen2BattleMenu.main_options(contest, _generation()), _menu_position - 1,
-			"", 0, extras
+			box, _safari_menu_options() if safari \
+				else Gen2BattleMenu.main_options(contest, _generation()),
+			_menu_position - 1, "", 0, extras
 		),
 		box.border_position() * Gen2Font.TILE
 	)

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -94,6 +94,8 @@ const MAX_NAME_LENGTH: int = 20
 const MAX_LANDMARK_LENGTH: int = 24
 ## `PokedexEntry` descriptions run to two pages of three lines.
 const MAX_DEX_TEXT: int = 256
+const SAFARI_LABEL_MAX: int = 16
+const SAFARI_MENU_MAX: int = 40
 ## An `EvosMoves` record cannot outrun this; the longest learnset is well under.
 const MAX_EVOS_MOVES: int = 128
 
@@ -180,6 +182,9 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"item_use": ["item_use_text", Gen1Layout.ITEM_USE_TEXT_AT],
 	"bicycle": ["bicycle_text", Gen1Layout.BICYCLE_TEXT_AT],
 	"poke_flute": ["poke_flute_text", Gen1Layout.POKE_FLUTE_TEXT_AT],
+	"safari_battle": ["safari_battle_text", Gen1Layout.SAFARI_BATTLE_TEXT_AT],
+	"safari": ["safari_game_over_text", Gen1Layout.SAFARI_TEXT_AT],
+	"safari_item": ["safari_item_text", Gen1Layout.SAFARI_ITEM_TEXT_AT],
 	"start_menu": ["start_menu_text", Gen1Layout.START_MENU_TEXT_AT],
 	"field_move": ["field_move_text", Gen1Layout.FIELD_MOVE_TEXT_AT],
 	"strength": ["strength_text", Gen1Layout.STRENGTH_TEXT_AT],
@@ -1428,6 +1433,53 @@ func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 		out[run] = boxes
 	out["npc_trade"] = _import_trade_text(rom, layout)
 	out["card_key"] = _import_card_key_text(rom, layout)
+	out["safari_labels"] = _import_safari_labels(rom, layout)
+	return out
+
+
+## `PrintSafariZoneSteps`' two labels and `SafariZoneBattleMenuText`'s two rows,
+## which are `db` strings rather than `text_far` rows.
+func _import_safari_labels(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var labels: int = int(layout["safari_steps_labels"])
+	var menu: String = Gen1Text.decode(
+		rom.bytes(), int(layout["safari_battle_menu_text"]), SAFARI_MENU_MAX
+	)
+	var lines: PackedStringArray = menu.split(
+		String(Gen1Text.CONTROL_CHARACTERS[Gen1Text.NEXT_LINE])
+	)
+	var steps: String = Gen1Text.decode(rom.bytes(), labels, SAFARI_LABEL_MAX)
+	var out: Dictionary = {
+		"steps": steps,
+		"balls": Gen1Text.decode(
+			rom.bytes(), labels + steps.length() + 1, SAFARI_LABEL_MAX
+		),
+		"menu_top": lines[0] if lines.size() > 0 else "",
+		"menu_bottom": lines[1] if lines.size() > 1 else "",
+		## `.outOfSafariBallsText` is local, so its far text is what is pinned.
+		"out_of_balls": facility_text(rom, int(layout["safari_out_of_balls_text"])),
+	}
+	out.merge(_import_safari_admission_text(rom, layout))
+	return out
+
+
+func _import_safari_admission_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var lines: int = int(layout.get("safari_nag_lines", 0))
+	if lines <= 0:
+		return {}
+	var out: Dictionary = {}
+	for slots: Array in [
+		[Gen1Layout.SAFARI_LOW_COST_TEXT_AT, "safari_low_cost_text"],
+		[Gen1Layout.SAFARI_NAG_TEXT_AT, "safari_nag_text"],
+	]:
+		for name: String in (slots[0] as Dictionary):
+			out[name] = facility_text(rom, Gen1Layout.facility_text_offset(
+				layout, String(slots[1]), slots[0] as Dictionary, name
+			))
+	var bank: int = RomFile.bank_of(lines)
+	for index: int in Gen1Layout.SAFARI_NAG_LINES:
+		out["nag_%d" % index] = facility_text(rom, Gen1Layout.banked(
+			bank, rom.u16le(lines + index * Gen1Layout.POINTER_SIZE)
+		))
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -604,6 +604,46 @@ const BICYCLE_TEXT_AT: Dictionary = {"got_on": 0x00, "got_off": 0x0A}
 const POKE_FLUTE_TEXT_AT: Dictionary = {
 	"no_effect": 0x00, "woke_up": 0x05, "had_effect": 0x0A,
 }
+const SAFARI_BATTLE_TEXT_AT: Dictionary = {"eating": 0x00, "angry": 0x05}
+const SAFARI_TEXT_AT: Dictionary = {"times_up": 0x00, "game_over": 0x05}
+const SAFARI_ITEM_TEXT_AT: Dictionary = {"bait": 0x00, "rock": 0x05}
+const SAFARI_LOW_COST_TEXT_AT: Dictionary = {"low_cost_1": 0x00, "low_cost_2": 0x05}
+const SAFARI_NAG_TEXT_AT: Dictionary = {"one_ball": 0x00}
+
+## `InitBattleVariables`' two comparisons and `PrintSafariZoneSteps`' own pair,
+## which reaches the rest houses a fight is never the game's on.
+const SAFARI_FIRST_MAP: int = 0xD9
+const SAFARI_BATTLE_END_MAP: int = 0xDD
+const SAFARI_WINDOW_END_MAP: int = 0xE2
+const SAFARI_ZONE_GATE_MAP: int = 0x9C
+const SAFARI_GAME_OVER_WARP: int = 3
+const SAFARI_SCRIPT_LEAVING: int = 5
+## Ahead of `const_next $550 - 1`, so all three cartridges number them alike.
+const SAFARI_GAME_OVER_EVENT: int = 590
+const IN_SAFARI_ZONE_EVENT: int = 591
+## `.success`: 30 balls and 502 steps for ¥500.
+const SAFARI_BALLS: int = 30
+const SAFARI_STEPS: int = 502
+## SAFARI_BALL, and the two badge numbers the bait and the rock overload.
+const SAFARI_BALL_ITEM: int = 0x08
+const SAFARI_BAIT_ITEM: int = 0x15
+const SAFARI_ROCK_ITEM: int = 0x16
+## `BaitRockCommon`'s `.randomLoop`, which grows a factor by 1 to 5.
+const SAFARI_FACTOR_MASK: int = 7
+const SAFARI_FACTOR_LIMIT: int = 5
+const SAFARI_MENU_COLUMN: int = 12
+
+## Yellow's admission for a purse that cannot pay: `ld a, 23` writes $17, which
+## `DivideBCD` reads as seventeen, and `.load_balls` stops the quotient at 29.
+const SAFARI_LOW_COST_DIVISOR: int = 17
+const SAFARI_LOW_COST_DIGITS: int = 100
+const SAFARI_LOW_COST_MAX_BALLS: int = 29
+## An empty purse's visits are counted in `wSafariSteps`' high byte and paid on
+## the fourth; `Pointers_f2100` has five rows for four counts.
+const SAFARI_NAG_LINES: int = 5
+const SAFARI_NAG_GIFT_VISIT: int = 3
+const SAFARI_NAG_BALLS: int = 1
+
 ## `CannotGetOffHereText`, which `.useOrTossItem` prints in front of `UseItem`
 ## rather than through `ItemUseFailed`. `CannotUseItemsHereText` above it is the
 ## Colosseum's and no screen here reaches it.
@@ -1246,6 +1286,7 @@ const SCRIPT_BANKED_CALLS: Array[String] = [
 	"pewter_guys", "convert_npc_directions", "heal_party", "save_game_data",
 	"get_item_quantity", "flag_action", "route23_copy_badge_text", "oaks_aide",
 	"starter_dex", "display_dex_rating",
+	"safari_low_cost", "safari_nag",
 ]
 ## The four of those a `farcall` spends nothing on: no node carries a sound.
 const SCRIPT_SILENT_BANKED_CALLS: Array[String] = [
@@ -1325,7 +1366,7 @@ const SCRIPT_SILENT_STORES: Array[String] = [
 	"npc_movement_bank", "list_scroll_offset", "dungeon_warp_destination",
 	"which_dungeon_warp", "sprite_screen_y", "sprite_screen_x",
 	"letter_printing_delay", "player_movement_byte_1", "override_joypad_mask",
-	"num_safari_balls", "gym_leader_no", "mon_data_location", "joy_released",
+	"gym_leader_no", "mon_data_location", "joy_released",
 	"trainer_header_flag_bit",
 	## The menu registers, which the `menu` node behind them carries instead.
 	"current_menu_item", "max_menu_item", "top_menu_item_y", "top_menu_item_x",
@@ -2044,6 +2085,14 @@ const RED_BLUE: Dictionary = {
 	"player_movement_byte_1": 0xC206,
 	"override_joypad_mask": 0xCD3B,
 	"num_safari_balls": 0xDA47,
+	"safari_game_over": 0xDA46,
+	"safari_steps": 0xD70D,
+	"safari_battle_text": 0x042A7,
+	"safari_game_over_text": 0x1EA0D,
+	"safari_item_text": 0x0DFA5,
+	"safari_steps_labels": 0x0C579,
+	"safari_battle_menu_text": 0x07468,
+	"safari_out_of_balls_text": 0x89639,
 	"rle_pallet_player": 0x1A4E9,
 	"flag_action": 0x0F666,
 	"route23_copy_badge_text": 0x5125D,
@@ -2434,6 +2483,19 @@ const YELLOW: Dictionary = {
 	"player_movement_byte_1": 0xC206,
 	"override_joypad_mask": 0xCD3B,
 	"num_safari_balls": 0xDA46,
+	"safari_game_over": 0xDA45,
+	"safari_steps": 0xD70C,
+	"safari_battle_text": 0x04141,
+	"safari_game_over_text": 0x1E3A5,
+	"safari_item_text": 0x0DDC5,
+	"safari_steps_labels": 0x0C2C4,
+	"safari_battle_menu_text": 0x0733D,
+	"safari_out_of_balls_text": 0x9F511,
+	"safari_low_cost": 0xF2077,
+	"safari_nag": 0xF20CE,
+	"safari_low_cost_text": 0xF20C4,
+	"safari_nag_text": 0xF20F6,
+	"safari_nag_lines": 0xF2100,
 	"rle_pallet_player": 0x1A5FB,
 	"flag_action": 0x0F4EC,
 	"route23_copy_badge_text": 0x51216,
@@ -2812,6 +2874,14 @@ static func hidden_routine(layout: Dictionary, offset: int) -> String:
 		if int(layout.get(name, -1)) == offset:
 			return name
 	return ""
+
+
+static func is_safari_battle_map(map_id: int) -> bool:
+	return map_id >= SAFARI_FIRST_MAP and map_id < SAFARI_BATTLE_END_MAP
+
+
+static func is_safari_map(map_id: int) -> bool:
+	return map_id >= SAFARI_FIRST_MAP and map_id < SAFARI_WINDOW_END_MAP
 
 
 ## `BIT_DUNGEON_BATTLE_TRANSITION`, which picks the stripes over the circles.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -730,7 +730,9 @@ static func _read_map(
 	var states: Dictionary = _read_map_states(
 		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
 	)
-	if _extend_texts(rom, layout, bank, rom.u16le(header + 5), texts, events, callback, states):
+	## A row the table grew by may reach one higher still, which is how the
+	## Safari Zone gate's own six are read rather than its first four.
+	while _extend_texts(rom, layout, bank, rom.u16le(header + 5), texts, events, callback, states):
 		states = _read_map_states(
 			rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
 		)
@@ -1732,6 +1734,8 @@ const SCRIPT_TESTS_FILTERED: int = -29
 const SCRIPT_TESTS_MENU_CANCEL: int = -30
 const SCRIPT_TESTS_MENU_ROW: int = -31
 const SCRIPT_TESTS_MENU_ITEM: int = -32
+const SCRIPT_TESTS_SAFARI_ADMISSION: int = -33
+const SCRIPT_TESTS_ANY_MONEY: int = -34
 const SCRIPT_AIDE: int = -3
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
@@ -1921,7 +1925,9 @@ static func _script_step_more(
 			state[pair] = int(state[pair]) + 1
 			return pc + 1
 		Gen1Layout.SCRIPT_LD_A_HLI:
-			return _script_read_table(ctx, pc, state)
+			var folded: int = _script_money_fold(ctx, pc, state)
+			return folded if folded != SCRIPT_NOT_FOLDED \
+				else _script_read_table(ctx, pc, state)
 		Gen1Layout.SCRIPT_LD_A_HL:
 			var next: int = _script_read_table(ctx, pc, state)
 			if next != SCRIPT_UNREAD:
@@ -1993,6 +1999,26 @@ static func _script_step_registers(
 			state.erase("b")
 			return pc + 1
 	return _script_flow(ctx, pc, at, state, out, depth)
+
+
+## `ld a, [hli] / or [hl] / inc hl / or [hl]` over `wPlayerMoney`: Z is raised
+## only by three zero bytes, so the `jr nz` behind it is a balance of one or more.
+const SCRIPT_NOT_FOLDED: int = -3
+const SCRIPT_MONEY_FOLD: Array[int] = [0xB6, Gen1Layout.SCRIPT_INC_HL, 0xB6]
+static func _script_money_fold(ctx: Dictionary, pc: int, state: Dictionary) -> int:
+	var layout: Dictionary = ctx["layout"]
+	if int(state.get("hl", -1)) != int(layout.get("player_money", -2)):
+		return SCRIPT_NOT_FOLDED
+	var rom: RomFile = ctx["rom"]
+	for step: int in SCRIPT_MONEY_FOLD.size():
+		if rom.u8(Gen1Layout.banked(int(ctx["bank"]), pc + 1 + step)) \
+			!= SCRIPT_MONEY_FOLD[step]:
+			return SCRIPT_NOT_FOLDED
+	_script_wrote_a(state)
+	state.erase("a")
+	state.erase("hl")
+	_script_tested(state, SCRIPT_TESTS_ANY_MONEY)
+	return pc + 1 + SCRIPT_MONEY_FOLD.size()
 
 
 static func _script_read_table(ctx: Dictionary, pc: int, state: Dictionary) -> int:
@@ -2340,8 +2366,12 @@ static func _script_stored(
 		return _script_map_script_mirror(state, out)
 	var byte: int = _map_script_byte(layout, address)
 	if byte >= 0:
+		## `wNextSafariZoneGateScript` is a union over `wSavedCoordIndex`.
 		if not state.has("a"):
-			return false
+			if int(state.get("source", -1)) != int(layout.get("saved_coord_index", -1)):
+				return false
+			out.append({"op": "set_map_script", "byte": byte, "from": "saved_coord_index"})
+			return true
 		out.append({"op": "set_map_script", "byte": byte, "value": int(state["a"])})
 		return true
 	if address == int(layout["do_not_wait"]):
@@ -2365,19 +2395,57 @@ static func _script_stored(
 			return false
 		state[String(SCRIPT_STORED_REGISTERS[name])] = int(state["a"])
 		return true
-	## The held buttons, the automatic box, `wJoyIgnore` and a redraw gate:
-	## nothing here reads any of the four.
 	if address == int(layout["facing_direction"]) and state.has("a") \
 		and Gen1Layout.FACING_STEPS.has(int(state["a"])):
 		out.append({"op": "player_facing", "facing": int(state["a"])})
 		return true
+	var safari: int = _script_stored_safari(layout, address, state, out)
+	if safari != STORE_NOT_NAMED:
+		return safari == STORE_OK
+	if _script_stored_silently(layout, address):
+		return true
+	return _script_stored_more(ctx, layout, address, state, out)
+
+
+## The held buttons, the automatic box, `wJoyIgnore`, a redraw gate and the list
+## `LoadItemList` already left behind: nothing here reads any of them.
+static func _script_stored_silently(layout: Dictionary, address: int) -> bool:
 	for silent: String in Gen1Layout.SCRIPT_SILENT_STORES:
 		if address == int(layout.get(silent, -1)):
 			return true
 	for word: String in Gen1Layout.SCRIPT_SILENT_WORDS:
 		if address - int(layout.get(word, -3)) in [0, 1]:
 			return true
-	return _script_stored_more(ctx, layout, address, state, out)
+	return false
+
+
+## `.success` writes 30 balls and 502 steps; the gate's `xor a` is the way out.
+static func _script_stored_safari(
+	layout: Dictionary, address: int, state: Dictionary, out: Array
+) -> int:
+	var steps: int = int(layout.get("safari_steps", -1))
+	var admitted: bool = state.has("safari_admission") and not state.has("a")
+	if address == int(layout.get("num_safari_balls", -1)):
+		if admitted:
+			out.append({"op": "safari_balls", "from": String(state["safari_admission"])})
+			return STORE_OK
+		if not state.has("a"):
+			return STORE_REFUSED
+		out.append({"op": "safari_balls", "count": int(state["a"])})
+		return STORE_OK
+	if address == steps:
+		if not state.has("a"):
+			return STORE_REFUSED
+		state["safari_steps_high"] = int(state["a"])
+		return STORE_OK
+	if address != steps + 1:
+		return STORE_NOT_NAMED
+	if not state.has("a") or not state.has("safari_steps_high"):
+		return STORE_REFUSED
+	out.append({"op": "safari_steps",
+		"steps": (int(state["safari_steps_high"]) << 8) | int(state["a"])})
+	state.erase("safari_steps_high")
+	return STORE_OK
 
 
 static func _script_stored_flag_byte(
@@ -3341,7 +3409,10 @@ static func _script_sprite_called(
 		"decode_arrow_movement":
 			return _script_arrow_movement(ctx, state, next)
 	var bank: int = int(ctx["bank"])
-	match _script_banked_routine(ctx["layout"], bank, target):
+	var banked: String = _script_banked_routine(ctx["layout"], bank, target)
+	if banked in ["safari_low_cost", "safari_nag"]:
+		return _script_safari_admission(state, banked, next)
+	match banked:
 		"coin_box":
 			out.append({"op": "coin_box"})
 			return next
@@ -3808,6 +3879,17 @@ static func _script_bcd_value(
 		var byte: int = int(bytes[first + index])
 		value = value * 100 + (byte >> 4) * 10 + (byte & 0xF)
 	return value
+
+
+## Yellow's two admission routines, each printing its lines, deciding a ball
+## count and answering carry when it hands nothing over.
+static func _script_safari_admission(state: Dictionary, routine: String, next: int) -> int:
+	## Both return `ld hl, 502` with the count in `a`, so only the count is here.
+	state.erase("a")
+	state["hl"] = Gen1Layout.SAFARI_STEPS
+	state["safari_admission"] = routine.trim_prefix("safari_")
+	_script_tested(state, SCRIPT_TESTS_SAFARI_ADMISSION, true)
+	return next
 
 
 ## `HasEnoughMoney` compares `hMoney` with the player's own three bytes through
@@ -4576,6 +4658,13 @@ static func _script_node(
 			return {"op": "has_coins", "coins": int(state["coins"]),
 				"test": "at_least" if carry else "exactly",
 				"then": fell, "else": taken}
+		SCRIPT_TESTS_SAFARI_ADMISSION:
+			## Carry is the refusal, so the `jr c` takes the walk back down.
+			return {"op": "safari_admission", "kind": String(state["safari_admission"]),
+				"then": fell, "else": taken}
+		SCRIPT_TESTS_ANY_MONEY:
+			## Z is an empty purse, so the `jr nz` takes the side with money in it.
+			return {"op": "has_money", "price": 1, "then": taken, "else": fell}
 	return _script_node_compared(tests, taken, fell, state, carry)
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 126
+const FORMAT_VERSION: int = 127
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -34,6 +34,17 @@ const CONTEST_LEVEL_AT: Vector2i = Vector2i(1, 3)
 const CONTEST_LEVEL_NUMBER_AT: Vector2i = Vector2i(7, 3)
 const CONTEST_BALLS_AT: Vector2i = Vector2i(1, 5)
 const CONTEST_BALLS_NUMBER_AT: Vector2i = Vector2i(8, 5)
+
+## `PrintSafariZoneSteps`' `TextBoxBorder` at `hlcoord 0, 0` with `b, 3` `c, 7`.
+const SAFARI_BOX_SIZE: Vector2i = Vector2i(9, 5)
+const SAFARI_STEPS_AT: Vector2i = Vector2i(1, 1)
+const SAFARI_STEPS_LABEL_AT: Vector2i = Vector2i(4, 1)
+const SAFARI_BALLS_AT: Vector2i = Vector2i(1, 3)
+const SAFARI_BALLS_BLANK_AT: Vector2i = Vector2i(5, 3)
+const SAFARI_BALLS_NUMBER_AT: Vector2i = Vector2i(6, 3)
+const SAFARI_STEPS_DIGITS: int = 3
+const SAFARI_BALLS_DIGITS: int = 2
+const SAFARI_BALLS_TENS: int = 10
 ## `.MenuData`'s own flags.
 const LIST_FLAGS: int = (
 	Gen2MenuBox.STATICMENU_CURSOR
@@ -160,7 +171,7 @@ static func list_box(count: int, contest: bool = false) -> Gen2MenuBox:
 ## names rather than the eight-character words the source list holds.
 func render_list(
 	labels: Array, cursor: int, description: String = "", contest: bool = false,
-	frame: Gen2MenuBox = null, status: Dictionary = {}
+	frame: Gen2MenuBox = null, status: Dictionary = {}, safari: Dictionary = {}
 ) -> Image:
 	if menu == null or font == null:
 		return null
@@ -173,6 +184,9 @@ func render_list(
 		## the flag alone decides. Drawn before the list, because the list's box
 		## sits two rows into it.
 		_blit(image, _render_contest_status(status), Vector2i.ZERO)
+	if not safari.is_empty():
+		## `RedisplayStartMenu` draws it behind `DrawStartMenu`, left of the list.
+		_blit(image, _render_safari_steps(safari), Vector2i.ZERO)
 	_blit(image, menu.render(box, labels, cursor), box.border_position())
 	if not description.is_empty():
 		_blit(image, _render_account(description), ACCOUNT_AT)
@@ -300,6 +314,36 @@ func _render_contest_status(status: Dictionary) -> Image:
 		)
 	return Gen2PicImage.from_indices(
 		indices, width, CONTEST_BOX_SIZE.y * TILE, _palette()
+	)
+
+
+## [param status] carries `steps`, `balls`, `steps_label` and `balls_label`.
+func _render_safari_steps(status: Dictionary) -> Image:
+	var width: int = SAFARI_BOX_SIZE.x * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * SAFARI_BOX_SIZE.y * TILE)
+	font.draw_box(
+		frame_style, indices, width, 0, 0, SAFARI_BOX_SIZE.x, SAFARI_BOX_SIZE.y
+	)
+	var balls: int = maxi(int(status.get("balls", 0)), 0)
+	for entry: Array in [
+		["%*d" % [SAFARI_STEPS_DIGITS, maxi(int(status.get("steps", 0)), 0)], SAFARI_STEPS_AT],
+		[String(status.get("steps_label", "")), SAFARI_STEPS_LABEL_AT],
+		[String(status.get("balls_label", "")), SAFARI_BALLS_AT],
+	]:
+		var at: Vector2i = entry[1]
+		font.draw_text(String(entry[0]), indices, width, at.x * TILE, at.y * TILE)
+	if balls < SAFARI_BALLS_TENS:
+		font.draw_text(
+			" ", indices, width,
+			SAFARI_BALLS_BLANK_AT.x * TILE, SAFARI_BALLS_BLANK_AT.y * TILE
+		)
+	font.draw_text(
+		"%*d" % [SAFARI_BALLS_DIGITS, balls], indices, width,
+		SAFARI_BALLS_NUMBER_AT.x * TILE, SAFARI_BALLS_NUMBER_AT.y * TILE
+	)
+	return Gen2PicImage.from_indices(
+		indices, width, SAFARI_BOX_SIZE.y * TILE, _palette()
 	)
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -765,6 +765,24 @@ func _confirm_list() -> void:
 ## `StartMenu_PrintBugContestStatus`' three values: `wContestMon` and its level,
 ## and `wParkBallsRemaining`. An unset `wContestMon` is the empty name the page
 ## prints `.NoneString` for.
+## `PrintSafariZoneSteps`, which prints nothing outside the Zone's own map run.
+func _safari_status() -> Dictionary:
+	if _world == null or _world.data == null or _world.current_map == null:
+		return {}
+	if not Gen1Layout.is_safari_map(_world.current_map.number) \
+		or _world.data.generation != RomRegistry.GEN1:
+		return {}
+	return {
+		"steps": _world.state.safari_steps(),
+		"balls": _world.state.safari_balls(),
+		"steps_label": _world.data.special_text(SAFARI_LABEL_RUN, "steps"),
+		"balls_label": _world.data.special_text(SAFARI_LABEL_RUN, "balls"),
+	}
+
+
+const SAFARI_LABEL_RUN: String = "safari_labels"
+
+
 func _contest_status() -> Dictionary:
 	if _world == null:
 		return {}
@@ -2484,7 +2502,7 @@ func _list_image() -> Image:
 	return _page.render_list(
 		labels.slice(_list_scroll, _list_scroll + shown),
 		_menu.cursor - _list_scroll, description, contest, null,
-		_contest_status() if contest else {}
+		_contest_status() if contest else {}, _safari_status()
 	)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3881,6 +3881,8 @@ const GEN1_TRADE_RUN: String = "npc_trade"
 ## `CardKeySuccessText` and `CardKeyFailText`, the two `TextPredefs` rows
 ## `PrintCardKeyText` prints.
 const GEN1_CARD_KEY_RUN: String = "card_key"
+const GEN1_SAFARI_RUN: String = "safari"
+const GEN1_SAFARI_LABEL_RUN: String = "safari_labels"
 ## `TextScript_PokemonCenterPC`, `TextScript_ItemStoragePC` and
 ## `TextScript_BillsPC`, each a machine, the run its own boxes were imported
 ## under and the boot line it opens with. `BIT_USING_GENERIC_PC` is clear on all
@@ -3907,6 +3909,10 @@ const GEN1_BATTLE_OUTCOMES: Dictionary = {
 var _gen1_battle_outcome: StringName = &""
 ## `wSavedCoordIndex`, the row a state matched and the state behind it reads.
 var _gen1_saved_coord_index: int = 0
+## `wSafariZoneGameOver`: scratch, the way the cartridge's own byte is.
+var _gen1_safari_game_over: bool = false
+var _gen1_safari_admitted: Dictionary = {}
+var _gen1_entry_steps: Array = []
 var _gen1_volatile: Dictionary = {}
 var _gen1_last_boulder: int = -1
 var _gen1_last_sprite_index: int = -1
@@ -3978,6 +3984,9 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"player_facing": &"_gen1_node_player_facing",
 	"map_script_table": &"_gen1_node_map_script_table",
 	"set_last_map": &"_gen1_node_set_last_map",
+	"safari_balls": &"_gen1_node_safari_balls",
+	"safari_admission": &"_gen1_node_safari_admission",
+	"safari_steps": &"_gen1_node_safari_steps",
 	"set_blackout_map": &"_gen1_node_set_blackout_map",
 	"set_player_coord": &"_gen1_node_set_player_coord",
 	"set_starter": &"_gen1_node_set_starter",
@@ -4385,7 +4394,9 @@ func _gen1_node_set_map_script(node: Dictionary, steps: Array, _run: Dictionary)
 	var byte: int = int(node["byte"])
 	if byte < 0:
 		return true
-	steps.append({"type": &"map_script", "byte": byte, "value": int(node["value"])})
+	## `wNextSafariZoneGateScript`: the state the walk before it is to land on.
+	var value: int = _gen1_saved_coord_index if node.has("from") else int(node["value"])
+	steps.append({"type": &"map_script", "byte": byte, "value": value})
 	return true
 
 
@@ -4571,6 +4582,62 @@ func _gen1_item_of(item: int, run: Dictionary) -> int:
 	if item != Gen1Layout.SCRIPT_MENU_ITEM_SOURCE:
 		return item
 	return int((run.get("menu", {}) as Dictionary).get("item", -1))
+
+
+func _gen1_node_safari_balls(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"safari_balls", "count": int(node.get(
+		"count", _gen1_safari_admitted.get("balls", 0)
+	))})
+	return true
+
+
+func _gen1_node_safari_steps(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"safari_steps", "steps": int(node["steps"])})
+	return true
+
+
+## Yellow's two admission routines for a purse that cannot pay ¥500, both of
+## which answer carry when nothing was won, which is the branch's `else`.
+func _gen1_node_safari_admission(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	_gen1_safari_admitted = {}
+	if String(node["kind"]) == "low_cost":
+		_gen1_safari_low_cost(steps, run)
+	else:
+		_gen1_safari_nag(steps)
+	return _gen1_resolve_side(node, not _gen1_safari_admitted.is_empty(), steps, run)
+
+
+func _gen1_safari_low_cost(steps: Array, run: Dictionary) -> void:
+	## `DivideBCDPredef3` divides the balance by the byte `ld a, 23` wrote, which
+	## packed decimal reads as seventeen; `SafariZoneEntranceConvertBCDtoNumber`
+	## then takes the quotient's last byte, so only its last two digits count.
+	@warning_ignore("integer_division")
+	var quotient: int = int(run["money"]) / Gen1Layout.SAFARI_LOW_COST_DIVISOR
+	var balls: int = quotient % Gen1Layout.SAFARI_LOW_COST_DIGITS + 1
+	## `FillMemory` empties the purse before either line is printed.
+	run["money"] = 0
+	steps.append({"type": &"money", "amount": 0})
+	steps.append(_gen1_safari_box("low_cost_1"))
+	steps.append({"type": &"money_box", "kind": &"money_top_right"})
+	steps.append(_gen1_safari_box("low_cost_2"))
+	_gen1_safari_admitted = {
+		"balls": mini(balls, Gen1Layout.SAFARI_LOW_COST_MAX_BALLS),
+		"steps": Gen1Layout.SAFARI_STEPS,
+	}
+
+
+func _gen1_safari_nag(steps: Array) -> void:
+	var visit: int = state.safari_steps() >> 8
+	steps.append(_gen1_safari_box("nag_%d" % mini(
+		visit, Gen1Layout.SAFARI_NAG_LINES - 1
+	)))
+	state.set_safari_steps(state.safari_steps() + (1 << 8))
+	if visit != Gen1Layout.SAFARI_NAG_GIFT_VISIT:
+		return
+	steps.append(_gen1_safari_box("one_ball"))
+	_gen1_safari_admitted = {
+		"balls": Gen1Layout.SAFARI_NAG_BALLS, "steps": Gen1Layout.SAFARI_STEPS,
+	}
 
 
 func _gen1_node_set_last_map(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
@@ -5829,6 +5896,9 @@ func _gen1_sight() -> Array:
 	if _gen1_holding():
 		return []
 	advance_gen1_movement_script()
+	var ended: Array = _gen1_safari_check()
+	if not ended.is_empty():
+		return ended
 	var running: Array = _gen1_map_script()
 	if not running.is_empty():
 		return running
@@ -5852,11 +5922,96 @@ func _gen1_sight() -> Array:
 	return _gen1_result()
 
 
+## `CheckEvent EVENT_IN_SAFARI_ZONE`, which gates the counter and the window.
+func gen1_safari_active() -> bool:
+	return _gen1 and state != null \
+		and state.is_event_flag_active(Gen1Layout.IN_SAFARI_ZONE_EVENT)
+
+
+## `SafariZoneCheckSteps`, in front of `CheckWarpsNoCollision`. The counter is
+## read before it is decremented, so a zero ends the game on that step.
+func gen1_count_safari_step() -> bool:
+	if not gen1_safari_active():
+		return false
+	if state.safari_steps() <= 0:
+		_gen1_safari_game_over = true
+		return true
+	state.set_safari_steps(state.safari_steps() - 1)
+	return false
+
+
+## `SafariZoneGameOver`, reached from `SafariZoneCheck`'s ball count as well as
+## from the step counter: the box, the warp to the gate and the state it leaves.
+func _gen1_safari_check() -> Array:
+	if not gen1_safari_active():
+		_gen1_safari_game_over = false
+		return []
+	if not _gen1_safari_game_over and state.safari_balls() > 0:
+		return []
+	_gen1_safari_game_over = false
+	var steps: Array = []
+	## `SafariGameOverText`'s first line is the timer rather than the bag.
+	if state.safari_balls() > 0:
+		steps.append(_gen1_safari_box("times_up"))
+	steps.append(_gen1_safari_box("game_over"))
+	steps.append({
+		"type": &"flag", "flag": Gen1Layout.SAFARI_GAME_OVER_EVENT, "set": true,
+	})
+	var byte: int = gen1_safari_gate_byte()
+	if byte >= 0:
+		steps.append({
+			"type": &"map_script", "byte": byte,
+			"value": Gen1Layout.SAFARI_SCRIPT_LEAVING,
+		})
+	steps.append({
+		"type": &"warp_to", "map": Gen1Layout.SAFARI_ZONE_GATE_MAP,
+		"warp": Gen1Layout.SAFARI_GAME_OVER_WARP,
+	})
+	_gen1_steps = steps
+	return _gen1_result()
+
+
+func _gen1_leave_safari_zone() -> void:
+	if not gen1_safari_active():
+		return
+	state.set_event_flag(Gen1Layout.IN_SAFARI_ZONE_EVENT, false)
+	state.set_safari_balls(0)
+	var byte: int = gen1_safari_gate_byte()
+	if byte >= 0:
+		state.set_gen1_map_script(byte, 0)
+
+
+func _gen1_safari_box(name: String) -> Dictionary:
+	if data == null:
+		return {"type": &"text", "text": ""}
+	var text: String = data.special_text(GEN1_SAFARI_RUN, name)
+	if text.is_empty():
+		text = data.special_text(GEN1_SAFARI_LABEL_RUN, name)
+	return {"type": &"text", "text": gen1_filled_text(text)}
+
+
+## `wSafariZoneGateCurScript`'s offset, read off the gate's own dispatch: it is
+## the one map whose state a routine outside that map writes.
+func gen1_safari_gate_byte() -> int:
+	var gate: Gen2WorldMap = data.world_map(0, Gen1Layout.SAFARI_ZONE_GATE_MAP) \
+		if data != null else null
+	if gate == null:
+		return -1
+	for node: Dictionary in (gate.scripts.get("entry", []) as Array):
+		if String(node.get("op", "")) == "map_script_table":
+			return int(node["byte"])
+	return -1
+
+
 ## `RunMapScript`, which `JoypadOverworld` runs every frame: what stands in
 ## front of `CallFunctionInTable` and then the state the map's byte selects.
 func _gen1_map_script() -> Array:
 	if current_map == null or state == null:
 		return []
+	if not _gen1_entry_steps.is_empty():
+		_gen1_steps = _gen1_entry_steps
+		_gen1_entry_steps = []
+		return _gen1_result()
 	var entry: Array = current_map.scripts.get("entry", [])
 	if entry.is_empty():
 		return []
@@ -6001,6 +6156,12 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 		&"last_map":
 			_gen1_last_map = int(step["map"])
 			return true
+		&"safari_balls":
+			state.set_safari_balls(int(step["count"]))
+			return true
+		&"safari_steps":
+			state.set_safari_steps(int(step["steps"]))
+			return true
 		&"starter":
 			state.set_gen1_starter(String(step["who"]), int(step["value"]))
 			return true
@@ -6129,10 +6290,12 @@ func _gen1_warp_to(map_number: int, warp: int) -> Dictionary:
 	var target_map: Gen2WorldMap = data.world_map(0, map_number) if data != null else null
 	if target_map == null:
 		return {}
+	## `LoadDestinationWarpPosition` reaches the row with `add a / add a`, so
+	## `wDestinationWarpID` counts from zero as a `warp_event`'s `\4 - 1` does.
 	var warps: Array = target_map.events.get("warps", [])
-	if warp < 1 or warp > warps.size():
+	if warp < 0 or warp >= warps.size():
 		return {}
-	var row: Dictionary = warps[warp - 1]
+	var row: Dictionary = warps[warp]
 	var from_map: Vector2i = map_id()
 	## The state's own steps behind the warp still stand.
 	var rest: Array = _gen1_steps
@@ -7096,10 +7259,13 @@ func _queue_map_callbacks(callback_type: int) -> void:
 		return
 	if _gen1:
 		_run_gen1_map_callback()
-		## `RunMapScript` runs on the first frame behind `EnterMap`, so what the
-		## map's own script writes is standing before the player may move. What
-		## it would show waits for the step dispatch, which resolves it again.
-		_spend_gen1_nodes(current_map.scripts.get("entry", []) as Array)
+		## `RunMapScript` runs once on the first frame behind `EnterMap`, so what
+		## it writes stands before the player may move and what it shows waits for
+		## the step dispatch. The rest of that one run is kept rather than resolved
+		## again: `CheckAndResetEvent` answers differently the second time.
+		_gen1_entry_steps = _spend_gen1_nodes(
+			current_map.scripts.get("entry", []) as Array
+		)
 		return
 	var bank: int = int(current_map.scripts.get("bank", 0))
 	for callback: Dictionary in current_map.scripts.get("callbacks", []):
@@ -7127,13 +7293,14 @@ func _run_gen1_map_callback() -> void:
 
 ## Spends every step of [param nodes] that takes no turn of its own, stopping
 ## at the first that would show something.
-func _spend_gen1_nodes(nodes: Array) -> void:
+func _spend_gen1_nodes(nodes: Array) -> Array:
 	var steps: Array = []
 	if nodes.is_empty() or not _gen1_resolve_script(nodes, steps, _gen1_run({})):
-		return
+		return []
 	var events: Array = []
 	while not steps.is_empty() and _gen1_written(steps[0], events):
 		steps.pop_front()
+	return steps
 
 
 ## `<Map>_SetCardKeyDoorYScript` and `<Map>_UnlockedDoorEventScript`, which run
@@ -9405,6 +9572,7 @@ func _apply_map(
 	])
 	_record_escape_points(target_map, from_warp)
 	_gen1_steps = []
+	_gen1_entry_steps = []
 	_gen1_money_window = false
 	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
 	## and that is the map a `LAST_MAP` warp comes back out to.
@@ -10047,6 +10215,7 @@ func escape_rope_request() -> Dictionary:
 	var wall_event: int = unown_wall_event(EVENT_WALL_OPENED_IN_KABUTO_CHAMBER)
 	if wall_event >= 0:
 		state.set_event_flag(wall_event, true)
+	_gen1_leave_safari_zone()
 	var staged: Dictionary = _stage_escape(&"escape_rope_requested", 0, -1)
 	staged["wall_event"] = wall_event
 	_pending_escape["wall_event"] = wall_event

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1282,7 +1282,8 @@ static func capture_wild(
 	caught_location: int = 0,
 	persist: bool = true,
 	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL,
-	thrower: Gen2BattleMon = null
+	thrower: Gen2BattleMon = null,
+	safari_catch_rate: int = -1
 ) -> Dictionary:
 	if world == null or save == null or world.data == null or wild == null:
 		return _failure(&"missing_capture_context", {})
@@ -1303,14 +1304,15 @@ static func capture_wild(
 	## landmark is not the map the player stands on, and every caller that has
 	## none passes 0 and takes the map's.
 	var catch_landmark: int = caught_location if caught_location > 0 else world.landmark_backup()
-	var refused: Dictionary = _capture_refusal(world, save, ball, catch_landmark)
+	var safari: bool = battle_type == Gen2Battle.BATTLETYPE_SAFARI
+	var refused: Dictionary = _capture_refusal(world, save, ball, catch_landmark, safari)
 	if not refused.is_empty():
 		return refused
 	var generator: RandomNumberGenerator = random if random != null else RandomNumberGenerator.new()
 	if random == null:
 		generator.randomize()
 	var outcome: Dictionary = _capture_outcome(
-		world.data, wild, ball, generator, battle_type, thrower
+		world.data, wild, ball, generator, battle_type, thrower, safari_catch_rate
 	)
 	var candidate: Gen2SaveData = opened["candidate"]
 	var stored: Dictionary = _store_capture(
@@ -1328,10 +1330,17 @@ static func capture_wild(
 		_register_unown(world, _unown_form(
 			wild.species, wild.persistent_dvs(), destination
 		))
-	var next_quantity: int = world.state.item_quantity(ball) - 1
-	var item_result: Dictionary = world.state.apply_changes({}, {}, {"items": {ball: next_quantity}})
-	if not bool(item_result.get("ok", false)):
-		return _failure(&"ball_state_failed", item_result)
+	## `.safariZone`'s `dec [hl]`: the bag has no row for a Safari Ball.
+	var next_quantity: int = world.state.safari_balls() - 1 if safari \
+		else world.state.item_quantity(ball) - 1
+	if safari:
+		world.state.set_safari_balls(next_quantity)
+	else:
+		var item_result: Dictionary = world.state.apply_changes(
+			{}, {}, {"items": {ball: next_quantity}}
+		)
+		if not bool(item_result.get("ok", false)):
+			return _failure(&"ball_state_failed", item_result)
 	var committed: Dictionary = Gen2WorldTransaction.commit(
 		world, save, candidate, before, persist
 	)
@@ -1362,7 +1371,8 @@ static func capture_wild(
 
 
 static func _capture_refusal(
-	world: Gen2WorldAPI, save: Gen2SaveData, ball: int, catch_landmark: int
+	world: Gen2WorldAPI, save: Gen2SaveData, ball: int, catch_landmark: int,
+	safari: bool = false
 ) -> Dictionary:
 	## `Ball_BoxIsFullMessage`, which stands in front of everything else the
 	## effect does: no line is said about the ball and the ball is not spent.
@@ -1381,7 +1391,10 @@ static func _capture_refusal(
 		return _failure(&"item_is_not_a_ball", {"ball": ball})
 	if ball not in capture_ball_items(generation):
 		return _failure(&"unsupported_ball_effect", {"ball": ball})
-	if world.state == null or world.state.item_quantity(ball) <= 0:
+	var owned: int = 0 if world.state == null else (
+		world.state.safari_balls() if safari else world.state.item_quantity(ball)
+	)
+	if owned <= 0:
 		return _failure(&"insufficient_ball_quantity", {"ball": ball})
 	## The Nuzlocke's first rule, at the one place a ball is ever thrown: only
 	## the encounter that claimed this area may be thrown at, and
@@ -2410,12 +2423,13 @@ static func _capture_outcome(
 	ball: int,
 	random: RandomNumberGenerator,
 	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL,
-	thrower: Gen2BattleMon = null
+	thrower: Gen2BattleMon = null,
+	safari_catch_rate: int = -1
 ) -> Dictionary:
 	if ball == ITEM_MASTER_BALL or battle_type == Gen2Battle.BATTLETYPE_TUTORIAL:
 		return {"caught": true, "catch_rate": 255, "wobbles": 3}
 	if _generation(data) == RomRegistry.GEN1:
-		return _gen1_capture_outcome(data, wild, ball, random)
+		return _gen1_capture_outcome(data, wild, ball, random, safari_catch_rate)
 	var max_hp: int = maxi(wild.max_hp(), 1)
 	var final_rate: int = final_catch_rate(data, ball, {
 		"base_rate": clampi(int(data.species(wild.species).get("catch_rate", 0)), 1, 255),
@@ -2443,11 +2457,13 @@ static func _capture_outcome(
 ## Tower ghost on the screen. The Safari Zone's branch spends `wNumSafariBalls`
 ## rather than the bag and changes nothing else.
 static func _gen1_capture_outcome(
-	data: GameData, wild: Gen2BattleMon, ball: int, random: RandomNumberGenerator
+	data: GameData, wild: Gen2BattleMon, ball: int, random: RandomNumberGenerator,
+	catch_rate: int = -1
 ) -> Dictionary:
 	var max_hp: int = maxi(wild.max_hp(), 1)
 	return gen1_ball_outcome(ball, {
-		"catch_rate": int(data.species(wild.species).get("catch_rate", 0)),
+		"catch_rate": catch_rate if catch_rate >= 0 \
+			else int(data.species(wild.species).get("catch_rate", 0)),
 		"max_hp": max_hp,
 		"current_hp": clampi(wild.hp, 0, max_hp),
 		"status": wild.status,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1826,6 +1826,11 @@ func _complete_player_step(movement: Dictionary) -> bool:
 	_spend_step_happiness()
 	_spend_egg_steps()
 	_spend_day_care_steps()
+	## In front of `CheckWarpsNoCollision`, so the step the timer runs out on ends
+	## the game rather than taking its warp.
+	if _world.gen1_count_safari_step():
+		_zero_map_name_sign_timer()
+		return _after_map_settled()
 	var kind: StringName = StringName(movement.get("kind", &""))
 	if kind == &"edge_warp" or (kind in [
 		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
@@ -5301,10 +5306,22 @@ func _play_battle_music(request: Dictionary) -> void:
 	_audio_player.play_record(record, &"map_music", _audio_assets())
 
 
+## `InitBattleVariables` reads `wCurMap` alone, so every wild fight on the Safari
+## Zone's own four maps is the game's however it was started.
+func _is_a_safari_fight(values: Dictionary) -> bool:
+	if _world == null or _world.current_map == null or _data == null:
+		return false
+	return _data.generation == RomRegistry.GEN1 \
+		and StringName(values.get("kind", &"")) == &"wild" \
+		and Gen1Layout.is_safari_battle_map(_world.current_map.number)
+
+
 func _open_battle_host(request: Dictionary) -> void:
 	if _battle_host != null or _data == null:
 		return
 	var values: Dictionary = request.get("values", {})
+	if _is_a_safari_fight(values):
+		values["battle_type"] = Gen2Battle.BATTLETYPE_SAFARI
 	var tutorial: bool = bool(values.get("tutorial", false))
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	_active_battle_save = save
@@ -5366,6 +5383,11 @@ func _open_battle_host(request: Dictionary) -> void:
 			host.set_capture_balls(
 				[Gen2WorldPartyHost.ITEM_PARK_BALL],
 				{Gen2WorldPartyHost.ITEM_PARK_BALL: _world.state.park_balls()}
+			)
+		elif int(values.get("battle_type", 0)) == Gen2Battle.BATTLETYPE_SAFARI:
+			host.set_capture_balls(
+				[Gen1Layout.SAFARI_BALL_ITEM],
+				{Gen1Layout.SAFARI_BALL_ITEM: _world.state.safari_balls()}
 			)
 		else:
 			host.set_capture_balls(
@@ -5456,7 +5478,8 @@ func _on_capture_requested(ball: int) -> void:
 		if _world.bug_contest_active()
 		else Gen2WorldPartyHost.capture_wild(
 			_world, save, target, ball, _encounter_random, 0, _active_battle_persist,
-			_battle_host.capture_battle_type(), _battle_host.capture_thrower()
+			_battle_host.capture_battle_type(), _battle_host.capture_thrower(),
+			_battle_host.capture_safari_catch_rate()
 		)
 	)
 	_battle_host.complete_capture(result)

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -313,6 +313,10 @@ var _gen1_map_scripts: Dictionary = {}
 ## `wPlayerStarter` and `wRivalStarter`, the cartridge's own bytes: a species
 ## index on Red and Blue, and Yellow's RIVAL_STARTER_* for the rival.
 var _gen1_starters: Dictionary = {}
+## `wNumSafariBalls` and `wSafariSteps`, both saved player data: the gate writes
+## 30 and 502, a step spends one and `SafariZoneGameOver` clears the balls.
+var _safari_balls: int = 0
+var _safari_steps: int = 0
 ## `wCardKeyDoorY` and its neighbour: the block `PrintCardKeyText` last opened a
 ## Silph Co. door at. The floor's own callback turns it into that door's flag on
 ## the next load and clears it, so opening a second door on one visit loses the
@@ -544,6 +548,8 @@ func to_dict() -> Dictionary:
 		"toggled_objects": _toggled_objects.duplicate(),
 		"gen1_map_scripts": _gen1_map_scripts.duplicate(),
 		"gen1_starters": _gen1_starters.duplicate(),
+		"safari_balls": _safari_balls,
+		"safari_steps": _safari_steps,
 		"card_key_door": [_card_key_door.x, _card_key_door.y],
 		"npc_trades": _npc_trades.duplicate(),
 		"registered_item": _registered_item,
@@ -601,6 +607,8 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 		var starter: int = int((source.get("gen1_starters", {}) as Dictionary).get(who, 0))
 		if starter > 0:
 			restored._gen1_starters[who] = starter
+	restored._safari_balls = maxi(int(source.get("safari_balls", 0)), 0)
+	restored._safari_steps = maxi(int(source.get("safari_steps", 0)), 0)
 	restored._card_key_door = _vector_from_value(
 		source.get("card_key_door", [NO_CARD_KEY_DOOR.x, NO_CARD_KEY_DOOR.y])
 	)
@@ -759,6 +767,8 @@ func restore_from_dict(raw: Variant) -> void:
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
 	_toggled_objects = restored._toggled_objects.duplicate()
 	_gen1_map_scripts = restored._gen1_map_scripts.duplicate()
+	_safari_balls = restored._safari_balls
+	_safari_steps = restored._safari_steps
 	_gen1_starters = restored._gen1_starters.duplicate()
 	_card_key_door = restored._card_key_door
 	_npc_trades = restored._npc_trades.duplicate()
@@ -1741,6 +1751,30 @@ func set_object_toggled(index: int, toggled: bool) -> void:
 
 func gen1_map_script(byte: int) -> int:
 	return int(_gen1_map_scripts.get(byte, 0))
+
+
+func safari_balls() -> int:
+	return _safari_balls
+
+
+func safari_steps() -> int:
+	return _safari_steps
+
+
+func set_safari_balls(count: int) -> void:
+	var kept: int = maxi(count, 0)
+	if kept == _safari_balls:
+		return
+	_safari_balls = kept
+	changed.emit()
+
+
+func set_safari_steps(steps: int) -> void:
+	var kept: int = maxi(steps, 0)
+	if kept == _safari_steps:
+		return
+	_safari_steps = kept
+	changed.emit()
 
 
 const GEN1_STARTER_ROLES: Array[String] = ["player", "rival"]

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, its neighbours, the 157 of the sound driver and the
-## 23 of its check are 1847 lines of it, and Generation 1 has added 2403 more to
+## 23 of its check are 1847 lines of it, and Generation 1 has added 2493 more to
 ## the shared code, the largest of them 152 the region map, 150 the battle
 ## animation engine, 140 the transition, 131 the field moves, 130 the Pokedex,
-## 108 the three PCs, 103 a map script's movement, 52 the menus a row draws.
-const MAX_COMMENT_LINES: int = 41922
+## 108 the three PCs, 90 the Safari Zone, 52 the menus a row draws.
+const MAX_COMMENT_LINES: int = 42012
 
 ## What no comment block ever ends on. A pass that meets the ceiling above trims
 ## the second line of a two-line block and leaves the first mid-sentence, which

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -67,6 +67,7 @@ func _one_game() -> void:
 	_conversion_copies_the_target()
 	_teleport_ends_the_battle()
 	_the_bag_in_a_fight()
+	_a_safari_battle()
 
 
 ## `AddPartyMon`'s four base moves and `WriteMonMoves` over them, for every
@@ -446,3 +447,89 @@ func _bag_battle(trainer: bool = false) -> Gen2Battle:
 		)),
 		generator, trainer
 	)
+
+
+## `BaitRockCommon`'s `.randomLoop`: a factor grows by 1 to 5, in even shares.
+const SAFARI_ROLLS: int = 4000
+const SAFARI_FACTOR_SHARE: float = 0.2
+const SAFARI_TOLERANCE: float = 0.03
+## `.compareWithRandomValue`: a low Speed byte at or above 128 carries out of the
+## doubling and takes the enemy away with no roll.
+const SAFARI_SLOW_SPEED: int = 20
+const SAFARI_FAST_SPEED: int = 200
+
+
+## A Safari battle's whole turn: `ItemUseBait` halves the catch rate where
+## `ItemUseRock` doubles it, `PrintSafariZoneBattleText` counts the factor the
+## last action raised, and `.notOutOfSafariBalls` may roll the enemy away.
+func _a_safari_battle() -> void:
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [], SWEEP_SEED)
+	if not _r.check(battle != null, "no battle could be built for the Safari game"):
+		return
+	var rate: int = int(_r.data.species(SWEEP_ENEMY).get("catch_rate", 0))
+	battle.battle_type = Gen2Battle.BATTLETYPE_SAFARI
+	battle.safari_catch_rate = rate
+	var rolls: Callable = Callable(battle.rng, "randi_range").bind(0, 0xFF)
+	battle.throw_bait_or_rock(true, rolls)
+	@warning_ignore("integer_division")
+	var halved: int = rate / 2
+	_r.check(battle.safari_catch_rate == halved and battle.safari_escape_factor == 0,
+		"bait left the catch rate at %d, wanted %d." % [battle.safari_catch_rate, halved])
+	battle.throw_bait_or_rock(false, rolls)
+	_r.check(battle.safari_catch_rate == mini(halved * 2, 0xFF)
+		and battle.safari_bait_factor == 0,
+		"a rock left the catch rate at %d." % battle.safari_catch_rate)
+
+	## `.no_bait` reads the escape counter only once the bait one is spent.
+	battle.safari_bait_factor = 1
+	battle.safari_escape_factor = 1
+	_r.check(battle.safari_battle_text(rate) == Gen2Battle.SAFARI_EATING_TEXT
+		and battle.safari_bait_factor == 0, "the bait counter said the wrong box.")
+	_r.check(battle.safari_battle_text(rate) == Gen2Battle.SAFARI_ANGRY_TEXT
+		and battle.safari_catch_rate == rate,
+		"the escape counter left the catch rate at %d." % battle.safari_catch_rate)
+	_r.check(battle.safari_battle_text(rate).is_empty(),
+		"a spent pair of counters still said something.")
+	_safari_factor_distribution()
+	_safari_run_roll()
+	_r.note("gen1 battle the Safari game's bait, rock and %d run rolls" % SAFARI_ROLLS)
+
+
+func _safari_factor_distribution() -> void:
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [], SWEEP_SEED)
+	if battle == null:
+		return
+	var rolls: Callable = Callable(battle.rng, "randi_range").bind(0, 0xFF)
+	var counts: Array[int] = [0, 0, 0, 0, 0]
+	for _roll: int in SAFARI_ROLLS:
+		battle.safari_bait_factor = 0
+		battle.throw_bait_or_rock(true, rolls)
+		var grown: int = battle.safari_bait_factor
+		if not _r.check(grown >= 1 and grown <= Gen1Layout.SAFARI_FACTOR_LIMIT,
+			"a bait raised the factor by %d." % grown):
+			return
+		counts[grown - 1] += 1
+	for grown: int in counts.size():
+		var share: float = float(counts[grown]) / SAFARI_ROLLS
+		_r.check(absf(share - SAFARI_FACTOR_SHARE) <= SAFARI_TOLERANCE,
+			"a factor of %d came up %.3f of the time." % [grown + 1, share])
+
+
+func _safari_run_roll() -> void:
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [], SWEEP_SEED)
+	if battle == null:
+		return
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	var rolls: Callable = Callable(battle.rng, "randi_range").bind(0, 0xFF)
+	enemy.stats["speed"] = SAFARI_FAST_SPEED
+	_r.check(battle.safari_enemy_runs(rolls), "a fast wild stayed with no roll.")
+	enemy.stats["speed"] = SAFARI_SLOW_SPEED
+	var ran: Array[int] = [0, 0, 0]
+	for index: int in ran.size():
+		battle.safari_bait_factor = 1 if index == 1 else 0
+		battle.safari_escape_factor = 1 if index == 2 else 0
+		for _roll: int in SAFARI_ROLLS:
+			if battle.safari_enemy_runs(rolls):
+				ran[index] += 1
+	_r.check(ran[1] < ran[0] and ran[0] < ran[2],
+		"the run rolls came out %s eating, plain and angry." % [ran])

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -115,9 +115,9 @@ const PALETTE_CENSUS: Dictionary = {
 ## byte that opens it. Yellow's six bare `text_end`s are Jessie and James, whose
 ## two ids share one on three maps.
 const TEXT_CENSUS: Dictionary = {
-	&"red": {0x08: 637, 0x17: 515, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"blue": {0x08: 637, 0x17: 515, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"yellow": {0x08: 686, 0x17: 491, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14,
+	&"red": {0x08: 637, 0x17: 517, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"blue": {0x08: 637, 0x17: 517, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"yellow": {0x08: 686, 0x17: 493, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14,
 		0xFF: 12},
 }
 
@@ -130,48 +130,48 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 316, "text": 584, "branch": 158, "choice": 37, "flag": 239,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 3, "pokedex": 13,
-		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 17,
-		"player_facing": 8, "set_map_script": 110, "npc_movement_script": 2,
+	&"red": {"rows": 317, "text": 588, "branch": 158, "choice": 38, "flag": 243,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 2, "pokedex": 13,
+		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
+		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 26, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
-		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 5,
-		"has_money": 4, "spend_money": 3, "menu": 3, "menu_cancel": 3, "menu_row": 1,
-		"guard_drink": 4, "day_care": 1, "random_bit": 2, "volatile": 1,
-		"filtered_bag": 2, "menu_item": 4, "elevator": 3, "coin_box": 2, "has_coins": 4,
-		"add_coins": 4, "replace_block": 1, "starter": 2, "trainer_battle": 3,
-		"copy_name": 4, "set_fossil": 6, "list_menu": 1},
-	&"blue": {"rows": 316, "text": 584, "branch": 158, "choice": 37, "flag": 239,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 3, "pokedex": 13,
-		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 17,
-		"player_facing": 8, "set_map_script": 110, "npc_movement_script": 2,
+		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
+		"spend_money": 4, "menu": 3, "menu_cancel": 3, "menu_row": 1, "guard_drink": 4,
+		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
+		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
+		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
+		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1},
+	&"blue": {"rows": 317, "text": 588, "branch": 158, "choice": 38, "flag": 243,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 2, "pokedex": 13,
+		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
+		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 26, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
-		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 5,
-		"has_money": 4, "spend_money": 3, "menu": 3, "menu_cancel": 3, "menu_row": 1,
-		"guard_drink": 4, "day_care": 1, "random_bit": 2, "volatile": 1,
-		"filtered_bag": 2, "menu_item": 4, "elevator": 3, "coin_box": 2, "has_coins": 4,
-		"add_coins": 4, "replace_block": 1, "starter": 2, "trainer_battle": 3,
-		"copy_name": 4, "set_fossil": 6, "list_menu": 1},
-	&"yellow": {"rows": 369, "text": 565, "branch": 154, "choice": 31, "flag": 213,
-		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 17, "pokedex": 10,
-		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 16,
-		"set_map_script": 68, "npc_movement_script": 2, "toggle_object": 22,
+		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
+		"spend_money": 4, "menu": 3, "menu_cancel": 3, "menu_row": 1, "guard_drink": 4,
+		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
+		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
+		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
+		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1},
+	&"yellow": {"rows": 370, "text": 570, "branch": 154, "choice": 32, "flag": 221,
+		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 16, "pokedex": 10,
+		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 23,
+		"set_map_script": 75, "npc_movement_script": 2, "toggle_object": 22,
 		"trainer_battle_object": 15, "random": 5, "facing": 13, "player_in_array": 1,
-		"name_species": 6, "pick_up_item": 109, "scratch": 18, "name_badge": 7,
-		"player_facing": 13, "heal_party": 2, "emote": 7, "dex_rating": 2,
-		"dex_count": 6, "map_text": 24, "trade": 7, "name_item": 7, "oaks_aide": 3,
-		"player_coord": 4, "money_box": 5, "has_money": 3, "spend_money": 3, "menu": 3,
-		"menu_cancel": 3, "menu_row": 1, "guard_drink": 4, "day_care": 1,
-		"random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4, "elevator": 3,
-		"coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
-		"trainer_battle": 1, "talking_to": 2, "copy_name": 4, "set_fossil": 6,
-		"list_menu": 1},
+		"name_species": 6, "pick_up_item": 109, "scratch": 20, "name_badge": 7,
+		"player_facing": 15, "heal_party": 2, "emote": 7, "dex_rating": 2, "dex_count": 6,
+		"map_text": 24, "trade": 7, "name_item": 7, "oaks_aide": 3, "player_coord": 4,
+		"money_box": 6, "has_money": 5, "spend_money": 4, "menu": 3, "menu_cancel": 3,
+		"menu_row": 1, "guard_drink": 4, "day_care": 1, "random_bit": 2, "volatile": 1,
+		"filtered_bag": 2, "menu_item": 4, "elevator": 3, "coin_box": 2, "has_coins": 4,
+		"add_coins": 4, "replace_block": 1, "trainer_battle": 1, "safari_balls": 3,
+		"safari_steps": 3, "safari_admission": 2, "save_coord_index": 2, "talking_to": 2,
+		"copy_name": 4, "set_fossil": 6, "list_menu": 1},
 }
 ## `SilphCo11FPorygonText` is a `call DisplayPokedex` the disassembly marks
 ## unreferenced. The `trade` rows are the eight `predef DoInGameTradeDialogue`
@@ -221,46 +221,44 @@ const CALLBACK_CENSUS: Dictionary = {
 ## The maps with a state machine, the states reachable from index 0 and from
 ## every `set_map_script` already read, and the bodies the walker gets whole.
 const STATE_CENSUS: Dictionary = {
-	&"red": {"tables": 98, "states": 200, "read": 141, "branch": 51,
-		"player_coord": 33, "player_facing": 39, "flag": 248, "set_map_script": 221,
-		"save_coord_index": 9, "map_text": 107, "toggle_object": 134,
-		"object_facing": 48, "set_player_coord": 1, "object_path": 1,
-		"movement_running": 48, "npc_movement_script": 1, "movement_script_running": 2,
-		"badges_byte": 1, "walk": 31, "wild_battle": 4, "player_in_array": 30,
-		"riding": 4, "object_move": 51, "object_position": 6, "coord_index": 17,
-		"starter": 28, "trainer_battle": 29, "battle_outcome": 28, "object_stay": 9,
-		"facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16, "unknown": 6,
-		"badge_guards": 1, "give_item": 9, "arrow_movement": 3, "guard_drink": 4,
-		"boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1, "save_game": 1,
-		"reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1, "volatile": 1,
-		"volatile_test": 1, "coord_lookup": 3, "trainer_battle_object": 1},
-	&"blue": {"tables": 98, "states": 200, "read": 141, "branch": 51,
-		"player_coord": 33, "player_facing": 39, "flag": 248, "set_map_script": 221,
-		"save_coord_index": 9, "map_text": 107, "toggle_object": 134,
-		"object_facing": 48, "set_player_coord": 1, "object_path": 1,
-		"movement_running": 48, "npc_movement_script": 1, "movement_script_running": 2,
-		"badges_byte": 1, "walk": 31, "wild_battle": 4, "player_in_array": 30,
-		"riding": 4, "object_move": 51, "object_position": 6, "coord_index": 17,
-		"starter": 28, "trainer_battle": 29, "battle_outcome": 28, "object_stay": 9,
-		"facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16, "unknown": 6,
-		"badge_guards": 1, "give_item": 9, "arrow_movement": 3, "guard_drink": 4,
-		"boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1, "save_game": 1,
-		"reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1, "volatile": 1,
-		"volatile_test": 1, "coord_lookup": 3, "trainer_battle_object": 1},
-	&"yellow": {"tables": 98, "states": 202, "read": 147, "branch": 64,
-		"player_coord": 46, "flag": 252, "player_facing": 38, "set_map_script": 230,
-		"save_coord_index": 11, "map_text": 120, "object_position": 6,
-		"toggle_object": 153, "object_facing": 50, "set_player_coord": 1,
-		"object_path": 1, "movement_running": 48, "wild_battle": 6,
-		"npc_movement_script": 1, "movement_script_running": 2, "badges_byte": 2,
-		"walk": 34, "object_move": 53, "player_in_array": 33, "riding": 4,
-		"coord_index": 17, "trainer_battle": 7, "battle_outcome": 26, "object_stay": 10,
-		"facing": 4, "has_item": 4, "emote": 2, "saved_coord_index": 18, "starter": 1,
-		"set_starter": 1, "badge_guards": 1, "give_item": 8, "arrow_movement": 3,
-		"guard_drink": 4, "unknown": 1, "volatile_test": 2, "volatile": 3,
-		"boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1, "save_game": 1,
-		"reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
-		"coord_lookup": 3, "trainer_battle_object": 2},
+	&"red": {"tables": 98, "states": 203, "read": 144, "branch": 52, "player_coord": 33,
+		"player_facing": 40, "flag": 250, "set_map_script": 224, "save_coord_index": 9,
+		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
+		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
+		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
+		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
+		"coord_index": 17, "starter": 28, "trainer_battle": 29, "battle_outcome": 28,
+		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
+		"unknown": 6, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
+		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
+		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
+		"trainer_battle_object": 1},
+	&"blue": {"tables": 98, "states": 203, "read": 144, "branch": 52, "player_coord": 33,
+		"player_facing": 40, "flag": 250, "set_map_script": 224, "save_coord_index": 9,
+		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
+		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
+		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
+		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
+		"coord_index": 17, "starter": 28, "trainer_battle": 29, "battle_outcome": 28,
+		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
+		"unknown": 6, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
+		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
+		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
+		"trainer_battle_object": 1},
+	&"yellow": {"tables": 98, "states": 205, "read": 150, "branch": 65, "player_coord": 46,
+		"flag": 254, "player_facing": 39, "set_map_script": 233, "save_coord_index": 11,
+		"map_text": 122, "object_position": 6, "toggle_object": 153, "object_facing": 50,
+		"set_player_coord": 1, "object_path": 1, "movement_running": 50, "wild_battle": 6,
+		"npc_movement_script": 1, "movement_script_running": 2, "badges_byte": 2, "walk": 35,
+		"object_move": 53, "player_in_array": 33, "riding": 4, "coord_index": 17,
+		"trainer_battle": 7, "battle_outcome": 26, "object_stay": 10, "facing": 4,
+		"has_item": 4, "emote": 2, "saved_coord_index": 18, "starter": 1, "set_starter": 1,
+		"badge_guards": 1, "give_item": 8, "arrow_movement": 3, "guard_drink": 4,
+		"unknown": 1, "volatile_test": 2, "volatile": 3, "boulder_on": 3, "hall_of_fame": 1,
+		"set_blackout_map": 1, "save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1,
+		"set_last_map": 1, "safari_balls": 1, "coord_lookup": 3, "trainer_battle_object": 2},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -357,6 +355,7 @@ func _one_game() -> void:
 	_wild_objects()
 	_palettes()
 	_sprites()
+	_safari()
 
 
 func _counts() -> void:
@@ -1204,3 +1203,53 @@ func _wild_objects() -> void:
 			species[int(object["species"])] = int(species.get(int(object["species"]), 0)) + 1
 	_r.check(species == POWER_PLANT_WILD,
 		"the Power Plant's standing wild objects read %s." % [species])
+
+
+## `SafariZoneGate_ScriptPointers`' seven states, the six rows its texts and its
+## states reach, and the two map runs `InitBattleVariables` and
+## `PrintSafariZoneSteps` read.
+const SAFARI_GATE: int = 0x9C
+const SAFARI_STATES: int = 7
+const SAFARI_TEXTS: int = 6
+const SAFARI_BATTLE_MAPS: int = 4
+const SAFARI_WINDOW_MAPS: int = 9
+const SAFARI_STEPS_LABEL: String = "/500"
+const SAFARI_MENU_TOP: String = "BALL×"
+
+
+func _safari() -> void:
+	var gate: Gen2WorldMap = _maps.get(SAFARI_GATE)
+	if not _r.check(gate != null, "the SAFARI ZONE gate has no record."):
+		return
+	_r.check((gate.scripts["states"] as Array).size() == SAFARI_STATES,
+		"the gate reads %d states." % (gate.scripts["states"] as Array).size())
+	_r.check(gate.texts.size() == SAFARI_TEXTS,
+		"the gate reads %d text rows." % gate.texts.size())
+	var battle_maps: int = 0
+	var window_maps: int = 0
+	for number: int in _maps:
+		battle_maps += 1 if Gen1Layout.is_safari_battle_map(number) else 0
+		window_maps += 1 if Gen1Layout.is_safari_map(number) else 0
+	_r.check(battle_maps == SAFARI_BATTLE_MAPS and window_maps == SAFARI_WINDOW_MAPS,
+		"the Safari game covers %d battle maps and %d with the window." % [
+			battle_maps, window_maps,
+		])
+	for row: Array in [
+		["safari", "times_up"], ["safari", "game_over"],
+		["safari_battle", "eating"], ["safari_battle", "angry"],
+		["safari_item", "bait"], ["safari_item", "rock"],
+		["safari_labels", "out_of_balls"],
+	]:
+		_r.check(not _r.data.special_text(String(row[0]), String(row[1])).is_empty(),
+			"%s/%s is empty." % row)
+	_r.check(_r.data.special_text("safari_labels", "steps") == SAFARI_STEPS_LABEL,
+		"the step window reads %s." % _r.data.special_text("safari_labels", "steps"))
+	var options: Array[String] = Gen2BattleMenu.safari_options(
+		_r.data.special_text("safari_labels", "menu_top"),
+		_r.data.special_text("safari_labels", "menu_bottom")
+	)
+	_r.check(options.size() == 4 and options[0] == SAFARI_MENU_TOP,
+		"the Safari battle menu reads %s." % [options])
+	_r.note("gen1 safari %d zone maps, %d with the step window, %d gate states" % [
+		battle_maps, window_maps, SAFARI_STATES,
+	])

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -492,6 +492,7 @@ func _one_game() -> void:
 	_check_the_tower_warp()
 	_check_the_silph_rival()
 	_check_a_seafoam_boulder_hole()
+	_check_the_safari_zone()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -2953,3 +2954,148 @@ func _check_a_seafoam_boulder_hole() -> void:
 
 func _first_text(results: Array) -> String:
 	return _event_text(results) if not results.is_empty() else ""
+
+
+const SAFARI_GATE: int = 0x9C
+const SAFARI_GATE_WORKER_CELLS: Array[Vector2i] = [Vector2i(3, 2), Vector2i(4, 2)]
+const SAFARI_CENTER: int = 0xDC
+const SAFARI_CENTER_CELL := Vector2i(15, 25)
+const SAFARI_ADMISSION: int = 500
+## `SafariZoneGate_ScriptPointers` by name, which is what the walk drives.
+const SAFARI_SCRIPT_JOIN: int = 2
+const SAFARI_SCRIPT_MOVING_UP: int = 3
+const SAFARI_SCRIPT_MOVING_DOWN: int = 4
+const SAFARI_TIMES_UP: String = "PA: Ding-dong!"
+
+
+## `SafariZoneGateWouldYouLikeToJoinScript` and `SafariZoneCheckSteps` behind it:
+## the fee buys 30 balls and 502 steps, and running out warps back to the gate.
+func _check_the_safari_zone() -> void:
+	var world: Gen2WorldAPI = _safari_offer(SAFARI_ADMISSION)
+	if world == null:
+		return
+	_safari_answer(world, 0)
+	_r.check(
+		world.state.safari_balls() == Gen1Layout.SAFARI_BALLS
+			and world.state.safari_steps() == Gen1Layout.SAFARI_STEPS,
+		"the fee bought %d balls and %d steps." % [
+			world.state.safari_balls(), world.state.safari_steps(),
+		]
+	)
+	_r.check(world.gen1_safari_active(), "the fee left EVENT_IN_SAFARI_ZONE clear.")
+	_r.check(
+		world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == 0,
+		"the fee left %d." % world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
+	)
+	_check_the_safari_game_ends(world.state)
+	_check_the_safari_zone_refuses()
+	_r.note("gen1 walk paid the SAFARI ZONE's %d and walked its %d steps out" % [
+		SAFARI_ADMISSION, Gen1Layout.SAFARI_STEPS,
+	])
+
+
+func _check_the_safari_game_ends(state: Gen2WorldState) -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, SAFARI_CENTER, SAFARI_CENTER_CELL, state)
+	if world == null:
+		return
+	var spent: int = 0
+	while world.gen1_count_safari_step() == false and spent <= Gen1Layout.SAFARI_STEPS:
+		spent += 1
+	_r.check(spent == Gen1Layout.SAFARI_STEPS,
+		"the timer ran out after %d steps." % spent)
+	var said: Array[String] = _safari_spoken(world, world.dispatch_sight_events())
+	_r.check(said.size() == 2 and said[0].begins_with(SAFARI_TIMES_UP),
+		"the game over said %s." % [said])
+	_r.check(world.map_id() == Vector2i(0, SAFARI_GATE),
+		"the game over landed on %s." % [world.map_id()])
+	_r.check(
+		world.state.gen1_map_script(world.gen1_safari_gate_byte())
+			== Gen1Layout.SAFARI_SCRIPT_LEAVING,
+		"the gate stands on state %d." % world.state.gen1_map_script(
+			world.gen1_safari_gate_byte()
+		)
+	)
+	## `SafariZoneGateLeavingSafariScript` runs on the frame the gate is entered
+	## and consumes the event the warp set, which is what says the game ended.
+	_r.check(not world.gen1_safari_active(),
+		"the gate left EVENT_IN_SAFARI_ZONE standing.")
+	var haul: Array[String] = _safari_spoken(world, world.dispatch_sight_events())
+	_r.check(haul.size() == 1 and not haul[0].is_empty(),
+		"the gate said %s on the way out." % [haul])
+	_r.check(world.state.safari_balls() == 0,
+		"the gate left %d balls." % world.state.safari_balls())
+
+
+## Red and Blue walk a short purse back down; Yellow's own two routines hand out
+## a reduced admission instead, and nothing at all until the fourth empty visit.
+func _check_the_safari_zone_refuses() -> void:
+	var world: Gen2WorldAPI = _safari_offer(SAFARI_ADMISSION - 1)
+	if world == null:
+		return
+	_safari_answer(world, 0)
+	if _r.game_id != RomRegistry.YELLOW:
+		_r.check(world.state.safari_balls() == 0
+			and world.state.gen1_map_script(world.gen1_safari_gate_byte())
+				== SAFARI_SCRIPT_MOVING_DOWN,
+			"a short purse bought %d balls." % world.state.safari_balls())
+		return
+	@warning_ignore("integer_division")
+	var discounted: int = mini(
+		(SAFARI_ADMISSION - 1) / Gen1Layout.SAFARI_LOW_COST_DIVISOR
+			% Gen1Layout.SAFARI_LOW_COST_DIGITS + 1,
+		Gen1Layout.SAFARI_LOW_COST_MAX_BALLS
+	)
+	_r.check(world.state.safari_balls() == discounted
+		and world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == 0,
+		"¥%d bought %d balls, wanted %d." % [
+			SAFARI_ADMISSION - 1, world.state.safari_balls(), discounted,
+		])
+	_check_the_safari_zone_nags()
+
+
+func _check_the_safari_zone_nags() -> void:
+	var state := Gen2WorldState.new()
+	for visit: int in Gen1Layout.SAFARI_NAG_GIFT_VISIT + 1:
+		var world: Gen2WorldAPI = _safari_offer(0, state)
+		if world == null:
+			return
+		_safari_answer(world, 0)
+		var owed: int = Gen1Layout.SAFARI_NAG_BALLS \
+			if visit == Gen1Layout.SAFARI_NAG_GIFT_VISIT else 0
+		_r.check(state.safari_balls() == owed,
+			"visit %d of an empty purse bought %d balls." % [visit, state.safari_balls()])
+
+
+func _safari_spoken(world: Gen2WorldAPI, results: Array) -> Array[String]:
+	var said: Array[String] = []
+	while not results.is_empty() and said.size() < Gen1Layout.MAX_OBJECT_EVENTS:
+		var text: String = _event_text(results)
+		if not text.is_empty():
+			said.append(text)
+		results = world.run_event_queue(true)
+	return said
+
+
+func _safari_answer(world: Gen2WorldAPI, choice: int) -> void:
+	var results: Array = world.choose_script_input(choice)
+	var guard: int = 0
+	while not results.is_empty() and guard < Gen1Layout.MAX_OBJECT_EVENTS:
+		results = world.run_event_queue(true)
+		guard += 1
+
+
+func _safari_offer(purse: int, state: Gen2WorldState = null) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(
+		0, SAFARI_GATE, SAFARI_GATE_WORKER_CELLS[0], state
+	)
+	if world == null:
+		return null
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: purse},
+	})
+	world.state.set_gen1_map_script(world.gen1_safari_gate_byte(), SAFARI_SCRIPT_JOIN)
+	world.dispatch_sight_events()
+	return world if _r.check(
+		not String(world.pending_script_input().get("text", "")).is_empty(),
+		"the SAFARI ZONE gate offered nothing on a %d purse." % purse
+	) else null

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -17,6 +17,7 @@ const KIND_HELP: Dictionary = {
 	&"battle_transition": "frames, index: DoBattleTransition over the map. 1 is the trainer branch; a Generation 1 cartridge reads BattleTransitions' own index, 0 the double circle, 2 the circle, 4 the horizontal stripes, 6 the vertical",
 	&"battle": "frames, 0: the wild fight preview_battle_request starts, settled past its transition. 1 opens the bag over it and 2 plays the POKé FLUTE from it",
 	&"battle_caught": "frames: the same fight against a species the dex already holds",
+	&"safari": "frames, 0: the Safari game's own battle menu over a Safari Zone map. 1 draws PrintSafariZoneSteps' window on the START menu instead",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
 	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
 	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
@@ -410,6 +411,7 @@ func _settle_mon_special(host_property: String) -> void:
 const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine", &"fly",
 	&"battle", &"battle_caught", &"battle_transition", &"level_evolution",
+	&"safari",
 	&"egg_hatch",
 	&"catch_tutorial",
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
@@ -428,6 +430,7 @@ const STAGERS: Dictionary = {
 	&"unown_wall": &"_stage_unown_wall",
 	&"battle": &"_stage_battle",
 	&"battle_caught": &"_stage_battle",
+	&"safari": &"_stage_safari",
 	&"catch_tutorial": &"_stage_catch_tutorial",
 	&"battle_transition": &"_stage_battle_transition",
 	&"script_fade": &"_stage_script_fade",
@@ -595,6 +598,27 @@ func _stage_battle() -> void:
 		_screen.advance_frames(frames)
 	if _cell.y >= 1:
 		_open_battle_bag(frames, flute)
+
+
+## The Safari game with the fee already paid: its battle menu, or the window
+## `PrintSafariZoneSteps` draws beside the START menu's list.
+func _stage_safari() -> void:
+	var world: Gen2WorldAPI = _screen.world()
+	world.state.set_event_flag(Gen1Layout.IN_SAFARI_ZONE_EVENT, true)
+	world.state.set_safari_balls(Gen1Layout.SAFARI_BALLS)
+	world.state.set_safari_steps(Gen1Layout.SAFARI_STEPS)
+	if _cell.y >= 1:
+		_screen.preview_start_menu()
+		return
+	_screen.preview_battle_request()
+	_screen.settle_battle_transition()
+	_screen.advance_frames(maxi(_cell.x, STAGED_FRAMES))
+	var host: Gen2BattleScreen = _screen.get("_battle_host")
+	for _press: int in BATTLE_MENU_WAIT:
+		if host == null or StringName(host.get("_menu_stage")) == &"main":
+			break
+		_screen.press_button(PokeButton.A)
+		_screen.advance_frames(maxi(_cell.x, STAGED_FRAMES))
 
 
 ## `BattleMenu`'s ITEM row. The appearance line and the send-out in front of it


### PR DESCRIPTION
## Added

The Safari Zone. `SafariZoneGate_Script`'s seven states decode, and what the purchase wanted was the two stores behind `SafariZoneEntranceAutoWalk`, which are `Gen2WorldState`'s own `safari_balls` and `safari_steps`.

`SafariZoneCheckSteps` runs where `_complete_player_step` stands in front of `CheckWarpsNoCollision`, `SafariZoneCheck` reads the same ball count, and `SafariZoneGameOver` is a step list of its own: `TimesUpText` only while balls are left, `GameOverText`, EVENT_SAFARI_GAME_OVER, the gate left on its leaving state and the warp to its third warp. `PrintSafariZoneSteps` draws beside the START menu list on the nine maps between SAFARI_ZONE_EAST and CERULEAN_CAVE_2F, and `ItemUseEscapeRope` ends the game where it stands.

`InitBattleVariables` reads `wCurMap` alone, so every wild fight on the four zones is BATTLETYPE_SAFARI: `TryRunningFromBattle` takes `.canEscape` on it, `SAFARI_BATTLE_MENU_TEMPLATE` is the box `SafariZoneBattleMenuText`'s four rows and `.safariLeftColumn`'s count sit in, and a throw spends `wNumSafariBalls` rather than a bag row. `ItemUseBait` halves `wEnemyMonActualCatchRate` where `ItemUseRock` doubles it, each zeroing the other's factor and growing its own by `.randomLoop`'s 1 to 5; `PrintSafariZoneBattleText` counts one down a turn and puts the species' own rate back when the escape counter runs out; and `.notOutOfSafariBalls` rolls against twice the low byte of the enemy's Speed, quartered while it is eating and doubled while it is angry.

Yellow's gate is its own routine. `ld a, [hli] / or [hl] / inc hl / or [hl]` over `wPlayerMoney` is a `has_money` of one, and its two admission routines are one node each: `SafariZoneEntranceCalculateLowCostAdmission` divides the balance by the seventeen `ld a, 23` writes in packed decimal and stops at 29 balls, and `SafariZoneEntranceGetLowCostAdmissionText` counts an empty purse's visits in `wSafariSteps`' own high byte and pays one ball on the fourth.

## Fixed

`_extend_texts` ran once, so a text row the grown table reached could not grow it again and the Safari Zone gate read four of its six rows. It is a loop now: Red and Blue go from 316 `text_asm` rows to 317 and Yellow from 369 to 370, and their unknown arms from 3 and 17 to 2 and 16.

`wDestinationWarpID` was read one-based where `LoadDestinationWarpPosition`'s `add a / add a` counts from zero, so every scripted warp landed on the row in front of its own.

A map's entry script was spent at `EnterMap` and then resolved a second time to show its boxes, which a body consuming what it read answers differently: `CheckAndResetEvent` in the gate's leaving state lost its own event that way. The one run is kept instead.

`wNextSafariZoneGateScript` is a union over `wSavedCoordIndex`, and a store of it into a map script byte is read now.

## Checks

`tools/checks/gen1_maps.gd` pins the gate's states, its texts and both map runs; `gen1_walk.gd` pays the fee, walks all 502 steps out and is answered by the PA and the warp, and takes Yellow's discount and its four empty-handed visits; `gen1_battle.gd` runs the bait, the rock, the two counters and 4,000 run rolls. All three cartridges. `tools/preview_world.gd -- red 0 220 <out.png> live safari 300 0` photographs the battle menu and `0 1` the step window.

`validate.gd -- all` passes, the unit tier is 3916 green, the analyser reports 0 warnings in 637 scripts, `replay_world.gd` is 33 routes and 0 failures, and the three-profile story walk runs to Silver Cave.