### PR TITLE
Rename a Pokemon at the NAME RATER

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -1187,6 +1187,8 @@ const SCRIPT_CALLS: Array[String] = [
 	"serial_connect", "fill_memory", "save_end_battle_text", "engage_map_trainer",
 	"check_boulder_coords", "sprite_pointer_1", "sprite_pointer_2",
 	"add_party_mon", "get_item_name", "get_mon_name", "get_sprite_position_2",
+	"display_party_menu", "get_party_mon_name",
+	"gb_pal_white_out_delay", "restore_screen_tiles", "load_gb_pal",
 	"save_screen_1", "load_screen_1", "save_screen_2", "reload_map_data", "copy_data",
 	"init_battle_enemy", "set_sprite_position", "get_sprite_position",
 	"fade_out_white", "fade_in_white", "fade_out_black", "fade_in_black", "init",
@@ -1286,7 +1288,7 @@ const SCRIPT_BANKED_CALLS: Array[String] = [
 	"pewter_guys", "convert_npc_directions", "heal_party", "save_game_data",
 	"get_item_quantity", "flag_action", "route23_copy_badge_text", "oaks_aide",
 	"starter_dex", "display_dex_rating",
-	"safari_low_cost", "safari_nag",
+	"safari_low_cost", "safari_nag", "name_rater_check_ot", "name_rater_screen",
 ]
 ## The four of those a `farcall` spends nothing on: no node carries a sound.
 const SCRIPT_SILENT_BANKED_CALLS: Array[String] = [
@@ -1309,6 +1311,7 @@ const SCRIPT_SILENT_CALLS: Array[String] = [
 	"start_trainer_battle", "end_trainer_battle",
 	"serial_connect", "fade_out_white", "fade_in_white", "fade_out_black",
 	"fade_in_black", "get_sprite_position", "init_battle_enemy",
+	"gb_pal_white_out_delay", "restore_screen_tiles", "load_gb_pal",
 	"get_sprite_position_2", "save_screen_1", "load_screen_1", "save_screen_2",
 	"reload_map_data", "copy_data",
 ]
@@ -1367,7 +1370,7 @@ const SCRIPT_SILENT_STORES: Array[String] = [
 	"which_dungeon_warp", "sprite_screen_y", "sprite_screen_x",
 	"letter_printing_delay", "player_movement_byte_1", "override_joypad_mask",
 	"gym_leader_no", "mon_data_location", "joy_released",
-	"trainer_header_flag_bit",
+	"trainer_header_flag_bit", "party_menu_type",
 	## The menu registers, which the `menu` node behind them carries instead.
 	"current_menu_item", "max_menu_item", "top_menu_item_y", "top_menu_item_x",
 	"menu_watched_keys",
@@ -1787,6 +1790,16 @@ const RED_BLUE: Dictionary = {
 	"filtered_bag_count": 0xCD37,
 	"name_buffer": 0xCD6D,
 	"string_buffer": 0xCF4B,
+	## `NameRatersHouseNameRaterText`'s four routines, `wBuffer` and `wNameBuffer`.
+	"display_party_menu": 0x13FC,
+	"get_party_mon_name": 0x15B4,
+	"gb_pal_white_out_delay": 0x3DD4,
+	"restore_screen_tiles": 0x3DBE,
+	"load_gb_pal": 0x20BA,
+	"name_rater_check_ot": 0x1DA20,
+	"name_rater_screen": 0x655C,
+	"party_menu_type": 0xD07D,
+	"entry_buffer": 0xCEE9,
 	"copy_to_string_buffer": 0x3826,
 	"display_dex_rating": 0x44169,
 	## `wFossilItem` and `wFossilMon`, written one visit and read the next.
@@ -2215,6 +2228,15 @@ const YELLOW: Dictionary = {
 	"filtered_bag_count": 0xCD37,
 	"name_buffer": 0xCD6D,
 	"string_buffer": 0xCF4A,
+	"display_party_menu": 0x11C8,
+	"get_party_mon_name": 0x1394,
+	"gb_pal_white_out_delay": 0x3DD8,
+	"restore_screen_tiles": 0x3DC2,
+	"load_gb_pal": 0x1E6F,
+	"name_rater_check_ot": 0x1D328,
+	"name_rater_screen": 0x62CD,
+	"party_menu_type": 0xD07C,
+	"entry_buffer": 0xCEE9,
 	"copy_to_string_buffer": 0x3813,
 	"display_dex_rating": 0x44169,
 	"fossil_item": 0xD70E,
@@ -2928,6 +2950,12 @@ static func super_palette_count(id: StringName) -> int:
 ## X-flipping the second; the helix has no symmetry and reads all four.
 static func mon_icon_tiles_read(icon: int) -> Array[int]:
 	return [0, 1, 2, 3] if icon == MON_ICON_HELIX else [0, 2]
+
+
+## Which tile of a frame one quadrant of the 2x2 draws, and whether X-flipped.
+static func mon_icon_quadrant(icon: int, quadrant: int) -> Array:
+	return [quadrant, false] if icon == MON_ICON_HELIX \
+		else [quadrant & 2, quadrant % 2 == 1]
 
 
 ## How many `MonPartySpritePointers` rows `LoadMonPartySpriteGfx` copies.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -936,7 +936,9 @@ static func _map_script_dispatch(nodes: Array) -> Dictionary:
 static func _map_script_successors(nodes: Array, byte: int) -> Array[int]:
 	var out: Array[int] = []
 	for node: Dictionary in nodes:
-		if String(node["op"]) == "set_map_script" and int(node["byte"]) == byte:
+		## `wNextSafariZoneGateScript` stores a byte read back, not a constant.
+		if String(node["op"]) == "set_map_script" and int(node["byte"]) == byte \
+			and node.has("value"):
 			out.append(int(node["value"]))
 		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
 			if node.has(key):
@@ -1736,6 +1738,9 @@ const SCRIPT_TESTS_MENU_ROW: int = -31
 const SCRIPT_TESTS_MENU_ITEM: int = -32
 const SCRIPT_TESTS_SAFARI_ADMISSION: int = -33
 const SCRIPT_TESTS_ANY_MONEY: int = -34
+const SCRIPT_TESTS_PARTY_MENU: int = -35
+const SCRIPT_TESTS_MON_OT: int = -36
+const SCRIPT_TESTS_NAME_ENTRY: int = -37
 const SCRIPT_AIDE: int = -3
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
@@ -3169,6 +3174,13 @@ static func _script_call(
 			return _script_pokedex(ctx, state, out, next)
 		"give_pokemon":
 			return _script_gift_pokemon(ctx, state, out, next)
+		"display_party_menu":
+			_script_tested(state, SCRIPT_TESTS_PARTY_MENU, true)
+			return next
+		"get_party_mon_name":
+			out.append({"op": "name_party_mon",
+				"buffer": int((ctx["layout"] as Dictionary).get("name_buffer", -1))})
+			return next
 	return _script_called(ctx, routine, target, state, out, next, depth)
 
 
@@ -3684,11 +3696,19 @@ static func _script_routine_call(
 	ctx: Dictionary, bank: int, target: int, state: Dictionary, out: Array,
 	next: int, depth: int
 ) -> int:
-	if _script_banked_routine(ctx["layout"], bank, target) \
-		in Gen1Layout.SCRIPT_SILENT_BANKED_CALLS:
+	var banked: String = _script_banked_routine(ctx["layout"], bank, target)
+	if banked in Gen1Layout.SCRIPT_SILENT_BANKED_CALLS:
 		return next
-	if _script_banked_routine(ctx["layout"], bank, target) == "route23_copy_badge_text":
-		return _script_name_badge(ctx, state, out, next)
+	match banked:
+		"route23_copy_badge_text":
+			return _script_name_badge(ctx, state, out, next)
+		"name_rater_check_ot":
+			_script_tested(state, SCRIPT_TESTS_MON_OT, true)
+			return next
+		"name_rater_screen":
+			state["entry_buffer"] = int((ctx["layout"] as Dictionary).get("entry_buffer", -1))
+			_script_tested(state, SCRIPT_TESTS_NAME_ENTRY, true)
+			return next
 	var named: int = _script_predef_named(
 		ctx["layout"], Gen1Layout.banked(bank, target), state, out
 	)
@@ -4751,6 +4771,13 @@ static func _script_node_state(
 		SCRIPT_TESTS_SCRATCH:
 			return {"op": "scratch_test", "address": int(state["scratch_test"][0]),
 				"value": int(state["scratch_test"][1]), "then": fell, "else": taken}
+	return _script_node_menu(tests, taken, fell, state)
+
+
+static func _script_node_menu(
+	tests: Variant, taken: Array, fell: Array, state: Dictionary
+) -> Variant:
+	match int(tests):
 		SCRIPT_TESTS_FILTERED:
 			return {"op": "filtered_bag", "items": state.get("filtered", []),
 				"then": taken, "else": fell}
@@ -4762,6 +4789,14 @@ static func _script_node_state(
 		SCRIPT_TESTS_MENU_ITEM:
 			return {"op": "menu_item", "item": int(state["menu_item"]),
 				"then": fell, "else": taken}
+		## Carry is CANCEL on all three: B, a foreign OT, an empty entry.
+		SCRIPT_TESTS_PARTY_MENU:
+			return {"op": "party_menu", "then": taken, "else": fell}
+		SCRIPT_TESTS_MON_OT:
+			return {"op": "mon_ot", "then": taken, "else": fell}
+		SCRIPT_TESTS_NAME_ENTRY:
+			return {"op": "name_mon", "buffer": int(state.get("entry_buffer", -1)),
+				"then": taken, "else": fell}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
 	}

--- a/game/render/naming_screen_page.gd
+++ b/game/render/naming_screen_page.gd
@@ -1,14 +1,11 @@
 class_name Gen2NamingScreenPage
 extends RefCounted
 
-## `engine/menus/naming_screen.asm`'s screen on the hardware tile grid. The naming
-## screen is a tilemap screen rather than a text one, the way the trainer card is,
-## so the page keeps the cartridge's own VRAM window: $60 the border, $eb and $f2
-## the two entry markers, and the font from $80 up. The layout is the same shape
-## on both keyboards and differs only in where the two `ClearBox` calls land and
-## how many rows are printed. `_ComposeMailMessage.InitCharset` is the third
-## layout: the same tiles and cursor over a wider keyboard, a two-line entry and
-## an icon instead of a prompt. Node-free.
+## `engine/menus/naming_screen.asm`'s screen on the hardware tile grid, which is
+## a tilemap screen rather than a text one: $60 the border, $eb and $f2 the two
+## entry markers, and the font from $80 up. The two keyboards differ only in
+## where the `ClearBox` calls land; `_ComposeMailMessage.InitCharset` is a third
+## layout, a wider keyboard with a two-line entry and an icon for the prompt.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -60,9 +57,8 @@ const CELL: int = 2
 ## `.OAMData_TextEntryCursor`'s four sprites and `.OAMData_TextEntryCursorBig`'s
 ## ten. `dbsprite` is `db (y_tile * 8) + y_px, (x_tile * 8) + x_px`
 ## (`macros/gfx.asm`), so the four sit at pixel (-1,-1), (0,-1), (-1,0) and
-## (0,0), each 8x8 and each drawing only its own top row and left column: a 9x9
-## outline hugging one letter tile, not a 2x2 block of them. The big one runs x
-## 0..32 in eights over the same two rows, so it is 40x9 and its left edge
+## (0,0), each drawing only its top row and left column: a 9x9 outline hugging
+## one letter tile. The big one is 40x9 over the same two rows and its left edge
 ## carries no -1. The z of each entry is its flip pair: bit 0 x, bit 1 y.
 const CURSOR_SPRITES: Array[Vector3i] = [
 	Vector3i(-1, -1, 0), Vector3i(0, -1, 1),
@@ -83,6 +79,12 @@ const MAIL_BORDER_ROWS: int = 6
 const CLEARED_MAIL: Array = [[1, 1, 4, 18]]
 
 const GEN1_PROMPT_AT: Vector2i = Vector2i(0, 1)
+## `PrintNamingText`'s NAME_MON header, whose `の` is a blank tile in English.
+const GEN1_MON_NAME_AT: Vector2i = Vector2i(4, 1)
+const GEN1_MON_LABEL_AT: Vector2i = Vector2i(1, 3)
+const GEN1_MON_LABEL: String = "NICKNAME?"
+## `WriteMonPartySpriteOAM`'s 2x2 at OAM ($10, $10).
+const GEN1_MON_ICON_AT: Vector2i = Vector2i(1, 0)
 const GEN1_ENTRY_AT: Vector2i = Vector2i(10, 2)
 const GEN1_UNDERSCORE_AT: Vector2i = Vector2i(10, 3)
 const GEN1_BORDER_AT: Vector2i = Vector2i(0, 4)
@@ -105,6 +107,7 @@ var _tiles: Dictionary = {}
 var _cursor_tiles: Dictionary = {}
 ## `_ComposeMailMessage.MailIcon`, drawn only by the mail screen.
 var _icon_tiles: Dictionary = {}
+var gen1_icon: int = 0
 
 
 static func from_data(data: GameData) -> Gen2NamingScreenPage:
@@ -154,7 +157,7 @@ func draw(
 	icon: PackedByteArray = PackedByteArray(), gender: int = 0
 ) -> PackedByteArray:
 	if _gen1:
-		return _draw_gen1(screen, prompt)
+		return _draw_gen1(screen, prompt, icon)
 	var map: PackedInt32Array = PackedInt32Array()
 	map.resize(COLUMNS * ROWS)
 	map.fill(BORDER_TILE)
@@ -181,11 +184,17 @@ func draw(
 	return indices
 
 
-func _draw_gen1(screen: Gen2NamingScreen, prompt: String) -> PackedByteArray:
+func _draw_gen1(
+	screen: Gen2NamingScreen, prompt: String, icon: PackedByteArray = PackedByteArray()
+) -> PackedByteArray:
 	var map: PackedInt32Array = PackedInt32Array()
 	map.resize(COLUMNS * ROWS)
 	map.fill(BLANK_TILE)
-	_string(map, prompt, GEN1_PROMPT_AT, 1)
+	if screen.is_gen1_mon:
+		_string(map, prompt, GEN1_MON_NAME_AT, 1)
+		_string(map, GEN1_MON_LABEL, GEN1_MON_LABEL_AT, 1)
+	else:
+		_string(map, prompt, GEN1_PROMPT_AT, 1)
 	for index: int in screen.length:
 		_put(map, GEN1_ENTRY_AT + Vector2i(index, 0), screen.buffer[index])
 	for index: int in screen.max_length:
@@ -214,7 +223,36 @@ func _draw_gen1(screen: Gen2NamingScreen, prompt: String) -> PackedByteArray:
 			0, indices, COLUMNS * TILE, GEN1_BORDER_AT.x * TILE,
 			GEN1_BORDER_AT.y * TILE, GEN1_BORDER_SIZE.x, GEN1_BORDER_SIZE.y
 		)
+	if screen.is_gen1_mon:
+		_gen1_mon_icon(indices, icon)
 	return indices
+
+
+## `farcall WriteMonPartySpriteOAMBySpecies`, at the first animation frame.
+func _gen1_mon_icon(indices: PackedByteArray, icon: PackedByteArray) -> void:
+	for quadrant: int in MAIL_ICON_TILES:
+		var read: Array = Gen1Layout.mon_icon_quadrant(gen1_icon, quadrant)
+		var cell: PackedByteArray = _sheet_cell(icon, int(read[0]))
+		if cell.is_empty():
+			return
+		_blit(
+			indices, {0: cell}, 0, GEN1_MON_ICON_AT, bool(read[1]), false, true,
+			Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
+		)
+
+
+## One tile of a side-by-side strip, the shape `Gen2PicImage.blit_tile` reads.
+func _sheet_cell(strip: PackedByteArray, tile: int) -> PackedByteArray:
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / TILE
+	if width <= 0 or (tile + 1) * TILE > width:
+		return PackedByteArray()
+	var cell := PackedByteArray()
+	cell.resize(TILE * TILE)
+	for y: int in TILE:
+		for x: int in TILE:
+			cell[y * TILE + x] = strip[y * width + tile * TILE + x]
+	return cell
 
 
 func _gen1_cursor(screen: Gen2NamingScreen) -> Vector2i:
@@ -246,13 +284,8 @@ func _mail_icon(indices: PackedByteArray) -> void:
 func _prompt_icon(indices: PackedByteArray, icon: PackedByteArray) -> void:
 	if icon.size() < MAIL_ICON_TILES * TILE * TILE:
 		return
-	var width: int = icon.size() / TILE
 	for quadrant: int in MAIL_ICON_TILES:
-		var cell := PackedByteArray()
-		cell.resize(TILE * TILE)
-		for y: int in TILE:
-			for x: int in TILE:
-				cell[y * TILE + x] = icon[y * width + quadrant * TILE + x]
+		var cell: PackedByteArray = _sheet_cell(icon, quadrant)
 		_blit(
 			indices, {0: cell}, 0, Vector2i.ZERO, false, false, true,
 			PROMPT_ICON_AT + Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -4,11 +4,9 @@ extends RefCounted
 ## The party menu as the hardware draws it: `WritePartyMenuTilemap`'s
 ## `PARTYMENUACTION_SWITCH` quality set plus `PlacePartyMenuText`.
 ## `SetUpBattlePartyMenu` clears the battle off the screen, so the page is the
-## whole 160x144 rather than a box over the field, and each quality steps two rows
-## per member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
-## [Gen2BattleSwitchMenu] owns the rows and the cursor. The one thing this owns is
-## `InitPartyMenuGFX`'s icons, whose sprite anim structs are per-frame state. A row
-## carrying `egg` is `PartyMenuCheckEgg`'s and only the overworld menu shows one.
+## whole 160x144, and each quality steps two rows per member because
+## `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`. [Gen2BattleSwitchMenu]
+## owns the rows; this owns `InitPartyMenuGFX`'s icons and their frame state.
 
 const TILE: int = Gen2Font.TILE
 
@@ -315,7 +313,7 @@ func reset(rows: Array) -> void:
 			"mail": Gen2HeldItem.is_mail(int(member.get("item", 0))),
 			"speed": speed,
 			"shakes": gen1 and Gen1Layout.MON_ICON_SHAKING.has(icon - 1),
-			"symmetric": gen1 and icon - 1 != Gen1Layout.MON_ICON_HELIX,
+			"icon": icon - 1,
 			"frame": -1 if not gen1 else 0,
 			"duration": 0,
 			"var1": 0,
@@ -387,11 +385,9 @@ func _blend_icons(pixels: PackedInt32Array, count: int) -> void:
 			var tile: int = first + quadrant
 			var flip: bool = false
 			if gen1:
-				## `WriteSymmetricMonPartySpriteOAM` writes each row's one tile
-				## twice, the second time X-flipped; the helix's own writer walks
-				## all four in raster order.
-				flip = bool(icon["symmetric"]) and quadrant % 2 == 1
-				tile = first + (quadrant & 2) if bool(icon["symmetric"]) else tile
+				var read: Array = Gen1Layout.mon_icon_quadrant(int(icon["icon"]), quadrant)
+				tile = first + int(read[0])
+				flip = bool(read[1])
 			elif quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
 				source = held
 				tile = ICON_MAIL_TILE if bool(icon["mail"]) else ICON_ITEM_TILE
@@ -481,11 +477,8 @@ func _draw_member(
 
 
 ## The fill of one bar, blended over the page in its own colour: the hardware
-## gives every tile its own palette, and one index buffer carries one.
-##
-## A bar is one tile row of the screen, so it is drawn into a strip that tall:
-## six party rows used to cost six 160x144 buffers and six whole images a frame
-## for six 48x8 rectangles.
+## gives every tile its own palette, and one index buffer carries one. A bar is
+## one tile row of the screen, so it is drawn into a strip that tall.
 func _blend_bar(pixels: PackedInt32Array, index: int, row: Dictionary) -> void:
 	var width: int = Gen2Screen.WIDTH
 	if bool(row.get("egg", false)):

--- a/game/world/name_rater.gd
+++ b/game/world/name_rater.gd
@@ -25,7 +25,14 @@ const ENDING_SAME_NAME: StringName = &"same_name"
 static func is_your_ot(mon: Gen2SaveMon, player_name: String, player_id: int) -> bool:
 	if mon == null:
 		return false
-	return mon.original_trainer == player_name and mon.ot_id == player_id
+	return matches_ot(mon.original_trainer, mon.ot_id, player_name, player_id)
+
+
+## The same on the two halves alone: `NameRatersHouseCheckMonOTScript`.
+static func matches_ot(
+	trainer: String, ot_id: int, player_name: String, player_id: int
+) -> bool:
+	return trainer == player_name and ot_id == player_id
 
 
 ## `IsNewNameEmpty`: an entry of nothing but spaces, or one that begins with the

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -1,13 +1,11 @@
 class_name Gen2NameRaterScreen
 extends Control
 
-## `_NameRater` (`engine/events/name_rater.asm`) on the overworld's own pump. The
-## routine is a straight line: an introduction and a `YesNoBox`, the party list
-## `SelectMonFromParty` opens, three endings that need no new name, a second
-## `YesNoBox`, `_NamingScreen`, and `.done`'s own text. [Gen2NameRater] answers
-## which ending a member reaches; this owns the boxes and the presses. The last
-## text is deliberately not pressed here: `special NameRater` returns the moment
-## `PrintText` has drawn it and the map script's own `waitbutton` dismisses it.
+## `_NameRater` (`engine/events/name_rater.asm`) on the overworld's own pump: an
+## introduction and a `YesNoBox`, `SelectMonFromParty`, three endings that need
+## no new name, a second `YesNoBox`, `_NamingScreen` and `.done`'s own text.
+## [Gen2NameRater] answers which ending a member reaches. The last text is not
+## pressed here: the map script's own `waitbutton` dismisses it.
 
 ## The chosen nickname, if the routine wrote one, and the text `.done` ends on.
 ## [param party_index] is -1 for every ending that renames nothing.

--- a/game/world/naming_screen.gd
+++ b/game/world/naming_screen.gd
@@ -2,11 +2,9 @@ class_name Gen2NamingScreen
 extends RefCounted
 
 ## `engine/menus/naming_screen.asm`'s model: which keyboard is live, where the
-## cursor is, what a press does to the name being typed and what comes out at the
-## end. Scene-free, so the whole walk can be tested without drawing it. The name is
-## kept as the cartridge keeps it, a fixed buffer of raw codes seeded with
-## NAMINGSCREEN_UNDERLINE and NAMINGSCREEN_MIDDLELINE rather than a String,
-## because every routine here reads and writes those two markers.
+## cursor is and what a press does to the name being typed. Scene-free. The name
+## is a fixed buffer of raw codes seeded with NAMINGSCREEN_UNDERLINE and
+## NAMINGSCREEN_MIDDLELINE, which every routine here reads and writes.
 
 ## The six keyboards in block order, which is the order they are imported in:
 ## `data/text/name_input_chars.asm`'s four and `mail_input_chars.asm`'s two.
@@ -68,7 +66,9 @@ const MAIL_LAST_COLUMN: int = MAIL_COLUMNS - 1
 ## screens: mail's own table repeats $00, $30 and $60 the same way.
 const COMMAND_GROUP: int = 3
 
+## `PrintNicknameAndUnderscores`: NAME_LENGTH - 1, or PLAYER_NAME_LENGTH - 1.
 const GEN1_MAX_LENGTH: int = 7
+const GEN1_MON_MAX_LENGTH: int = 10
 const GEN1_LAST_COLUMN: int = Gen1Layout.ALPHABET_COLUMNS - 1
 const GEN1_COMMAND_ROW: int = Gen1Layout.ALPHABET_ROWS
 const GEN1_END_ROW: int = Gen1Layout.ALPHABET_ROWS - 1
@@ -77,6 +77,8 @@ const GEN1_END_ROW: int = Gen1Layout.ALPHABET_ROWS - 1
 ## five, so the command row is row 5 or row 4.
 var is_box: bool = false
 var is_gen1: bool = false
+## `wNamingScreenType` NAME_MON_SCREEN: the same keyboard, its own header.
+var is_gen1_mon: bool = false
 ## `_ComposeMailMessage` rather than `NamingScreen`: a six-row, ten-column
 ## keyboard of its own, a two-line entry with a fixed break in the middle, and
 ## no prompt. Everything else on the screen is the same walk.
@@ -126,9 +128,18 @@ static func for_mail(data: GameData) -> Gen2NamingScreen:
 
 
 static func for_gen1_player(data: GameData) -> Gen2NamingScreen:
+	return _build_gen1(data, false)
+
+
+static func for_gen1_mon(data: GameData) -> Gen2NamingScreen:
+	return _build_gen1(data, true)
+
+
+static func _build_gen1(data: GameData, mon: bool) -> Gen2NamingScreen:
 	var screen := Gen2NamingScreen.new()
 	screen.is_gen1 = true
-	screen.max_length = GEN1_MAX_LENGTH
+	screen.is_gen1_mon = mon
+	screen.max_length = GEN1_MON_MAX_LENGTH if mon else GEN1_MAX_LENGTH
 	if data != null:
 		for table: int in [Gen1Layout.ALPHABET_UPPER, Gen1Layout.ALPHABET_LOWER]:
 			screen._tables.append(data.name_input_chars(table))
@@ -337,8 +348,6 @@ func press_select() -> void:
 	upper_case = not upper_case
 
 
-## `NamingScreen_StoreEntry`: every marker still in the buffer becomes a
-## terminator, so the name is what was typed and nothing behind it.
 ## `NamingScreen_StoreEntry` whole: the buffer at its own length with every
 ## marker turned into a terminator and everything else left where it is. Mail
 ## needs the whole buffer rather than the run in front of the first marker,

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -2,11 +2,8 @@ class_name Gen2NamingScreenScreen
 extends Control
 
 ## The naming screen (`engine/menus/naming_screen.asm`), embedded the way the
-## trainer card and the Hall of Fame are.
-##
-## [Gen2NamingScreen] owns the walk and [Gen2NamingScreenPage] the tiles; this
-## is the node between them. Input is the eight hardware buttons and nothing
-## else, so a test presses a button rather than a key.
+## trainer card is. [Gen2NamingScreen] owns the walk and [Gen2NamingScreenPage]
+## the tiles; input is the eight hardware buttons and nothing else.
 
 ## Carries the stored entry. `NamingScreen_StoreEntry` runs on END and on
 ## nothing else, so a caller that never sees this signal has no name to take.
@@ -88,7 +85,8 @@ func open(data: GameData, prompt: String, kind: StringName = KIND_PLAYER) -> boo
 
 static func _model(data: GameData, kind: StringName) -> Gen2NamingScreen:
 	if data != null and data.generation == RomRegistry.GEN1:
-		return Gen2NamingScreen.for_gen1_player(data)
+		return Gen2NamingScreen.for_gen1_mon(data) if kind == KIND_MON \
+			else Gen2NamingScreen.for_gen1_player(data)
 	if kind == KIND_MON:
 		return Gen2NamingScreen.for_mon(data)
 	if kind == KIND_BOX:
@@ -125,6 +123,8 @@ func set_icon(strip: PackedByteArray, gender: int = 0) -> void:
 func set_species_icon(data: GameData, species: int, gender: int = 0) -> void:
 	if data == null:
 		return
+	if _page != null:
+		_page.gen1_icon = data.mon_menu_icon(species) - 1
 	set_icon(data.species_icon_indices(species), gender)
 
 

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -2,12 +2,9 @@ class_name Gen2NicknamePromptScreen
 extends Control
 
 ## `GiveANickname_YesNo`, `InitNickname` and the `WasSentToBillsPCText` behind
-## them, for a Pokemon that was received rather than hatched: `GivePoke`'s
-## `.wildmon` branch and every `givepoke` that names no OT. Text only, because the
-## routine draws nothing else: it stands over whatever screen the caller left up.
-## [Gen2EggHatchScreen] keeps its own copy of the same pair rather than opening
-## this one, since its question is `_BreedAskNicknameText` and its box stands over
-## its own animation backdrop.
+## them, for a Pokemon received rather than hatched. Text only, because the
+## routine draws nothing else. [Gen2EggHatchScreen] keeps its own copy: its
+## question is `_BreedAskNicknameText` over its own animation backdrop.
 
 ## The nickname the player settled on, emitted once, before [signal closed].
 signal named(nickname: String)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4027,6 +4027,10 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"dex_rating": &"_gen1_node_dex_rating",
 	"set_fossil": &"_gen1_node_set_fossil",
 	"copy_name": &"_gen1_node_copy_name",
+	"party_menu": &"_gen1_node_party_menu",
+	"name_mon": &"_gen1_node_name_mon",
+	"name_party_mon": &"_gen1_node_name_party_mon",
+	"mon_ot": &"_gen1_node_mon_ot",
 	"list_menu": &"_gen1_node_list_menu",
 }
 
@@ -4682,6 +4686,52 @@ func _gen1_named(node: Dictionary, run: Dictionary, name: String) -> void:
 	var buffers: Dictionary = run.get("buffers", {})
 	buffers[int(node["buffer"])] = name
 	run["buffers"] = buffers
+
+
+## `DisplayPartyMenu` and `DisplayNameRaterScreen`: what either answers decides
+## the boxes behind it, so both sides ride the request unresolved.
+func _gen1_node_party_menu(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	return _gen1_stage_later(node, steps, run, {
+		"kind": &"party_selection_requested", "values": {"routine": &"name_rater"},
+	}, &"party_index")
+
+
+func _gen1_node_name_mon(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var chosen: Dictionary = run.get("party", {})
+	if chosen.is_empty():
+		return false
+	return _gen1_stage_later(node, steps, run, {
+		"kind": &"gen1_nickname_requested", "values": {
+			"party_index": int(chosen.get("index", -1)),
+			"buffer": int(node.get("buffer", -1)),
+		},
+	}, &"name")
+
+
+func _gen1_stage_later(
+	node: Dictionary, steps: Array, run: Dictionary, values: Dictionary, answer: StringName
+) -> bool:
+	steps.append({
+		"type": &"request", "values": values, "answer": answer,
+		"later": {"then": node["then"], "else": node["else"]},
+		"run": _gen1_run_copy(run),
+	})
+	return true
+
+
+## `GetPartyMonName2` into `wNameBuffer`: the nickname the list came back with.
+func _gen1_node_name_party_mon(node: Dictionary, _steps: Array, run: Dictionary) -> bool:
+	_gen1_named(node, run, String((run.get("party", {}) as Dictionary).get("nickname", "")))
+	return true
+
+
+## `NameRatersHouseCheckMonOTScript`: carry when either half of the OT differs.
+func _gen1_node_mon_ot(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var chosen: Dictionary = run.get("party", {})
+	return _gen1_resolve_side(node, not Gen2NameRater.matches_ot(
+		String(chosen.get("original_trainer", "")), int(chosen.get("ot_id", -1)),
+		_player_name, _player_id
+	), steps, run)
 
 
 func _gen1_node_copy_name(node: Dictionary, _steps: Array, run: Dictionary) -> bool:
@@ -5488,6 +5538,7 @@ func _gen1_run_copy(run: Dictionary) -> Dictionary:
 		"coins": run.get("coins", 0),
 		"menu": run.get("menu", {}),
 		"fossil": (run.get("fossil", {}) as Dictionary).duplicate(),
+		"party": (run.get("party", {}) as Dictionary).duplicate(),
 	}
 
 
@@ -6428,6 +6479,8 @@ func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 		if row < 0 or row >= answers.size() - 1:
 			row = answers.size() - 1
 		_gen1_steps = (answers[row] as Array).duplicate(true) + _gen1_steps
+	elif step.has("later"):
+		_gen1_steps = _gen1_resolve_later(step, result) + _gen1_steps
 	elif step.has("ok"):
 		## `accepted` is the carry `_GivePokemon` answers in.
 		_gen1_steps = (step[
@@ -6435,6 +6488,31 @@ func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 		] as Array).duplicate(true) + _gen1_steps
 	_gen1_battle_won(step, result)
 	return _gen1_result()
+
+
+## The side a staged request came back on, with its answer on the run.
+func _gen1_resolve_later(step: Dictionary, result: Dictionary) -> Array:
+	var run: Dictionary = (step.get("run", {}) as Dictionary).duplicate(true)
+	var cancelled: bool = true
+	if StringName(step.get("answer", &"")) == &"party_index":
+		cancelled = int(result.get("party_index", -1)) < 0
+		if not cancelled:
+			run["party"] = {
+				"index": int(result["party_index"]),
+				"nickname": String(result.get("nickname", "")),
+				"ot_id": int(result.get("ot_id", -1)),
+				"original_trainer": String(result.get("original_trainer", "")),
+			}
+	else:
+		var entered: String = String(result.get("name", ""))
+		cancelled = entered.is_empty()
+		if not cancelled:
+			var buffers: Dictionary = run.get("buffers", {})
+			buffers[int((step["values"]["values"] as Dictionary)["buffer"])] = entered
+			run["buffers"] = buffers
+	var steps: Array = []
+	var nodes: Array = (step["later"] as Dictionary)["then" if cancelled else "else"]
+	return steps if _gen1_resolve_script(nodes, steps, run) else []
 
 
 func _gen1_ride_elevator(result: Dictionary) -> void:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -246,6 +246,8 @@ var _nickname_preview: bool = false
 ## `special NameRater`'s screen and the save whose party row it may rename.
 var _name_rater_host: Gen2NameRaterScreen = null
 var _rival_name_host: Gen2NamingScreenScreen = null
+var _gen1_nickname_host: Gen2NamingScreenScreen = null
+var _gen1_nickname: Dictionary = {}
 var _name_rater_save: Gen2SaveData = null
 ## `special MoveDeletion`'s screen. It needs no save of its own beside it: the
 ## moves and their PP belong to the save it was handed and it writes them itself.
@@ -1313,6 +1315,7 @@ const FULLSCREEN_HOSTS: Array[StringName] = [
 	&"_nickname_host",
 	&"_name_rater_host",
 	&"_rival_name_host",
+	&"_gen1_nickname_host",
 	&"_move_deleter_host",
 	&"_move_tutor_host",
 	&"_day_care_host",
@@ -1439,6 +1442,7 @@ const OVERLAY_HOSTS: Array[StringName] = [
 	&"_nickname_host",
 	&"_name_rater_host",
 	&"_rival_name_host",
+	&"_gen1_nickname_host",
 	&"_move_tutor_host",
 	&"_move_deleter_host",
 	&"_day_care_host",
@@ -7711,6 +7715,7 @@ const REQUEST_OPENERS: Dictionary = {
 	],
 	## A cache with no keyboards answers blank, which `InitName` reads as SILVER.
 	&"rival_name_requested": [&"_open_rival_name", &"values", {"ok": true}],
+	&"gen1_nickname_requested": [&"_open_gen1_nickname", &"continue", {}],
 	&"magnet_train_requested": [&"_open_magnet_train", &"values", {"ok": true}],
 	&"pokemon_requested": [&"_open_gift_nickname", &"prompt", {}],
 	&"contest_mon_requested": [&"_open_contest_nickname", &"prompt", {}],
@@ -7970,6 +7975,53 @@ func _on_rival_named(entered: String) -> void:
 	if _world != null:
 		_show_script_results(
 			_world.complete_runtime_request({"ok": true, "name": entered})
+		)
+	_refresh_labels()
+
+
+## `DisplayNameRaterScreen`: NAME_MON_SCREEN, whose entry is copied into
+## `wPartyMonNicks`; an empty one is the carry the caller reads.
+func _open_gen1_nickname(request: Dictionary) -> bool:
+	if _gen1_nickname_host != null or _world == null or _data == null:
+		return false
+	var index: int = int((request.get("values", {}) as Dictionary).get("party_index", -1))
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or index < 0 or index >= save.party.size():
+		return false
+	var mon: Gen2SaveMon = save.party[index] as Gen2SaveMon
+	var host := Gen2NamingScreenScreen.new()
+	if mon == null or not host.open(
+		_data, String(_data.species(mon.species).get("name", "")),
+		Gen2NamingScreenScreen.KIND_MON
+	):
+		return false
+	host.set_species_icon(_data, mon.species)
+	host.closed.connect(_on_gen1_nickname_entered)
+	host.z_index = 30
+	_gen1_nickname = {"save": save, "party_index": index}
+	_gen1_nickname_host = host
+	_screen.display(host)
+	_script_prompt = "Nickname"
+	_refresh_labels()
+	return true
+
+
+func _on_gen1_nickname_entered(entered: String) -> void:
+	var host: Gen2NamingScreenScreen = _gen1_nickname_host
+	_gen1_nickname_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	var save: Gen2SaveData = _gen1_nickname.get("save", null) as Gen2SaveData
+	var index: int = int(_gen1_nickname.get("party_index", -1))
+	_gen1_nickname = {}
+	var nickname: String = entered.strip_edges()
+	if not nickname.is_empty() and save != null:
+		Gen2WorldPartyHost.rename_party_mon(save, index, nickname)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		_show_script_results(
+			_world.complete_runtime_request({"ok": true, "name": nickname})
 		)
 	_refresh_labels()
 

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,8 +130,8 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 317, "text": 588, "branch": 158, "choice": 38, "flag": 243,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 2, "pokedex": 13,
+	&"red": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 1, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
@@ -143,9 +143,10 @@ const SCRIPT_CENSUS: Dictionary = {
 		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
 		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
-		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1},
-	&"blue": {"rows": 317, "text": 588, "branch": 158, "choice": 38, "flag": 243,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 2, "pokedex": 13,
+		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
+	&"blue": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 1, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
@@ -157,9 +158,10 @@ const SCRIPT_CENSUS: Dictionary = {
 		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
 		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
-		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1},
-	&"yellow": {"rows": 370, "text": 570, "branch": 154, "choice": 32, "flag": 221,
-		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 16, "pokedex": 10,
+		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
+	&"yellow": {"rows": 370, "text": 583, "branch": 154, "choice": 34, "flag": 221,
+		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 12, "pokedex": 10,
 		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 23,
 		"set_map_script": 75, "npc_movement_script": 2, "toggle_object": 22,
 		"trainer_battle_object": 15, "random": 5, "facing": 13, "player_in_array": 1,
@@ -171,7 +173,8 @@ const SCRIPT_CENSUS: Dictionary = {
 		"filtered_bag": 2, "menu_item": 4, "elevator": 3, "coin_box": 2, "has_coins": 4,
 		"add_coins": 4, "replace_block": 1, "trainer_battle": 1, "safari_balls": 3,
 		"safari_steps": 3, "safari_admission": 2, "save_coord_index": 2, "talking_to": 2,
-		"copy_name": 4, "set_fossil": 6, "list_menu": 1},
+		"copy_name": 4, "set_fossil": 6, "list_menu": 1,
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
 }
 ## `SilphCo11FPorygonText` is a `call DisplayPokedex` the disassembly marks
 ## unreferenced. The `trade` rows are the eight `predef DoInGameTradeDialogue`

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -171,6 +171,15 @@ const CABLE_CLUB_ROWS: int = 12
 
 ## `Daycare_Object`'s one object, faced from the cell beside him, and the party
 ## the row's `wPartyCount` tests are answered with.
+## `NAME_RATERS_HOUSE` and its one object, at `object_event 5, 3` facing LEFT.
+const NAME_RATER_MAP: int = 0xE5
+const NAME_RATER_CELL := Vector2i(6, 3)
+const NAME_RATER_TEXT: int = 1
+const NAME_RATER_TRAINER: String = "RED"
+const NAME_RATER_ID: int = 22222
+const NAME_RATER_NICKNAME: String = "BOLT"
+const NAME_RATER_SPECIES_NAME: String = "SPARKY"
+
 const DAYCARE: int = 0x48
 const DAYCARE_GENTLEMAN := Vector2i(3, 3)
 const DAYCARE_PARTY: int = 2
@@ -470,6 +479,7 @@ func _one_game() -> void:
 	_check_the_fossil_lab()
 	_check_the_badge_house()
 	_check_the_day_care()
+	_check_the_name_rater()
 	_check_the_town_map_poster()
 	_check_flying()
 	_check_a_dungeon_fall()
@@ -1744,6 +1754,151 @@ func _trade_filled(text: String) -> String:
 ## `DaycareGentlemanText` walked both ways: the offer, the party list and
 ## `MoveMon PARTY_TO_DAYCARE`, then the growth, `HasEnoughMoney` and the way
 ## back out. `IncrementDayCareMonExp` is what makes the second half possible.
+## `NameRatersHouseNameRaterText` end to end, and the OT test both ways.
+func _check_the_name_rater() -> void:
+	var boxes: Dictionary = _name_rater_boxes()
+	if boxes.is_empty():
+		return
+	_check_the_name_rater_refuses(boxes)
+	var world: Gen2WorldAPI = _name_rater_world()
+	if world == null:
+		return
+	world.interact()
+	_r.check(
+		_name_rater_asked(world) == _name_rater_text(boxes, "hello"),
+		"the rater opened on something else."
+	)
+	_r.check(
+		_event_text(world.choose_script_input(0)) == _name_rater_text(boxes, "which"),
+		"YES asked for no member."
+	)
+	world.run_event_queue(true)
+	_r.check(
+		StringName(world.pending_runtime_request().get("kind", &""))
+			== &"party_selection_requested",
+		"the question opened no party list."
+	)
+	world.complete_runtime_request(_name_rater_row(true))
+	_r.check(
+		_name_rater_asked(world)
+			== _name_rater_text(boxes, "decent", NAME_RATER_SPECIES_NAME),
+		"a member of the player's own was not offered a rename."
+	)
+	_r.check(
+		_event_text(world.choose_script_input(0)) == _name_rater_text(boxes, "what"),
+		"YES did not ask for a name."
+	)
+	world.run_event_queue(true)
+	_r.check(
+		StringName(world.pending_runtime_request().get("kind", &""))
+			== &"gen1_nickname_requested",
+		"the question opened no keyboard."
+	)
+	_r.check(
+		_event_text(world.complete_runtime_request({
+			"ok": true, "name": NAME_RATER_NICKNAME,
+		})) == _name_rater_text(boxes, "renamed", NAME_RATER_NICKNAME),
+		"the entry was not read back."
+	)
+	_r.note("gen1 walk the NAME RATER: a rename, a traded member and three refusals")
+
+
+func _check_the_name_rater_refuses(boxes: Dictionary) -> void:
+	var come_again: String = _name_rater_text(boxes, "come_again")
+	var world: Gen2WorldAPI = _name_rater_world()
+	if world == null:
+		return
+	world.interact()
+	_r.check(
+		_event_text(world.choose_script_input(1)) == come_again,
+		"NO said something else."
+	)
+	for row: Dictionary in [{"ok": true, "party_index": -1}, _name_rater_row(false)]:
+		var refused: Gen2WorldAPI = _name_rater_world()
+		if refused == null:
+			return
+		refused.interact()
+		refused.choose_script_input(0)
+		refused.run_event_queue(true)
+		var said: String = _event_text(refused.complete_runtime_request(row))
+		var wanted: String = come_again if int(row.get("party_index", -1)) < 0 \
+			else _name_rater_text(boxes, "impeccable", NAME_RATER_SPECIES_NAME)
+		_r.check(said == wanted, "the list was answered with %s." % said)
+	var blank: Gen2WorldAPI = _name_rater_world()
+	if blank == null:
+		return
+	blank.interact()
+	blank.choose_script_input(0)
+	blank.run_event_queue(true)
+	blank.complete_runtime_request(_name_rater_row(true))
+	blank.choose_script_input(0)
+	blank.run_event_queue(true)
+	_r.check(
+		_event_text(blank.complete_runtime_request({"ok": true, "name": ""})) == come_again,
+		"an empty entry was not refused."
+	)
+
+
+func _name_rater_row(mine: bool) -> Dictionary:
+	return {
+		"ok": true, "party_index": 0, "nickname": NAME_RATER_SPECIES_NAME,
+		"ot_id": NAME_RATER_ID if mine else NAME_RATER_ID + 1,
+		"original_trainer": NAME_RATER_TRAINER,
+	}
+
+
+## What the box over a YES/NO says: the pending input's text, not the step's.
+func _name_rater_asked(world: Gen2WorldAPI) -> String:
+	return String(world.pending_script_input().get("text", ""))
+
+
+func _name_rater_world() -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, NAME_RATER_MAP, NAME_RATER_CELL)
+	if world == null:
+		return null
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	world.set_player_name(NAME_RATER_TRAINER)
+	world.set_player_id(NAME_RATER_ID)
+	return world
+
+
+## The row's own boxes, by where each stands in the tree: the shape is pinned too.
+func _name_rater_boxes() -> Dictionary:
+	var map: Gen2WorldMap = _r.data.world_map(0, NAME_RATER_MAP)
+	var nodes: Variant = map.text_at(NAME_RATER_TEXT).get("script", []) if map != null else []
+	if not nodes is Array or (nodes as Array).is_empty():
+		_r.fail("the NAME RATER's row decoded to nothing.")
+		return {}
+	var rows: Array = nodes as Array
+	var offer: Dictionary = rows[-1]
+	var listed: Dictionary = (offer.get("yes", []) as Array)[-1]
+	var ot: Dictionary = (listed.get("else", []) as Array)[-1]
+	var nicer: Dictionary = (ot.get("else", []) as Array)[-1]
+	var keyboard: Dictionary = (nicer.get("yes", []) as Array)[-1]
+	return {
+		"hello": (rows[0] as Dictionary).get("text", ""),
+		"come_again": ((offer.get("no", []) as Array)[0] as Dictionary).get("text", ""),
+		"which": ((offer.get("yes", []) as Array)[0] as Dictionary).get("text", ""),
+		"impeccable": ((ot.get("then", []) as Array)[0] as Dictionary).get("text", ""),
+		"decent": ((ot.get("else", []) as Array)[0] as Dictionary).get("text", ""),
+		"what": ((nicer.get("yes", []) as Array)[0] as Dictionary).get("text", ""),
+		"renamed": ((keyboard.get("else", []) as Array)[0] as Dictionary).get("text", ""),
+	}
+
+
+func _name_rater_text(boxes: Dictionary, name: String, ram: String = "") -> String:
+	var text: String = Gen2TextStream.fill_names(
+		String(boxes.get(name, "")), {"player": NAME_RATER_TRAINER}
+	)
+	var layout: Dictionary = Gen1Layout.for_id(_r.game_id)
+	for buffer: String in ["name_buffer", "entry_buffer"]:
+		var marker: String = "%s%04X>" % [
+			Gen2TextStream.RAM_MARKER, int(layout[buffer])
+		]
+		text = Gen2TextStream.fill_all_markers(text, marker, ram)
+	return text
+
+
 func _check_the_day_care() -> void:
 	_check_the_day_care_refuses()
 	var world: Gen2WorldAPI = _day_care_world(0)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -69,7 +69,7 @@ const KIND_HELP: Dictionary = {
 	&"yes_no": "script, presses: Script_yesorno's box over the map's script",
 	&"npc_trade": "cell below the trader: NPCTrade's own TRADE_DIALOG_INTRO with the YesNoBox over it",
 	&"battle_tower": "A presses, DOWN presses: BattleTower1FReceptionistScript, talked to from the cell below her",
-	&"name_rater": "presses: special NameRater. 0 is the introduction, 2 the last page with YES/NO, 4 the party list",
+	&"name_rater": "presses: special NameRater. 0 is the introduction, 2 the last page with YES/NO, 4 the party list. On a Generation 1 cartridge, NameRatersHouseNameRaterText faced left from 6,3 on NAME_RATERS_HOUSE (`red 0 229 ... name_rater@6,3`)",
 	&"move_deleter": "presses: special MoveDeletion, the same three stages",
 	&"gift_nickname": "presses, species: GiveANickname_YesNo. 1 the question, 2 the WasSentToBillsPCText behind NO; add 1000 for the box branch",
 	&"unown_printer": "slot, page: _UnownPrinter's browser. Slot 26 is the vacant one; page 1 is what A sends to a printer that is not there",
@@ -211,6 +211,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"elevator": BOX_REVEAL_FRAMES,
 	&"coins": BOX_REVEAL_FRAMES, &"deal": BOX_REVEAL_FRAMES,
 	&"ticket": BOX_REVEAL_FRAMES, &"day_care": BOX_REVEAL_FRAMES,
+	&"name_rater": BOX_REVEAL_FRAMES,
 	&"poke_flute": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
@@ -818,6 +819,10 @@ func _stage_day_care() -> void:
 ## Presses are spent only once the box owes no frames, since nothing shortens a
 ## printing text.
 func _stage_party_routine() -> void:
+	if _kind == &"name_rater" and _screen._data != null \
+		and _screen._data.generation == RomRegistry.GEN1:
+		_stage_gen1_name_rater()
+		return
 	_screen.call(SCREEN_DRIVER % _kind)
 	var host_property: String = "_%s_host" % _kind
 	_settle_mon_special(host_property)
@@ -1283,6 +1288,17 @@ func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP, rows: int = 
 		for _frame: int in BOX_REVEAL_FRAMES:
 			_screen.advance_frame()
 		_screen.press_button(PokeButton.A)
+
+
+## `NameRatersHouseNameRaterText`, faced left from the cell beside him.
+func _stage_gen1_name_rater() -> void:
+	var save: Gen2SaveData = _stage_party()
+	## A development party carries no OT, which every real gift stamps.
+	if save != null and not save.party.is_empty():
+		var mon: Gen2SaveMon = save.party[0] as Gen2SaveMon
+		mon.original_trainer = save.player_name
+		mon.ot_id = save.player_id
+	_stage_counter({}, PokeButton.LEFT, 0)
 
 
 ## `DaycareGentlemanText`, whose second number is `wDayCareInUse`: a seeded slot


### PR DESCRIPTION
`DisplayPartyMenu` and `DisplayNameRaterScreen` are two decoded nodes whose carry is CANCEL, and what either answers decides the boxes behind it, so both sides ride the request unresolved and are walked once it has come back. `NameRatersHouseCheckMonOTScript` is read by its own address rather than walked, being a loop, and `Gen2NameRater.matches_ot` is the one test both generations compare an OT through. `GetPartyMonName2` fills `wNameBuffer` and the keyboard's entry `wBuffer`, so each box names by its own address.

`Gen2NamingScreen.for_gen1_mon` is NAME_MON_SCREEN: ten underscores where the player's keyboard has seven, `PrintNamingText`'s species name at `hlcoord 4, 1` with NICKNAME? at `hlcoord 1, 3`, and `WriteMonPartySpriteOAM`'s 2x2 icon at OAM ($10, $10). `Gen1Layout.mon_icon_quadrant` is the one place the symmetric writer's tile and flip are decided, which the party menu reads too.

## Fixed

- `_map_script_successors` read `value` off every `set_map_script`, and Yellow's `wNextSafariZoneGateScript` stores a byte it read back rather than a constant, so a Yellow import raised a runtime error and left that map's state reachability half built.
- `_prompt_icon` sliced a tile strip by hand where `Gen2PicImage.blit_tile` reads it side by side; the naming screen's own icon shares that seam now.

## Measurements

| | Red | Blue | Yellow |
|---|---|---|---|
| `text_asm` rows read | 317 | 317 | 370 |
| rows with an unknown arm | 1 | 1 | 12, from 16 |

The one arm left on Red and Blue is unreachable: `GateUpstairsScript_PrintIfFacingUp.up`, which only a facing the `jp nz` already refused could take.

`tools/checks/gen1_walk.gd` renames a member, is answered `.ATrulyImpeccableName` for another trainer's, and is refused four ways: NO at either question, a list left with B, and an entry left blank. `tools/checks/gen1_maps.gd` pins the new census. Unit tier 3916/3916, full tier 4534/4534, `validate.gd -- all` clean on all six cartridges, `replay_world.gd` 33 routes 0 failures, the three-profile story walk clean, the analyser 0 warnings in 637 scripts.

`tools/preview_world.gd -- red 0 229 <out.png> live name_rater@6,3 2 0` photographs the party list and `6 0` the keyboard.