### PR TITLE
Settle a Generation 1 script branch on a byte with a closed set

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -3071,6 +3071,19 @@ static func rod_slots(rod: StringName) -> Array:
 
 
 ## Whether the Super Rod is read as Yellow's flat slot table.
+## `wRivalStarter` and `wPlayerStarter` hold one of these and nothing else, so
+## `Route22GetRivalTrainerNoByStarterScript`'s unterminated table walk stops.
+const SCRIPT_STARTERS: Dictionary = {
+	RomRegistry.RED: {"rival": [0xB0, 0xB1, 0x99], "player": [0xB0, 0xB1, 0x99]},
+	RomRegistry.BLUE: {"rival": [0xB0, 0xB1, 0x99], "player": [0xB0, 0xB1, 0x99]},
+	RomRegistry.YELLOW: {"rival": [1, 2, 3], "player": [0x54]},
+}
+
+
+static func script_starters(id: StringName, who: String) -> Array:
+	return (SCRIPT_STARTERS.get(id, {}) as Dictionary).get(who, [])
+
+
 static func flat_super_rod(id: StringName) -> bool:
 	return id == RomRegistry.YELLOW
 

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1762,12 +1762,11 @@ const SCRIPT_STORED_REGISTERS: Dictionary = {
 ## choosing between them; a path reaching anything unread is dropped whole.
 ## [param known] is the argument byte a hidden event's own routine is handed.
 static func decode_script(
-	rom: RomFile, layout: Dictionary, bank: int, at: int, known: Dictionary = {},
-	refused: Array = []
+	rom: RomFile, layout: Dictionary, bank: int, at: int, known: Dictionary = {}
 ) -> Array:
 	var ctx: Dictionary = {
 		"rom": rom, "layout": layout, "bank": bank,
-		"budget": [SCRIPT_BUDGET], "calls": [0], "refused": refused,
+		"budget": [SCRIPT_BUDGET], "calls": [0],
 	}
 	var walked: Variant = _walk_script(ctx, at, known.duplicate(), 0)
 	return walked as Array if walked is Array else []
@@ -1779,7 +1778,6 @@ static func _walk_script(
 	ctx: Dictionary, pc: int, state: Dictionary, depth: int
 ) -> Variant:
 	if depth > SCRIPT_DEPTH:
-		_script_refused(ctx, pc, "depth")
 		return null
 	## A `jp nc, CheckFightingMapTrainers` lands here rather than on a call, and
 	## a `<Map>_ScriptPointers` row may stand at a routine outright, so a routine
@@ -1809,18 +1807,63 @@ static func _walk_script(
 		if next == SCRIPT_END:
 			return _script_ended(state, out)
 		if next == SCRIPT_UNREAD:
-			_script_refused(ctx, pc, "op")
 			return null
 		if next == SCRIPT_AIDE:
 			return _script_aide_branch(ctx, pc + Gen1Layout.SCRIPT_LONG_SIZE, state, depth, out)
 		pc = next
-	_script_refused(ctx, pc, "budget")
 	return null
 
 
-static func _script_refused(ctx: Dictionary, pc: int, why: String) -> void:
-	if ctx.has("refused"):
-		(ctx["refused"] as Array).append({"bank": int(ctx["bank"]), "pc": pc, "why": why})
+const SCRIPT_TEST_DOMAINS: Dictionary = {
+	SCRIPT_TESTS_FACING: "facing", SCRIPT_TESTS_STARTER: "starter",
+}
+
+
+static func _script_domain(ctx: Dictionary, state: Dictionary, tests: int) -> Array:
+	if tests == SCRIPT_TESTS_FACING:
+		return Gen1Layout.FACING_STEPS.keys()
+	return Gen1Layout.script_starters(
+		(ctx["rom"] as RomFile).id, String(state.get("starter_who", ""))
+	)
+
+
+static func _script_domain_settled(
+	ctx: Dictionary, state: Dictionary, tests: Variant
+) -> Variant:
+	if not (tests is int) or not SCRIPT_TEST_DOMAINS.has(int(tests)):
+		return null
+	var key: int = int(tests)
+	var domain: Array = _script_domain(ctx, state, key)
+	var value: int = int(state[SCRIPT_TEST_DOMAINS[key]])
+	if domain.is_empty():
+		return null
+	var known: Dictionary = state.get("domains", {})
+	var fixed: Dictionary = known.get("fixed", {})
+	if fixed.has(key):
+		return int(fixed[key]) == value
+	var seen: Array = (known.get("excluded", {}) as Dictionary).get(key, [])
+	if seen.has(value) or not domain.has(value):
+		return false
+	for other: int in domain:
+		if other != value and not seen.has(other):
+			return null
+	return true
+
+
+static func _script_domain_learn(
+	state: Dictionary, tests: Variant, miss: Dictionary, match_side: Dictionary
+) -> void:
+	if not (tests is int) or not SCRIPT_TEST_DOMAINS.has(int(tests)):
+		return
+	var key: int = int(tests)
+	var value: int = int(state[SCRIPT_TEST_DOMAINS[key]])
+	var known: Dictionary = state.get("domains", {})
+	var excluded: Dictionary = (known.get("excluded", {}) as Dictionary).duplicate()
+	excluded[key] = (excluded.get(key, []) as Array) + [value]
+	miss["domains"] = {"fixed": known.get("fixed", {}), "excluded": excluded}
+	var fixed: Dictionary = (known.get("fixed", {}) as Dictionary).duplicate()
+	fixed[key] = value
+	match_side["domains"] = {"fixed": fixed, "excluded": known.get("excluded", {})}
 
 
 ## `AfterDisplayingTextID` reads `wDoNotWaitForButtonPress...` once the row is
@@ -3036,7 +3079,6 @@ static func _script_call_branch(
 	var tests: Variant = state.get("tests", SCRIPT_TESTS_NOTHING)
 	var carry: bool = Gen1Layout.SCRIPT_CARRY_CALLS.has(op)
 	if not _script_reads_flag(state, tests, carry):
-		_script_refused(ctx, pc, "call_branch")
 		return null
 	var called: Variant = _script_call_walked_on(ctx, pc, target, state.duplicate(), depth + 1, [])
 	var passed: Variant = _walk_script(ctx, next, state.duplicate(), depth + 1)
@@ -3056,7 +3098,6 @@ static func _script_call_walked_on(
 ) -> Variant:
 	var called: int = _script_call(ctx, pc, target, state, out, depth)
 	if called == SCRIPT_UNREAD:
-		_script_refused(ctx, pc, "call")
 		return null
 	if called == SCRIPT_END:
 		return _script_ended(state, out)
@@ -4355,8 +4396,7 @@ static func _script_box(ctx: Dictionary, pointer: int) -> Dictionary:
 
 
 ## A conditional, walked both ways. A side reaching machine code this decoder
-## does not read becomes an `unknown` node, so an interaction taking that side
-## says nothing at all, as an undecoded row does.
+## does not read becomes an `unknown` node the runtime can do nothing with.
 static func _script_branch(
 	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
 ) -> Variant:
@@ -4364,8 +4404,11 @@ static func _script_branch(
 	var carry: bool = Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op)
 	if state.has("known_zero") and not carry:
 		return _script_known_branch(ctx, op, pc, state, depth, out)
+	var settled: Variant = null if carry else _script_domain_settled(ctx, state, tests)
+	if settled != null:
+		state["known_zero"] = bool(settled)
+		return _script_known_branch(ctx, op, pc, state, depth, out)
 	if not _script_reads_flag(state, tests, carry):
-		_script_refused(ctx, pc, "branch")
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
@@ -4381,6 +4424,9 @@ static func _script_branch(
 		## the side a `jp nz` does not take knows the register is zero.
 		var zero: Dictionary = fell_state if bool(table[op]) else jumped_state
 		zero["a"] = 0
+	if not carry:
+		_script_domain_learn(state, tests, jumped_state if bool(table[op]) else fell_state,
+			fell_state if bool(table[op]) else jumped_state)
 	var branches: Array = [
 		_walk_script(ctx, jumped, jumped_state, depth + 1),
 		_walk_script(ctx, pc + size, fell_state, depth + 1),
@@ -4391,7 +4437,6 @@ static func _script_branch(
 		return null
 	var node: Variant = _script_node(tests, branches, state, out, carry)
 	if node == null:
-		_script_refused(ctx, pc, "node")
 		return null
 	out.append(node)
 	return out
@@ -4418,8 +4463,7 @@ static func _script_known_branch(
 	return out
 
 
-## A conditional `ret`, which a wrong facing is refused with: the side that
-## returns prints nothing and the other carries on behind it.
+## A conditional `ret`: the side that returns prints nothing.
 static func _script_ret_branch(
 	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
 ) -> Variant:
@@ -4433,7 +4477,6 @@ static func _script_ret_branch(
 		state.erase("known_zero")
 		return _script_walked_on(ctx, pc + 1, state, depth, out)
 	if not _script_reads_flag(state, tests, carry):
-		_script_refused(ctx, pc, "ret_branch")
 		return null
 	var walked: Variant = _walk_script(ctx, pc + 1, state.duplicate(), depth + 1)
 	if walked == null:

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -132,7 +132,10 @@ const RET_NZ: int = 0xC0
 const CALL_NZ: int = 0xC4
 
 
-func _rom(program: Array, strings: Dictionary = {}, raw: Dictionary = {}) -> RomFile:
+func _rom(
+	program: Array, strings: Dictionary = {}, raw: Dictionary = {},
+	game_id: StringName = &""
+) -> RomFile:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomFile.BANK_SIZE)
 	for offset: int in program.size():
@@ -150,7 +153,7 @@ func _rom(program: Array, strings: Dictionary = {}, raw: Dictionary = {}) -> Rom
 		var row: int = int(LAYOUT["predef_pointers"]) + id * Gen1Layout.PREDEF_SIZE
 		data[row + 1] = int(PREDEFS[id]) & 0xFF
 		data[row + 2] = int(PREDEFS[id]) >> 8
-	return RomFile.from_bytes(data)
+	return RomFile.from_bytes(data, game_id)
 
 
 func _boxes(text: String = "HI", second: String = "BYE") -> Dictionary:
@@ -171,9 +174,12 @@ func _print(address: int) -> Array:
 
 
 func _decode(
-	program: Array, strings: Dictionary = {}, raw: Dictionary = {}
+	program: Array, strings: Dictionary = {}, raw: Dictionary = {},
+	game_id: StringName = &""
 ) -> Array:
-	return Gen1WorldImporter.decode_script(_rom(program, strings, raw), LAYOUT, 0, AT)
+	return Gen1WorldImporter.decode_script(
+		_rom(program, strings, raw, game_id), LAYOUT, 0, AT
+	)
 
 
 func _load_a(address: int) -> Array:
@@ -1061,6 +1067,44 @@ func test_the_rivals_starter_picks_the_party() -> void:
 	assert_eq(script, [{"op": "starter", "who": "rival", "value": 0xB1,
 		"then": [{"op": "trainer_battle", "class": 0x2A, "number": 7}],
 		"else": [{"op": "trainer_battle", "class": 0x2A, "number": 9}]}])
+
+
+## `Route11Gate2FLeftBinocularsText` hands a facing its own `jp nz` has already
+## refused to `GateUpstairsScript_PrintIfFacingUp`, which tests the same byte
+## again: the second match is unreachable rather than unread.
+func test_a_facing_the_walk_excluded_cannot_match_again() -> void:
+	var script: Array = _decode(
+		_load_a(int(LAYOUT["facing_direction"]))
+			+ [Gen1Layout.SCRIPT_CP_N, Gen1Layout.FACING_UP, 0x20, 0x07]
+			+ _print(HELLO) + [Gen1Layout.SCRIPT_RET]
+			+ _load_a(int(LAYOUT["facing_direction"]))
+			+ [Gen1Layout.SCRIPT_CP_N, Gen1Layout.FACING_UP, 0x28, 0x01]
+			+ [Gen1Layout.SCRIPT_RET] + _print(BYE) + [Gen1Layout.SCRIPT_RET],
+		_boxes()
+	)
+	assert_eq(script, [{"op": "facing", "facing": Gen1Layout.FACING_UP,
+		"then": [{"op": "text", "text": "HI"}], "else": []}])
+
+
+## `Route22GetRivalTrainerNoByStarterScript` walks a three-row table its `cp b`
+## loop has no terminator for, so the third starter is the one the set has left
+## rather than a test with the bytes behind the table under it.
+func test_the_last_starter_of_the_set_is_not_a_test() -> void:
+	var script: Array = _decode(
+		_load_a(int(LAYOUT["rival_starter"]))
+			+ [Gen1Layout.SCRIPT_CP_N, 0xB0, 0x28, 0x09]
+			+ [Gen1Layout.SCRIPT_CP_N, 0xB1, 0x28, 0x0C]
+			+ [Gen1Layout.SCRIPT_CP_N, 0x99, 0x28, 0x0F] + [0xFF]
+			+ _print(HELLO) + [Gen1Layout.SCRIPT_RET]
+			+ _print(BYE) + [Gen1Layout.SCRIPT_RET]
+			+ _print(HELLO) + [Gen1Layout.SCRIPT_RET],
+		_boxes(), {}, RomRegistry.RED
+	)
+	assert_eq(script, [{"op": "starter", "who": "rival", "value": 0xB0,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "starter", "who": "rival", "value": 0xB1,
+			"then": [{"op": "text", "text": "BYE"}],
+			"else": [{"op": "text", "text": "HI"}]}]}])
 
 
 func _raw_at(address: int, bytes: Array) -> Dictionary:

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -131,10 +131,10 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
 	&"red": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 1, "pokedex": 13,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 0, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
-		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
+		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
 		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
@@ -146,10 +146,10 @@ const SCRIPT_CENSUS: Dictionary = {
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
 		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
 	&"blue": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
-		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 1, "pokedex": 13,
+		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 0, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
-		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 13,
+		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
 		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
@@ -161,10 +161,10 @@ const SCRIPT_CENSUS: Dictionary = {
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
 		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
 	&"yellow": {"rows": 370, "text": 583, "branch": 154, "choice": 34, "flag": 221,
-		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 12, "pokedex": 10,
+		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 11, "pokedex": 10,
 		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 23,
 		"set_map_script": 75, "npc_movement_script": 2, "toggle_object": 22,
-		"trainer_battle_object": 15, "random": 5, "facing": 13, "player_in_array": 1,
+		"trainer_battle_object": 15, "random": 5, "facing": 12, "player_in_array": 1,
 		"name_species": 6, "pick_up_item": 109, "scratch": 20, "name_badge": 7,
 		"player_facing": 15, "heal_party": 2, "emote": 7, "dex_rating": 2, "dex_count": 6,
 		"map_text": 24, "trade": 7, "name_item": 7, "oaks_aide": 3, "player_coord": 4,
@@ -230,9 +230,9 @@ const STATE_CENSUS: Dictionary = {
 		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
 		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
 		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
-		"coord_index": 17, "starter": 28, "trainer_battle": 29, "battle_outcome": 28,
+		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
 		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
-		"unknown": 6, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"unknown": 2, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
@@ -243,9 +243,9 @@ const STATE_CENSUS: Dictionary = {
 		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
 		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
 		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
-		"coord_index": 17, "starter": 28, "trainer_battle": 29, "battle_outcome": 28,
+		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
 		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
-		"unknown": 6, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"unknown": 2, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
@@ -714,9 +714,6 @@ func _walk_script(
 				_walk_script(font, node[side] as Array, census, wrong, number)
 
 
-## Every `hidden_event` row of the corpus, the nodes behind it and the bookshelf
-## tiles the A button falls through to. `silent` counts the rows whose routine is
-## a screen this port has no counterpart for.
 func _elevators() -> void:
 	var floors: int = 0
 	var maps: Array[int] = []
@@ -761,6 +758,9 @@ func _elevator_rows(number: int, rows: Array, wrong: Array[String]) -> int:
 	return rows.size()
 
 
+## Every `hidden_event` row of the corpus, the nodes behind it and the bookshelf
+## tiles the A button falls through to. `silent` counts the rows whose routine is
+## a screen this port has no counterpart for.
 func _hidden_events() -> void:
 	var census: Dictionary = {"rows": 0, "silent": 0}
 	var wrong: Array[String] = []


### PR DESCRIPTION
`wSpritePlayerStateData1FacingDirection` holds one of four values and `wRivalStarter` and `wPlayerStarter` one of three. A `cp` against a value the walk has already excluded cannot match, and one the set has nothing else left beside always does, so both unknown arms of the `text_asm` corpus on Red and Blue are gone.

## Fixed
- `GateUpstairsScript_PrintIfFacingUp` re-tests a facing its caller's `jp nz` has already refused, so Route 11 Gate 2F's left binoculars row no longer carries an unreachable arm.
- `Route22GetRivalTrainerNoByStarterScript`'s `cp b` loop walks a three-row table with no terminator and unrolled into the code behind it. 12 `starter` nodes and 8 `trainer_battle` rows of the map state census were bytes rather than table rows.
- The hidden event census doc in `tools/checks/gen1_maps.gd` sat above `_elevators`.

## Removed
- `Gen1WorldImporter.decode_script`'s `refused` parameter, which no caller passed, and the six sites that appended to its list.

`tools/validate.gd -- all` passes 94 topics on all six cartridges; the unit tier's 1293 gen1 and world tests pass and two new cases in `tests/unit/test_gen1_script.gd` cover both settled shapes.