### PR TITLE
Complete Gen 1 rival placement and Cinnabar gate scripts

### DIFF
--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -144,6 +144,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_field_moves,
 	_verify_intro,
 	_verify_world,
+	_verify_gym_gates,
 ]
 
 const NEW_NAME: String = "NEW NAME"
@@ -634,6 +635,23 @@ static func _verify_field_moves(rom: RomFile, layout: Dictionary) -> Dictionary:
 		+ (rom.u8(event + 4) - Gen1Layout.OPCODE_BIT_A) / 8
 	if index != Gen1Layout.MET_BILL_EVENT:
 		return _fail("DisplayPCMainMenu reads event %d, not EVENT_MET_BILL." % index)
+	return _ok()
+
+
+static func _verify_gym_gates(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var routine: int = int(layout["update_gym_gates"])
+	var body: int = Gen1Layout.banked(rom.u8(routine + 1), rom.u16le(routine + 3))
+	var table: int = int(layout["gym_gate_coords"])
+	if rom.u8(routine) != 0x06 or rom.u8(routine + 2) != 0x21 \
+		or rom.u8(body) != 0x3E or rom.u8(body + 1) != 6 \
+		or rom.u8(body + 12) != 0x21 \
+		or Gen1Layout.banked(7, rom.u16le(body + 13)) != table:
+		return _fail("UpdateCinnabarGymGateTileBlocks does not address its six gate rows.")
+	for gate: int in 6:
+		var at: int = table + gate * 4
+		if rom.u8(at) >= 10 or rom.u8(at + 1) >= 9 \
+			or rom.u8(at + 2) not in [0x54, 0x5F] or rom.u8(at + 3) != 0:
+			return _fail("CinnabarGymGateCoords contains an invalid gate.")
 	return _ok()
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -1086,6 +1086,11 @@ const SCRIPT_INC_A: int = 0x3C
 ## `ld [hli], a`, which is how `AgathaScriptWalkIntoRoom` writes its six steps.
 const SCRIPT_LD_HLI_A: int = 0x22
 const SCRIPT_LD_A_HLI: int = 0x2A
+const SCRIPT_LD_E: int = 0x1E
+const SCRIPT_ADD_HL_DE: int = 0x19
+const SCRIPT_LD_H_HL: int = 0x66
+const SCRIPT_LD_L_A: int = 0x6F
+const SCRIPT_INC_H: int = 0x24
 const SCRIPT_INC_HL: int = 0x23
 const SCRIPT_INC_DE: int = 0x13
 const SCRIPT_DEC_B: int = 0x05
@@ -1183,7 +1188,7 @@ const SCRIPT_CALLS: Array[String] = [
 	"player_coords_in_array", "start_trainer_battle", "end_trainer_battle",
 	"play_music", "stop_all_music",
 	"set_sprite_facing", "set_sprite_facing_delay", "sprite_stay", "move_sprite",
-	"decode_rle", "decode_arrow_movement",
+	"decode_rle", "decode_arrow_movement", "update_gym_gates",
 	"serial_connect", "fill_memory", "save_end_battle_text", "engage_map_trainer",
 	"check_boulder_coords", "sprite_pointer_1", "sprite_pointer_2",
 	"add_party_mon", "get_item_name", "get_mon_name", "get_sprite_position_2",
@@ -1202,7 +1207,9 @@ const FORCED_WARP_BIT: int = 2
 ## carries, and `wPikachuMapScriptFlags` the follower nothing here draws.
 const NO_MAP_MUSIC_BIT: int = 1
 const NO_TEXT_DELAY_BIT: int = 6
-const SCRIPT_SCRATCH_BYTES: Array[String] = ["which_trade", "rival_starter_ball"]
+const SCRIPT_SCRATCH_BYTES: Array[String] = [
+	"which_trade", "rival_starter_ball", "trainer_header_flag_bit",
+]
 const SCRIPT_FLAG_ACTION_SOURCE: int = -101
 ## The row a hand-drawn menu's cursor stands on, read as an item id.
 const SCRIPT_MENU_ITEM_SOURCE: int = -102
@@ -1261,12 +1268,12 @@ const PIKACHU_MAP_SCRIPT_ACTIVE_BIT: int = 7
 ## Bits that live for one map, held by name until the next map load.
 const SCRIPT_VOLATILE_BITS: Dictionary = {
 	"misc_flags": {PUSHED_BOULDER_BIT: "pushed_boulder"},
+	"gym_quiz_flags": {7: "gym_quiz_answered"},
 	"status_flags_3": {NO_NPC_FACE_PLAYER_BIT: "no_npc_face_player"},
 	"pikachu_map_script_flags": {PIKACHU_MAP_SCRIPT_ACTIVE_BIT: "pikachu_script_active"},
 }
 const SCRIPT_TEMP_BYTES: Array[String] = ["object_to_hide", "object_to_show"]
-## The bytes an `and a` reads a known zero out of: the sight walk owns a trainer
-## engagement here, and Cinnabar Gym's six quiz gates say nothing yet.
+## The sight walk owns engagement; dungeon warps are dispatched separately.
 const SCRIPT_ZERO_SOURCES: Array[String] = [
 	"trainer_header_flag_bit", "opponent_after_wrong_answer", "which_dungeon_warp",
 ]
@@ -2042,6 +2049,8 @@ const RED_BLUE: Dictionary = {
 	"serial_connect": 0x22FA,
 	"check_boulder_coords": 0x34E4,
 	"get_item_quantity": 0x0F8A5,
+	"update_gym_gates": 0x3EAD,
+	"gym_gate_coords": 0x1EB48,
 	"sprite_pointer_1": 0x34FC,
 	"sprite_pointer_2": 0x3500,
 	"fill_memory": 0x36E0,
@@ -2449,6 +2458,9 @@ const YELLOW: Dictionary = {
 	"serial_connect": 0x2156,
 	"check_boulder_coords": 0x34E1,
 	"get_item_quantity": 0x0F735,
+	"update_gym_gates": 0x3EF0,
+	"gym_gate_coords": 0x1E503,
+	"gym_quiz_flags": 0xD474,
 	"sprite_pointer_1": 0x34F9,
 	"sprite_pointer_2": 0x34FD,
 	"fill_memory": 0x166E,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1028,11 +1028,44 @@ static func _read_map_callback(
 	var coordinates: Array = _card_key_coordinates(rom, bank, body) if card_key else []
 	if not coordinates.is_empty():
 		body += CARD_KEY_PROLOGUE_SIZE
-	return {"nodes": decode_script(rom, layout, bank, body), "coordinates": coordinates}
+	var nodes: Array = decode_script(rom, layout, bank, body)
+	var calls: Array[int] = _map_load_calls(rom, layout, bank, script)
+	if not calls.is_empty():
+		nodes = []
+		for target: int in calls:
+			nodes.append_array(decode_script(rom, layout, bank, target))
+	return {"nodes": nodes, "coordinates": coordinates}
 
 
-## The gate is the entry script's own opening or that of the routine its first
-## `call` names, where `AgathaShowOrHideExitBlock` keeps it.
+static func _map_load_calls(rom: RomFile, layout: Dictionary, bank: int, script: int) -> Array[int]:
+	var at: int = Gen1Layout.banked(bank, script)
+	if rom.u8(at) == Gen1Layout.SCRIPT_CALL:
+		at = Gen1Layout.banked(bank, rom.u16le(at + 1))
+	var calls: Array[int] = []
+	if rom.u8(at) != Gen1Layout.SCRIPT_LD_HL or rom.u16le(at + 1) != int(layout["map_script_flags"]):
+		return calls
+	at += 3
+	var loaded: bool = false
+	for _step: int in 16:
+		var op: int = rom.u8(at)
+		if op == Gen1Layout.SCRIPT_PREFIX:
+			var code: int = rom.u8(at + 1)
+			if (code & 7) != Gen1Layout.SCRIPT_OPERAND_HL:
+				break
+			if code < Gen1Layout.SCRIPT_RES_BASE:
+				loaded = ((code - Gen1Layout.SCRIPT_BIT_BASE) / 8) in [5, 6]
+			at += 2
+		elif Gen1Layout.SCRIPT_STACK_HL.has(op):
+			at += 1
+		elif op in [0xC4, 0xCC]:
+			if loaded == (op == 0xC4):
+				calls.append(rom.u16le(at + 1))
+			at += 3
+		else:
+			break
+	return calls
+
+
 static func _map_load_gate(rom: RomFile, layout: Dictionary, bank: int, at: int) -> int:
 	var body: int = _map_load_body(rom, layout, bank, at)
 	if body >= 0:
@@ -1375,14 +1408,14 @@ static func _read_texts(
 	var table: int = Gen1Layout.banked(bank, address)
 	var out: Array = []
 	for id: int in _highest_text_id(events):
-		out.append(_read_text(rom, layout, bank, rom.u16le(table + id * 2)))
+		out.append(_read_text(rom, layout, bank, rom.u16le(table + id * 2), id + 1))
 	return out
 
 
 ## A `TX_SCRIPT_*` row keeps its own inventory where it has one, so nothing
 ## downstream has to read the cartridge again to open the shop.
 static func _read_text(
-	rom: RomFile, layout: Dictionary, bank: int, pointer: int
+	rom: RomFile, layout: Dictionary, bank: int, pointer: int, text_id: int = 0
 ) -> Dictionary:
 	var at: int = Gen1Layout.banked(bank, pointer)
 	var decoded: Dictionary = Gen1Text.decode_stream(rom, at)
@@ -1407,7 +1440,8 @@ static func _read_text(
 	var code: int = _text_code_at(decoded)
 	if code < 0:
 		return row
-	var script: Array = decode_script(rom, layout, bank, code)
+	var script: Array = decode_script(rom, layout, bank, code,
+		{"map_text": text_id} if text_id > 0 else {})
 	if script.is_empty():
 		return row
 	if not String(row["text"]).is_empty():
@@ -1741,13 +1775,14 @@ const SCRIPT_TESTS_ANY_MONEY: int = -34
 const SCRIPT_TESTS_PARTY_MENU: int = -35
 const SCRIPT_TESTS_MON_OT: int = -36
 const SCRIPT_TESTS_NAME_ENTRY: int = -37
+const SCRIPT_TESTS_INDEXED_FLAG: int = -38
 const SCRIPT_AIDE: int = -3
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
 ## clobbered.
 const SCRIPT_AF_KEYS: Array[String] = [
 	"a", "source", "rotated", "tests", "tests_in_carry", "tests_engine",
-	"tests_and_a",
+	"tests_and_a", "a_runtime", "a_symbolic", "tests_snapshot", "tests_all",
 ]
 ## The stores a row is read for that are `a` under another name. `hSpriteIndex`
 ## shares `hTextID`'s byte, so the routine behind a store says which was meant.
@@ -1981,10 +2016,14 @@ static func _script_step_more(
 			if next != SCRIPT_UNREAD:
 				state["hl"] = int(state["hl"]) - 1
 			return next
-		Gen1Layout.SCRIPT_ADD_N:
+		Gen1Layout.SCRIPT_ADD_N, Gen1Layout.SCRIPT_SUB_N:
 			return _script_added(ctx, pc, at, state)
 		Gen1Layout.SCRIPT_LD_D:
-			return _script_filtered_index(ctx, pc, at, state)
+			var filtered: int = _script_filtered_index(ctx, pc, at, state)
+			return filtered if filtered != SCRIPT_UNREAD else _script_table_register(ctx, pc, at, state)
+		Gen1Layout.SCRIPT_LD_E, Gen1Layout.SCRIPT_ADD_HL_DE, \
+		Gen1Layout.SCRIPT_LD_H_HL, Gen1Layout.SCRIPT_LD_L_A, Gen1Layout.SCRIPT_INC_H:
+			return _script_table_register(ctx, pc, at, state)
 		Gen1Layout.SCRIPT_CP_B:
 			return _script_compared_b(ctx, pc, state)
 	return _script_step_registers(ctx, pc, at, state, out, depth)
@@ -2079,6 +2118,41 @@ static func _script_read_table(ctx: Dictionary, pc: int, state: Dictionary) -> i
 	return pc + 1
 
 
+static func _script_table_register(ctx: Dictionary, pc: int, at: int, state: Dictionary) -> int:
+	var rom: RomFile = ctx["rom"]
+	var op: int = rom.u8(at)
+	if op == Gen1Layout.SCRIPT_INC_H:
+		if not state.has("hl"):
+			return SCRIPT_UNREAD
+		state["hl"] = (int(state["hl"]) + 0x100) & 0xFFFF
+		_script_untested(state)
+		state["known_zero"] = int(state["hl"]) < 0x100
+		return pc + 1
+	if op in [Gen1Layout.SCRIPT_LD_D, Gen1Layout.SCRIPT_LD_E]:
+		var high: bool = op == Gen1Layout.SCRIPT_LD_D
+		var mask: int = 0x00FF if high else 0xFF00
+		state["de"] = (int(state.get("de", 0)) & mask) \
+			| (rom.u8(at + 1) << (8 if high else 0))
+		return pc + 2
+	if not state.has("hl"):
+		return SCRIPT_UNREAD
+	match op:
+		Gen1Layout.SCRIPT_ADD_HL_DE:
+			if not state.has("de"):
+				return SCRIPT_UNREAD
+			state["hl"] = (int(state["hl"]) + int(state["de"])) & 0xFFFF
+		Gen1Layout.SCRIPT_LD_H_HL:
+			if int(state["hl"]) < 0 or int(state["hl"]) >= Gen1Layout.SCRIPT_CEILING:
+				return SCRIPT_UNREAD
+			state["hl"] = (int(state["hl"]) & 0xFF) \
+				| (rom.u8(Gen1Layout.banked(int(ctx["bank"]), int(state["hl"]))) << 8)
+		Gen1Layout.SCRIPT_LD_L_A:
+			if not state.has("a"):
+				return SCRIPT_UNREAD
+			state["hl"] = (int(state["hl"]) & 0xFF00) | (int(state["a"]) & 0xFF)
+	return pc + 1
+
+
 static func _script_moved_half(pc: int, op: int, state: Dictionary) -> int:
 	var to_hl: bool = op in [Gen1Layout.SCRIPT_LD_H_D, Gen1Layout.SCRIPT_LD_L_E]
 	## `ld h, d` with `ld l, e` is a copy: the unwritten half is not read.
@@ -2096,6 +2170,8 @@ static func _script_moved_half(pc: int, op: int, state: Dictionary) -> int:
 
 static func _script_added(ctx: Dictionary, pc: int, at: int, state: Dictionary) -> int:
 	var value: int = (ctx["rom"] as RomFile).u8(at + 1)
+	if (ctx["rom"] as RomFile).u8(at) == Gen1Layout.SCRIPT_SUB_N:
+		value = -value
 	var layout: Dictionary = ctx["layout"]
 	if int(state.get("source", -1)) == int(layout.get("rival_starter", -1)):
 		_script_wrote_a(state)
@@ -2104,8 +2180,11 @@ static func _script_added(ctx: Dictionary, pc: int, at: int, state: Dictionary) 
 		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 	if not state.has("a") or state.has("a_symbolic"):
 		return SCRIPT_UNREAD
+	var runtime: int = int(state.get("a_runtime", -1))
 	_script_wrote_a(state)
-	state["a"] = int(state["a"]) + value
+	state["a"] = (int(state["a"]) + value) & 0xFF
+	if runtime >= 0:
+		state["a_runtime"] = runtime
 	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 
 
@@ -2219,18 +2298,19 @@ static func _script_jumped(
 		Gen1Layout.SCRIPT_CALL:
 			return _script_call(ctx, pc, rom.u16le(at + 1), state, out, depth)
 		Gen1Layout.SCRIPT_PUSH_HL:
-			state["hl_saved"] = int(state.get("hl", -1))
+			_script_push(state, "hl_saved", int(state.get("hl", -1)))
 			return pc + 1
 		Gen1Layout.SCRIPT_POP_HL:
-			if not state.has("hl_saved"):
+			if (state.get("hl_saved", []) as Array).is_empty():
 				return SCRIPT_UNREAD
-			state["hl"] = int(state["hl_saved"])
+			state["hl"] = int(_script_pop(state, "hl_saved"))
 			return pc + 1
 		Gen1Layout.SCRIPT_PUSH_AF:
-			state["af"] = _script_pushed_af(state)
+			_script_push(state, "af", _script_pushed_af(state))
 			return pc + 1
 		Gen1Layout.SCRIPT_POP_AF:
-			return SCRIPT_UNREAD if not state.has("af") else _script_popped_af(state, pc)
+			return SCRIPT_UNREAD if (state.get("af", []) as Array).is_empty() \
+				else _script_popped_af(state, pc)
 	if Gen1Layout.SCRIPT_CONDITIONAL_CALLS.has(rom.u8(at)):
 		return _script_call_if(ctx, pc, rom.u16le(at + 1), state, out, depth)
 	return SCRIPT_UNREAD
@@ -2254,6 +2334,19 @@ static func _script_call_if(
 	return next
 
 
+static func _script_push(state: Dictionary, key: String, value: Variant) -> void:
+	var stack: Array = (state.get(key, []) as Array).duplicate()
+	stack.append(value)
+	state[key] = stack
+
+
+static func _script_pop(state: Dictionary, key: String) -> Variant:
+	var stack: Array = (state[key] as Array).duplicate()
+	var value: Variant = stack.pop_back()
+	state[key] = stack
+	return value
+
+
 static func _script_pushed_af(state: Dictionary) -> Dictionary:
 	var saved: Dictionary = {}
 	for key: String in SCRIPT_AF_KEYS:
@@ -2263,12 +2356,11 @@ static func _script_pushed_af(state: Dictionary) -> Dictionary:
 
 
 static func _script_popped_af(state: Dictionary, pc: int) -> int:
-	var saved: Dictionary = state["af"]
+	var saved: Dictionary = _script_pop(state, "af")
 	for key: String in SCRIPT_AF_KEYS:
 		state.erase(key)
 		if saved.has(key):
 			state[key] = saved[key]
-	state.erase("af")
 	return pc + 1
 
 
@@ -2276,7 +2368,7 @@ static func _script_popped_af(state: Dictionary, pc: int) -> int:
 static func _script_untested(state: Dictionary) -> void:
 	for key: String in [
 		"tests", "tests_in_carry", "tests_engine", "tests_and_a", "tests_all",
-		"known_zero",
+		"known_zero", "tests_snapshot",
 	]:
 		state.erase(key)
 
@@ -2288,6 +2380,7 @@ static func _script_tested(
 	state["tests_in_carry"] = in_carry
 	state["tests_engine"] = engine
 	state.erase("tests_and_a")
+	state.erase("tests_snapshot")
 	state.erase("tests_all")
 	state.erase("known_zero")
 
@@ -2311,6 +2404,7 @@ static func _script_hop(operand: int) -> int:
 static func _script_loaded_register(state: Dictionary, register: String, value: int) -> void:
 	state[register] = value
 	state.erase(register + "_source")
+	state.erase(register + "_runtime")
 
 
 ## `ld b, a` and `ld c, a`: a register handed a value the walk does not know
@@ -2319,6 +2413,8 @@ static func _script_loaded_register(state: Dictionary, register: String, value: 
 static func _script_moved_a(state: Dictionary, register: String) -> bool:
 	if state.has("a"):
 		_script_loaded_register(state, register, int(state["a"]))
+		if state.has("a_runtime"):
+			state[register + "_runtime"] = int(state["a_runtime"])
 		state.erase(register + "_symbolic")
 		if state.has("a_symbolic"):
 			state[register + "_symbolic"] = String(state["a_symbolic"])
@@ -2326,6 +2422,8 @@ static func _script_moved_a(state: Dictionary, register: String) -> bool:
 	if not state.has("source"):
 		return false
 	state.erase(register)
+	state.erase(register + "_runtime")
+	state.erase(register + "_symbolic")
 	state[register + "_source"] = int(state["source"])
 	return true
 
@@ -2336,6 +2434,7 @@ static func _script_wrote_a(state: Dictionary) -> void:
 	state.erase("tests_and_a")
 	state.erase("a_symbolic")
 	state.erase("a_half_of")
+	state.erase("a_runtime")
 
 
 ## `ld a, [nn]`. `ShowPokedexDataInternal` leaves `wPokedexNum` in
@@ -2345,6 +2444,9 @@ static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> 
 	state.erase("a")
 	state["source"] = address
 	var layout: Dictionary = ctx["layout"]
+	if address == int(layout.get("text_id_hram", -1)) and state.has("map_text"):
+		state["a"] = int(state["map_text"])
+		state.erase("source")
 	if address == int(layout["cur_party_species"]) and state.has("species_index"):
 		state["a"] = int(state["species_index"])
 	## `wHiddenEventFunctionArgument` is `wWhichTrade`'s own byte.
@@ -2353,9 +2455,14 @@ static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> 
 	if address == int(layout.get("npc_sprite_offset", -1)) and state.has("npc_path"):
 		state["a"] = 0
 		state["a_symbolic"] = "npc_y_distance"
+	if address == int(layout.get("trainer_header_flag_bit", -1)):
+		state["a"] = 0
+		state["a_runtime"] = address
 	var temps: Dictionary = state.get("mem", {})
 	if temps.has(address):
 		state["a"] = int(temps[address])
+		state.erase("a_runtime")
+		state.erase("source")
 	if address == int(layout.get("which_trade", -1)) and state.has("coord_array"):
 		state["a"] = 0
 		state["a_symbolic"] = Gen1Layout.SCRIPT_SYMBOLIC_COORD_INDEX
@@ -2496,9 +2603,27 @@ static func _script_stored_safari(
 	return STORE_OK
 
 
+static func _script_snapshot_flags(ctx: Dictionary, state: Dictionary, out: Array) -> void:
+	if state.has("tests_snapshot"):
+		return
+	var tests: Variant = state.get("tests", -1)
+	if not tests is Array and int(tests) < 0:
+		return
+	var id: int = int(ctx.get("flag_snapshots", 0))
+	ctx["flag_snapshots"] = id + 1
+	var node: Dictionary = {"op": "flag_test", "snapshot": id,
+		"flag": int(tests[0]) if tests is Array else int(tests),
+		"engine": bool(state.get("tests_engine", false))}
+	if tests is Array:
+		node["all" if bool(state.get("tests_all", false)) else "either"] = tests.slice(1)
+	out.append(node)
+	state["tests_snapshot"] = id
+
+
 static func _script_stored_flag_byte(
 	ctx: Dictionary, address: int, state: Dictionary, out: Array
 ) -> bool:
+	_script_snapshot_flags(ctx, state, out)
 	var same: bool = address == int(state.get("source", -1))
 	if same and state.has("mask_set"):
 		for bit: int in 8:
@@ -2637,6 +2762,11 @@ static func _script_stored_scratch(
 	for name: String in Gen1Layout.SCRIPT_SCRATCH_BYTES:
 		if address == int(layout.get(name, -1)) and state.has("a"):
 			out.append({"op": "scratch", "address": address, "value": int(state["a"])})
+			if name == "trainer_header_flag_bit":
+				var temps: Dictionary = (state.get("mem", {}) as Dictionary).duplicate()
+				temps[address] = int(state["a"])
+				state["mem"] = temps
+				return STORE_OK
 	return _script_stored_sprite({}, layout, address, state, out)
 
 
@@ -2763,6 +2893,8 @@ static func _script_stored_more(
 			if source == int(layout.get("fossil_item", -1)) else 0)
 	if address == int(layout["item_to_remove"]) and marked != 0:
 		state["remove"] = marked
+		return true
+	if address == int(layout["item_to_remove"]) and state.has("a_runtime"):
 		return true
 	if address != int(layout["item_to_remove"]) or int(state.get("a", 0)) < 1:
 		return false
@@ -2940,7 +3072,8 @@ static func _script_tests_byte(layout: Dictionary, source: int, state: Dictionar
 		return [SCRIPT_TESTS_ITEM, false]
 	if source == Gen1Layout.SCRIPT_FLAG_ACTION_SOURCE and state.has("flag_action"):
 		var action: Array = state["flag_action"]
-		return [int(action[0]), bool(action[1])]
+		return [SCRIPT_TESTS_INDEXED_FLAG if int(action[2]) >= 0 else int(action[0]),
+			bool(action[1])]
 	if source == int(layout.get("saved_coord_index", -1)):
 		state["coord_index"] = 0
 		return [SCRIPT_TESTS_SAVED_INDEX, false]
@@ -3041,6 +3174,7 @@ static func _script_prefix(
 	}
 	if written < 0:
 		node["engine"] = true
+	_script_snapshot_flags(ctx, state, out)
 	out.append(node)
 	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 
@@ -3137,6 +3271,8 @@ static func _script_special_body(ctx: Dictionary, pc: int) -> Variant:
 	var layout: Dictionary = ctx["layout"]
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
+	if pc == int(layout.get("update_gym_gates", -1)):
+		return _script_gym_gates(ctx)
 	if at != int(layout.get("route23_default_script", -1)):
 		return null
 	var guards: int = Gen1Layout.banked(int(ctx["bank"]), rom.u16le(at + 1))
@@ -3186,6 +3322,9 @@ static func _script_call(
 	if shaped != SCRIPT_NOT_SHAPED:
 		return next if shaped == SCRIPT_SHAPE_READ else SCRIPT_UNREAD
 	match routine:
+		"update_gym_gates":
+			out.append_array(_script_gym_gates(ctx))
+			return next
 		"print_text":
 			var box: Dictionary = _script_box(ctx, int(state.get("hl", 0)))
 			if box.is_empty():
@@ -3371,6 +3510,22 @@ static func _script_fill_memory(
 	buffer.fill(int(state["a"]))
 	state["walk_buffer"] = buffer
 	return next
+
+
+## `UpdateCinnabarGymGateTileBlocks_` counts gates six through one.
+static func _script_gym_gates(ctx: Dictionary) -> Array:
+	var rom: RomFile = ctx["rom"]
+	var table: int = int((ctx["layout"] as Dictionary)["gym_gate_coords"])
+	var nodes: Array = []
+	for gate: int in range(6, 0, -1):
+		var at: int = table + (gate - 1) * 4
+		var block: Dictionary = {"op": "replace_block", "x": rom.u8(at),
+			"y": rom.u8(at + 1), "block": 0x0E}
+		var closed: Dictionary = block.duplicate()
+		closed["block"] = rom.u8(at + 2)
+		nodes.append({"op": "branch", "flag": 0x2A8 + gate,
+			"then": [block], "else": [closed]})
+	return nodes
 
 
 ## `hSpriteDataOffset` shares `hWarpDestinationMap`'s byte.
@@ -4128,20 +4283,26 @@ static func _script_flag_action(layout: Dictionary, state: Dictionary, out: Arra
 	var ctx: Dictionary = {"layout": layout}
 	var flag: int = _script_flag(ctx, int(state["hl"]), int(state["c"]))
 	var engine: bool = flag < 0
+	var runtime: int = int(state.get("c_runtime", -1))
 	if engine:
 		flag = _script_engine_flag(ctx, int(state["hl"]), int(state["c"]))
 	if flag < 0:
 		return STORE_REFUSED
 	match int(state["b"]):
 		Gen1Layout.FLAG_ACTION_TEST:
+			state["c_offset"] = int(state["c"])
 			state.erase("c")
 			state["c_source"] = Gen1Layout.SCRIPT_FLAG_ACTION_SOURCE
-			state["flag_action"] = [flag, engine]
+			state["flag_action"] = [flag, engine, runtime, int(state.get("c_offset", 0))]
 		Gen1Layout.FLAG_ACTION_SET, Gen1Layout.FLAG_ACTION_RESET:
 			var node: Dictionary = {"op": "flag", "flag": flag,
 				"set": int(state["b"]) == Gen1Layout.FLAG_ACTION_SET}
 			if engine:
 				node["engine"] = true
+			if runtime >= 0:
+				node["index_source"] = runtime
+				node["index_offset"] = int(state["c"])
+				node["flag"] = flag - int(state["c"])
 			out.append(node)
 		_:
 			return STORE_REFUSED
@@ -4591,7 +4752,8 @@ static func _script_compared_more(
 static func _script_compared_byte(
 	layout: Dictionary, state: Dictionary, source: int, value: int
 ) -> bool:
-	if state.has("a") and not state.has("source") and not state.has("a_symbolic"):
+	if state.has("a") and not state.has("source") and not state.has("a_symbolic") \
+		and not state.has("a_runtime"):
 		_script_untested(state)
 		state["known_zero"] = int(state["a"]) == value
 		return true
@@ -4604,7 +4766,8 @@ static func _script_compared_byte(
 		int(layout.get("random_add", -1)): ["random_below", SCRIPT_TESTS_RANDOM, 0],
 		int(layout.get("sprite_index_wram", -1)): ["talking", SCRIPT_TESTS_TALKING, -1],
 	}
-	if source == int(layout.get("rival_starter_ball", -1)):
+	if source in [int(layout.get("rival_starter_ball", -1)),
+		int(layout.get("trainer_header_flag_bit", -1))]:
 		state["scratch_test"] = [source, value]
 		_script_tested(state, SCRIPT_TESTS_SCRATCH)
 		return true
@@ -4698,6 +4861,10 @@ static func _script_node(
 ) -> Variant:
 	var taken: Array = branches[0] if branches[0] != null else [{"op": "unknown"}]
 	var fell: Array = branches[1] if branches[1] != null else [{"op": "unknown"}]
+	if state.has("tests_snapshot"):
+		var all: bool = bool(state.get("tests_all", false))
+		return {"op": "branch", "snapshot": int(state["tests_snapshot"]),
+			"then": fell if all else taken, "else": taken if all else fell}
 	if tests is Array:
 		var rest: Array = (tests as Array).slice(1)
 		var all: bool = bool(state.get("tests_all", false))
@@ -4705,6 +4872,11 @@ static func _script_node(
 			"all" if all else "either": rest,
 			"then": fell if all else taken, "else": taken if all else fell}
 	match int(tests):
+		SCRIPT_TESTS_INDEXED_FLAG:
+			var action: Array = state["flag_action"]
+			return {"op": "branch", "flag": int(action[0]) - int(action[3]),
+				"index_source": int(action[2]), "index_offset": int(action[3]),
+				"then": taken, "else": fell}
 		SCRIPT_TESTS_CHOICE:
 			return {"op": "choice", "no": taken, "yes": fell}
 		SCRIPT_TESTS_CARRY:
@@ -4924,7 +5096,8 @@ static func _extend_texts(
 	var table: int = Gen1Layout.banked(bank, address)
 	while texts.size() < highest:
 		texts.append(_read_text(
-			rom, layout, bank, rom.u16le(table + texts.size() * Gen1Layout.POINTER_SIZE)
+			rom, layout, bank, rom.u16le(table + texts.size() * Gen1Layout.POINTER_SIZE),
+			texts.size() + 1
 		))
 	return true
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 127
+const FORMAT_VERSION: int = 128
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3941,6 +3941,7 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"text": &"_gen1_node_text",
 	"flag": &"_gen1_node_flag",
 	"branch": &"_gen1_node_branch",
+	"flag_test": &"_gen1_node_flag_test",
 	"has_item": &"_gen1_node_has_item",
 	"has_money": &"_gen1_node_has_money",
 	"has_coins": &"_gen1_node_has_coins",
@@ -4217,6 +4218,7 @@ func _gen1_run(event: Dictionary) -> Dictionary:
 		"bag": state.items() if state != null else {}, "named": "", "object": event,
 		"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
 		"coins": state.coins() if state != null else 0,
+		"flags": {}, "engine_flags": {}, "flag_tests": {}, "scratch": _gen1_scratch.duplicate(),
 	}
 
 
@@ -4245,10 +4247,20 @@ func _gen1_node_text(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	return true
 
 
-func _gen1_node_flag(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_flag_index(node: Dictionary, run: Dictionary) -> int:
+	var index: int = int(node["flag"])
+	if node.has("index_source"):
+		index += (int((run["scratch"] as Dictionary).get(int(node["index_source"]), 0))
+			+ int(node.get("index_offset", 0))) & 0xFF
+	return index
+
+
+func _gen1_node_flag(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var shadow: Dictionary = run["engine_flags" if bool(node.get("engine", false)) else "flags"]
+	shadow[_gen1_node_flag_index(node, run)] = bool(node["set"])
 	steps.append({
 		"type": &"flag",
-		"flag": int(node["flag"]),
+		"flag": _gen1_node_flag_index(node, run),
 		"set": bool(node["set"]),
 		"engine": bool(node.get("engine", false)),
 	})
@@ -4264,7 +4276,7 @@ func _gen1_node_replace_block(node: Dictionary, steps: Array, _run: Dictionary) 
 
 
 func _gen1_node_branch(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	return _gen1_resolve_side(node, _gen1_branch_set(node), steps, run)
+	return _gen1_resolve_side(node, _gen1_branch_set(node, run), steps, run)
 
 
 func _gen1_node_has_item(node: Dictionary, steps: Array, run: Dictionary) -> bool:
@@ -4769,14 +4781,15 @@ func _gen1_node_name_badge(node: Dictionary, _steps: Array, run: Dictionary) -> 
 	return true
 
 
-func _gen1_node_scratch(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_scratch(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	(run["scratch"] as Dictionary)[int(node["address"])] = int(node["value"])
 	steps.append({"type": &"scratch", "address": int(node["address"]), "value": int(node["value"])})
 	return true
 
 
 func _gen1_node_scratch_test(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	return _gen1_resolve_side(
-		node, int(_gen1_scratch.get(int(node["address"]), 0)) == int(node["value"]), steps, run
+		node, int((run["scratch"] as Dictionary).get(int(node["address"]), 0)) == int(node["value"]), steps, run
 	)
 
 
@@ -4914,8 +4927,15 @@ func _gen1_node_trainer_battle_object(
 	var index: int = _gen1_last_sprite_index
 	if index < 0 or index >= objects.size():
 		return false
-	var trainer: Dictionary = (objects[index] as Gen2WorldObject).trainer_data
-	if trainer.is_empty():
+	var rows: Array = current_map.events.get("objects", [])
+	if index >= rows.size():
+		return false
+	var trainer: Dictionary = rows[index]
+	if trainer.has("species"):
+		steps.append({"type": &"request", "values": {"kind": &"battle_requested",
+			"values": _gen1_battle_values({}, trainer)}})
+		return true
+	if not trainer.has("trainer_class"):
 		return false
 	steps.append(_gen1_trainer_request(
 		int(trainer.get("trainer_class", 0)), int(trainer.get("trainer_number", 1)),
@@ -4988,10 +5008,10 @@ func _gen1_node_reset_game(_node: Dictionary, steps: Array, _run: Dictionary) ->
 	return true
 
 
-func _gen1_node_flag_range(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_flag_range(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	var first: int = int(node["first"])
 	for offset: int in int(node["count"]):
-		steps.append({"type": &"flag", "flag": first + offset, "set": bool(node["set"])})
+		_gen1_node_flag({"flag": first + offset, "set": bool(node["set"])}, steps, run)
 	return true
 
 
@@ -5071,23 +5091,32 @@ func _gen1_node_pokedex(node: Dictionary, steps: Array, _run: Dictionary) -> boo
 	return true
 
 
-## `CheckEvent`'s one flag, or `CheckEitherEventSet`'s mask over the flags of
-## one `wEventFlags` byte, which is set when any of them is. A row may read one
-## of Generation 1's own saved bytes instead, which the engine flags hold.
-## One flag, or the run a mask named: `either` is `CheckEitherEventSet`'s own
-## any and `all` is `CheckBothEventsSet`'s every.
-func _gen1_branch_set(node: Dictionary) -> bool:
+func _gen1_run_flag(flag: int, run: Dictionary) -> bool:
+	return bool((run["flags"] as Dictionary).get(flag, event_flag_active(flag)))
+
+
+func _gen1_node_flag_test(node: Dictionary, _steps: Array, run: Dictionary) -> bool:
+	var condition: Dictionary = node.duplicate()
+	condition.erase("snapshot")
+	run["flag_tests"][int(node["snapshot"])] = _gen1_branch_set(condition, run)
+	return true
+
+
+func _gen1_branch_set(node: Dictionary, run: Dictionary) -> bool:
+	if node.has("snapshot"):
+		return bool(run["flag_tests"][int(node["snapshot"])])
 	if bool(node.get("engine", false)):
-		return state != null and state.is_engine_flag_active(int(node["flag"]))
-	var first: bool = event_flag_active(int(node["flag"]))
+		return bool((run["engine_flags"] as Dictionary).get(int(node["flag"]),
+			state != null and state.is_engine_flag_active(int(node["flag"]))))
+	var first: bool = _gen1_run_flag(_gen1_node_flag_index(node, run), run)
 	if node.has("all"):
 		for flag: int in node["all"] as Array:
-			first = first and event_flag_active(flag)
+			first = first and _gen1_run_flag(flag, run)
 		return first
 	if first:
 		return true
 	for flag: int in node.get("either", []):
-		if event_flag_active(flag):
+		if _gen1_run_flag(flag, run):
 			return true
 	return false
 
@@ -5529,17 +5558,7 @@ func _gen1_last_box(steps: Array) -> int:
 
 
 func _gen1_run_copy(run: Dictionary) -> Dictionary:
-	return {
-		"bag": (run["bag"] as Dictionary).duplicate(),
-		"named": run["named"],
-		"buffers": (run.get("buffers", {}) as Dictionary).duplicate(),
-		"object": run.get("object", {}),
-		"money": run.get("money", 0),
-		"coins": run.get("coins", 0),
-		"menu": run.get("menu", {}),
-		"fossil": (run.get("fossil", {}) as Dictionary).duplicate(),
-		"party": (run.get("party", {}) as Dictionary).duplicate(),
-	}
+	return run.duplicate(true)
 
 
 func _gen1_script_box(
@@ -5766,6 +5785,7 @@ func _gen1_trainer_steps(row: Dictionary, event: Dictionary) -> Array:
 		return []
 	var header: Dictionary = raw as Dictionary
 	var flag: int = int(header["event_flag"])
+	_gen1_scratch[int(Gen1Layout.for_id(data.id)["trainer_header_flag_bit"])] = flag % 8
 	if event_flag_active(flag):
 		return [{"type": &"text", "text": String(header["after"])}]
 	return [

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -104,11 +104,15 @@ const LAYOUT: Dictionary = {
 	"check_boulder_coords": 0x0440,
 	"trainer_no": 0xD05D,
 	"rival_starter": 0xD715,
+	"sprite_pointer_1": 0x0450,
+	"warp_destination_map": 0xFF8B,
+	"trainer_header_flag_bit": 0xCC55,
+	"flag_action": 0x0460,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
 const PREDEFS: Dictionary = {
 	1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240, 5: 0x0250, 6: 0x0270,
-	7: 0x02C0,
+	7: 0x02C0, 8: 0x0460,
 }
 const AT: int = 0x1000
 const HELLO: int = 0x1800
@@ -1112,3 +1116,44 @@ func _raw_at(address: int, bytes: Array) -> Dictionary:
 	for index: int in bytes.size():
 		out[address + index] = int(bytes[index])
 	return out
+
+
+func test_nested_sprite_pointer_saves_restore_each_position() -> void:
+	var program: Array = _load_hl(0xC225) + [0xE5, 0x3E, 2, 0xE0, 0x8C,
+		0x3E, 4, 0xE0, 0x8B] + _call(0x0450) + [0xE5, 0x36, 0x4C,
+		0x23, 0x23, 0x36, 0, 0xE1, 0x24, 0x36, 8, 0x23, 0x36, 9,
+		0xE1, 0x36, 10, 0xC9]
+	assert_eq(_decode(program), [
+		{"op": "object_position", "object": 1, "axis": "y", "value": 4},
+		{"op": "object_position", "object": 1, "axis": "x", "value": 5},
+		{"op": "object_position", "object": 1, "axis": "x", "value": 6},
+	])
+
+
+func test_indexed_flag_action_keeps_the_byte_offset_and_both_arms() -> void:
+	var program: Array = _load_a(0xCC55) + [0xD6, 2, 0x4F, 0x06, 2] \
+		+ _load_hl(0xD747) + [0x3E, 8] + _call(0x01A0) \
+		+ [0x79, 0xA7, 0xC0] + _print(HELLO) + [0xC9]
+	assert_eq(_decode(program, _boxes()), [
+		{"op": "branch", "flag": 0, "index_source": 0xCC55, "index_offset": 254,
+			"then": [], "else": [{"op": "text", "text": "HI"}]},
+	])
+
+
+func test_indexed_flag_action_sets_and_resets_a_runtime_bit() -> void:
+	for action: int in [0, 1]:
+		var program: Array = _load_a(0xCC55) + [0xD6, 2, 0x4F, 0x06, action] \
+			+ _load_hl(0xD748) + [0x3E, 8] + _call(0x01A0) + [0xC9]
+		assert_eq(_decode(program), [{"op": "flag", "flag": 8,
+			"set": action == 1, "index_source": 0xCC55, "index_offset": 254}])
+
+
+func test_flag_reset_preserves_the_preceding_bit_test() -> void:
+	var program: Array = _load_hl(0xD747) + [0xCB, 0x46, 0xCB, 0x86, 0xC0] \
+		+ _print(HELLO) + [0xC9]
+	assert_eq(_decode(program, _boxes()), [
+		{"op": "flag_test", "snapshot": 0, "flag": 0, "engine": false},
+		{"op": "flag", "flag": 0, "set": false},
+		{"op": "branch", "snapshot": 0, "then": [],
+			"else": [{"op": "text", "text": "HI"}]},
+	])

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -21,7 +21,7 @@ const MAX_COMMENT_BLOCK: int = 8
 ## the shared code, the largest of them 152 the region map, 150 the battle
 ## animation engine, 140 the transition, 131 the field moves, 130 the Pokedex,
 ## 108 the three PCs, 90 the Safari Zone, 52 the menus a row draws.
-const MAX_COMMENT_LINES: int = 42012
+const MAX_COMMENT_LINES: int = 42002
 
 ## What no comment block ever ends on. A pass that meets the ceiling above trims
 ## the second line of a two-line block and leaves the first mid-sentence, which

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -10075,3 +10075,31 @@ func test_gen1_wanderer_climbs_eight_cells_and_never_comes_back_down() -> void:
 	assert_eq(highest, walker.initial_cell.y - 8, "it stopped short of its counter")
 	assert_eq(walker.cell.y, walker.initial_cell.y - 8, "it left the top of its band")
 	RomCache.clear(_gen1_directory())
+
+
+func test_gen1_script_branches_read_pending_flags_and_scratch_in_each_choice() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 2))
+	var source: int = 0xCC55
+	var chosen: Array = [
+		{"op": "scratch", "address": source, "value": 5},
+		{"op": "flag", "flag": 680, "index_source": source, "index_offset": 254, "set": true},
+		{"op": "branch", "flag": 683, "then": [{"op": "text", "text": "OPEN"}], "else": []},
+		{"op": "flag_test", "snapshot": 0, "flag": 683},
+		{"op": "flag_range", "first": 683, "count": 1, "set": false},
+		{"op": "branch", "snapshot": 0, "then": [{"op": "text", "text": "WAS OPEN"}], "else": []},
+		{"op": "branch", "flag": 683, "then": [], "else": [{"op": "text", "text": "CLOSED"}]},
+	]
+	var steps: Array = world._gen1_script_steps({"script": [
+		{"op": "text", "text": "QUESTION"},
+		{"op": "choice", "yes": chosen, "no": [
+			{"op": "branch", "flag": 683, "then": [], "else": [{"op": "text", "text": "NO"}]},
+		]},
+	]})
+	assert_false(steps.is_empty())
+	if not steps.is_empty():
+		assert_eq((steps[0]["yes"] as Array).filter(func(row: Dictionary) -> bool:
+			return row["type"] == &"text").map(func(row: Dictionary) -> String:
+			return row["text"]), ["OPEN", "WAS OPEN", "CLOSED"])
+		assert_eq(steps[0]["no"], [{"type": &"text", "text": "NO"}])
+	assert_false(world.state.is_event_flag_active(683), "planning a choice writes no save flags")
+	RomCache.clear(_gen1_directory())

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -135,7 +135,7 @@ const SCRIPT_CENSUS: Dictionary = {
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 35, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
 		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
@@ -144,13 +144,14 @@ const SCRIPT_CENSUS: Dictionary = {
 		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
-		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
+		"flag_test": 3},
 	&"blue": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
 		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 0, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 28, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 35, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
 		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
 		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
@@ -159,22 +160,24 @@ const SCRIPT_CENSUS: Dictionary = {
 		"elevator": 3, "coin_box": 2, "has_coins": 4, "add_coins": 4, "replace_block": 1,
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
-		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
-	&"yellow": {"rows": 370, "text": 583, "branch": 154, "choice": 34, "flag": 221,
-		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 11, "pokedex": 10,
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
+		"flag_test": 3},
+	&"yellow": {"rows": 370, "text": 601, "branch": 160, "choice": 34, "flag": 221,
+		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 5, "pokedex": 10,
 		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 23,
-		"set_map_script": 75, "npc_movement_script": 2, "toggle_object": 22,
-		"trainer_battle_object": 15, "random": 5, "facing": 12, "player_in_array": 1,
-		"name_species": 6, "pick_up_item": 109, "scratch": 20, "name_badge": 7,
+		"set_map_script": 99, "npc_movement_script": 2, "toggle_object": 22,
+		"trainer_battle_object": 27, "random": 5, "facing": 12, "player_in_array": 1,
+		"name_species": 6, "pick_up_item": 109, "scratch": 27, "name_badge": 7,
 		"player_facing": 15, "heal_party": 2, "emote": 7, "dex_rating": 2, "dex_count": 6,
 		"map_text": 24, "trade": 7, "name_item": 7, "oaks_aide": 3, "player_coord": 4,
 		"money_box": 6, "has_money": 5, "spend_money": 4, "menu": 3, "menu_cancel": 3,
 		"menu_row": 1, "guard_drink": 4, "day_care": 1, "random_bit": 2, "volatile": 1,
 		"filtered_bag": 2, "menu_item": 4, "elevator": 3, "coin_box": 2, "has_coins": 4,
 		"add_coins": 4, "replace_block": 1, "trainer_battle": 1, "safari_balls": 3,
-		"safari_steps": 3, "safari_admission": 2, "save_coord_index": 2, "talking_to": 2,
+		"safari_steps": 3, "safari_admission": 2, "save_coord_index": 2, "talking_to": 14,
 		"copy_name": 4, "set_fossil": 6, "list_menu": 1,
-		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1},
+		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
+		"flag_test": 6, "volatile_test": 6},
 }
 ## `SilphCo11FPorygonText` is a `call DisplayPokedex` the disassembly marks
 ## unreferenced. The `trade` rows are the eight `predef DoInGameTradeDialogue`
@@ -216,52 +219,55 @@ const CARD_KEY_FLOORS: int = 10
 ## `read` the ones whose body decodes whole; `blocks` counts the
 ## `ReplaceTileBlock` writes on every branch of those bodies.
 const CALLBACK_CENSUS: Dictionary = {
-	&"red": {"gated": 36, "read": 24, "blocks": 85, "doors": 20, "floors": 10},
-	&"blue": {"gated": 36, "read": 24, "blocks": 85, "doors": 20, "floors": 10},
-	&"yellow": {"gated": 34, "read": 22, "blocks": 82, "doors": 20, "floors": 10},
+	&"red": {"gated": 36, "read": 26, "blocks": 99, "doors": 20, "floors": 10},
+	&"blue": {"gated": 36, "read": 26, "blocks": 99, "doors": 20, "floors": 10},
+	&"yellow": {"gated": 34, "read": 24, "blocks": 96, "doors": 20, "floors": 10},
 }
 
 ## The maps with a state machine, the states reachable from index 0 and from
 ## every `set_map_script` already read, and the bodies the walker gets whole.
 const STATE_CENSUS: Dictionary = {
-	&"red": {"tables": 98, "states": 203, "read": 144, "branch": 52, "player_coord": 33,
-		"player_facing": 40, "flag": 250, "set_map_script": 224, "save_coord_index": 9,
+	&"red": {"tables": 98, "states": 203, "read": 144, "branch": 65, "player_coord": 33,
+		"player_facing": 40, "flag": 254, "set_map_script": 227, "save_coord_index": 9,
 		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
 		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
 		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
-		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
+		"player_in_array": 30, "riding": 4, "object_move": 52, "object_position": 8,
 		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
 		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
-		"unknown": 2, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
-		"trainer_battle_object": 1},
-	&"blue": {"tables": 98, "states": 203, "read": 144, "branch": 52, "player_coord": 33,
-		"player_facing": 40, "flag": 250, "set_map_script": 224, "save_coord_index": 9,
+		"trainer_battle_object": 1,
+		"flag_test": 15, "replace_block": 24},
+	&"blue": {"tables": 98, "states": 203, "read": 144, "branch": 65, "player_coord": 33,
+		"player_facing": 40, "flag": 254, "set_map_script": 227, "save_coord_index": 9,
 		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
 		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
 		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
-		"player_in_array": 30, "riding": 4, "object_move": 51, "object_position": 6,
+		"player_in_array": 30, "riding": 4, "object_move": 52, "object_position": 8,
 		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
 		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
-		"unknown": 2, "badge_guards": 1, "give_item": 9, "arrow_movement": 3,
+		"badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
-		"trainer_battle_object": 1},
-	&"yellow": {"tables": 98, "states": 205, "read": 150, "branch": 65, "player_coord": 46,
-		"flag": 254, "player_facing": 39, "set_map_script": 233, "save_coord_index": 11,
-		"map_text": 122, "object_position": 6, "toggle_object": 153, "object_facing": 50,
+		"trainer_battle_object": 1,
+		"flag_test": 15, "replace_block": 24},
+	&"yellow": {"tables": 98, "states": 207, "read": 152, "branch": 84, "player_coord": 46,
+		"flag": 280, "player_facing": 39, "set_map_script": 240, "save_coord_index": 11,
+		"map_text": 125, "object_position": 6, "toggle_object": 153, "object_facing": 50,
 		"set_player_coord": 1, "object_path": 1, "movement_running": 50, "wild_battle": 6,
 		"npc_movement_script": 1, "movement_script_running": 2, "badges_byte": 2, "walk": 35,
 		"object_move": 53, "player_in_array": 33, "riding": 4, "coord_index": 17,
-		"trainer_battle": 7, "battle_outcome": 26, "object_stay": 10, "facing": 4,
+		"trainer_battle": 7, "battle_outcome": 28, "object_stay": 10, "facing": 4,
 		"has_item": 4, "emote": 2, "saved_coord_index": 18, "starter": 1, "set_starter": 1,
-		"badge_guards": 1, "give_item": 8, "arrow_movement": 3, "guard_drink": 4,
-		"unknown": 1, "volatile_test": 2, "volatile": 3, "boulder_on": 3, "hall_of_fame": 1,
+		"badge_guards": 1, "give_item": 9, "arrow_movement": 3, "guard_drink": 4,
+		"unknown": 1, "volatile_test": 2, "volatile": 5, "boulder_on": 3, "hall_of_fame": 1,
 		"set_blackout_map": 1, "save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1,
-		"set_last_map": 1, "safari_balls": 1, "coord_lookup": 3, "trainer_battle_object": 2},
+		"set_last_map": 1, "safari_balls": 1, "coord_lookup": 3, "trainer_battle_object": 2,
+		"flag_test": 18, "replace_block": 36, "scratch_test": 1},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -359,6 +365,7 @@ func _one_game() -> void:
 	_palettes()
 	_sprites()
 	_safari()
+	_cinnabar_gate_corpus()
 
 
 func _counts() -> void:
@@ -700,7 +707,7 @@ func _walk_script(
 		if op == "text" and not _drawn(font, String(node["text"]).replace("\n", "")) \
 			and wrong.size() < 4:
 			wrong.append("map %d draws a blank tile" % number)
-		if op == "flag" or op == "branch":
+		if node.has("flag") and op in ["flag", "branch", "flag_test"]:
 			var flag: int = int(node["flag"])
 			if (flag < 0 or flag >= Gen1Layout.EVENT_FLAG_BYTES * 8) and wrong.size() < 4:
 				wrong.append("map %d names flag %d" % [number, flag])
@@ -1256,3 +1263,28 @@ func _safari() -> void:
 	_r.note("gen1 safari %d zone maps, %d with the step window, %d gate states" % [
 		battle_maps, window_maps, SAFARI_STATES,
 	])
+
+
+func _cinnabar_gate_corpus() -> void:
+	var map: Gen2WorldMap = _maps[166]
+	var callbacks: Array = map.scripts["callbacks"]
+	if not _r.check(not callbacks.is_empty(), "Cinnabar has no map-load callback"):
+		return
+	var lines := PackedStringArray()
+	for mask: int in 128:
+		var state := Gen2WorldState.new()
+		for bit: int in 7:
+			state.set_event_flag(0x2A8 + bit, (mask & (1 << bit)) != 0)
+		var world: Gen2WorldAPI = _r.open_world(0, 166, Vector2i(17, 3), state)
+		if world == null:
+			return
+		var steps: Array = world._gen1_script_steps({"script": callbacks[0]["nodes"]})
+		var writes := PackedStringArray()
+		for step: Dictionary in steps:
+			if step["type"] == &"block":
+				writes.append("%d,%d,%d" % [step["x"], step["y"], step["block"]])
+		lines.append("%d:%s" % [mask, ";".join(writes)])
+	var digest: String = ("\n".join(lines) + "\n").sha256_text()
+	if _r.check(digest == "69f96f320d03eba9bdd86b113c71276a00ebb5bdc1c1770adc1fcf156214a38a",
+		"Cinnabar's 128 gate masks differ from the cartridge's block-write trace: %s" % digest):
+		_r.note("gen1 Cinnabar: 128 masks, 768 block writes match the cartridge")

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -447,6 +447,7 @@ func run(r: RefCounted) -> void:
 
 
 func _one_game() -> void:
+	_check_cinnabar_gates()
 	_check_warps()
 	_check_ledges()
 	_check_last_map_round_trip()
@@ -3254,3 +3255,62 @@ func _safari_offer(purse: int, state: Gen2WorldState = null) -> Gen2WorldAPI:
 		not String(world.pending_script_input().get("text", "")).is_empty(),
 		"the SAFARI ZONE gate offered nothing on a %d purse." % purse
 	) else null
+
+
+const CINNABAR_GYM: int = 166
+const CINNABAR_GATES: Array[Vector2i] = [
+	Vector2i(9, 3), Vector2i(6, 3), Vector2i(6, 6),
+	Vector2i(3, 8), Vector2i(2, 6), Vector2i(2, 3),
+]
+
+
+func _check_cinnabar_gates() -> void:
+	for trainer: int in range(1, 8):
+		for won: bool in [false, true]:
+			_check_cinnabar_trainer(trainer, won)
+	_r.note("gen1 Cinnabar: seven trainers, both battle outcomes, six gates and re-entry")
+
+
+func _check_cinnabar_trainer(trainer: int, won: bool) -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CINNABAR_GYM, Vector2i(17, 3))
+	if world == null:
+		return
+	world.dispatch_map_entry()
+	var object: Dictionary = (world.current_map.events["objects"] as Array)[trainer]
+	world.player_cell = Vector2i(int(object["x"]), int(object["y"]) + 1)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if _r.game_id == RomRegistry.YELLOW and trainer > 1:
+		_r.check(not _event_text(world.interact()).is_empty(), "the quiz requirement has no text")
+		world.run_event_queue(true)
+		_r.check(world.pending_runtime_request().is_empty(), "a trainer skipped Yellow's quiz gate")
+		world._gen1_volatile["gym_quiz_answered"] = true
+	world.interact()
+	for _pass: int in 12:
+		if not world.pending_runtime_request().is_empty():
+			break
+		world.run_event_queue(true)
+	if not _r.check(StringName(world.pending_runtime_request().get("kind", &"")) \
+		== &"battle_requested", "Cinnabar trainer %d never requested a battle" % trainer):
+		return
+	world.complete_runtime_request({"ok": true, "outcome": &"won" if won else &"lost"})
+	for _pass: int in 12:
+		world.run_event_queue(true)
+		world.dispatch_sight_events()
+	_r.check(world.event_flag_active(665 + trainer) == won, "the trainer's beaten flag is wrong")
+	_r.check(world.event_flag_active(679 + trainer) == won, "the trainer's gate flag is wrong")
+	_check_cinnabar_blocks(world, trainer, won)
+	var returned: Gen2WorldAPI = _r.open_world(0, CINNABAR_GYM, Vector2i(17, 3), world.state)
+	if returned != null:
+		returned.dispatch_map_entry()
+		_check_cinnabar_blocks(returned, trainer, won)
+
+
+func _check_cinnabar_blocks(world: Gen2WorldAPI, trainer: int, won: bool) -> void:
+	for gate: int in CINNABAR_GATES.size():
+		var cell: Vector2i = CINNABAR_GATES[gate]
+		var expected: int = 0x5F if gate == 3 else 0x54
+		if won and gate == trainer - 2:
+			expected = 0x0E
+		_r.check(world.block_at(cell.x, cell.y) == expected,
+			"trainer %d won=%s gate %d is %02x, expected %02x" % [
+				trainer, won, gate + 1, world.block_at(cell.x, cell.y), expected])

--- a/tools/lib/check_run.gd
+++ b/tools/lib/check_run.gd
@@ -6,8 +6,7 @@ extends RefCounted
 ## reports through [method check] and prints its own census lines with
 ## [method note]; the runner owns the exit code.
 
-## The Generation 2 cartridges, which is what a topic naming these means: every
-## topic here but `gen1_tables` is about that generation's tables and maps.
+## The cartridges used by topics that call `each_game`.
 static var GAME_IDS: Array[StringName] = RomRegistry.ids_of_generation(RomRegistry.GEN2)
 
 ## The party [code]CheckPartyMove[/code] gates every field move against. These

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -13,6 +13,7 @@ extends SceneTree
 ## twice when its name ends in `_use`, or one of [constant FIELD_ITEMS]' names,
 ## which is the pack's USE on that item.
 const KIND_HELP: Dictionary = {
+	&"gym_gates": "gate mask: Cinnabar Gym after its map-entry redraw (`red 0 166 ... gym_gates@17,6 0 0`)",
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
 	&"battle_transition": "frames, index: DoBattleTransition over the map. 1 is the trainer branch; a Generation 1 cartridge reads BattleTransitions' own index, 0 the double circle, 2 the circle, 4 the horizontal stripes, 6 the vertical",
 	&"battle": "frames, 0: the wild fight preview_battle_request starts, settled past its transition. 1 opens the bag over it and 2 plays the POKé FLUTE from it",
@@ -428,6 +429,7 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 ## does not name is a field item, one of the screen's own `preview_*` drivers, or
 ## an overworld effect sprite, in that order.
 const STAGERS: Dictionary = {
+	&"gym_gates": &"_stage_gym_gates",
 	&"unown_wall": &"_stage_unown_wall",
 	&"battle": &"_stage_battle",
 	&"battle_caught": &"_stage_battle",
@@ -566,8 +568,14 @@ func _process(_delta: float) -> bool:
 	return true
 
 
-## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from the cell below it
-## and read it, which is the only way in.
+func _stage_gym_gates() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	for bit: int in 7:
+		world.state.set_event_flag(0x2A8 + bit, (_cell.x & (1 << bit)) != 0)
+	world.dispatch_callbacks()
+	_screen._renderer.refresh()
+
+
 func _stage_unown_wall() -> void:
 	_screen.move_up()
 	_screen.interact()


### PR DESCRIPTION
Oak's lab now preserves nested sprite pointers when placing the rival, and Cinnabar Gym resolves indexed trainer and gate flags in Red, Blue, and Yellow. Map entry runs each gated callback so closed doors are restored and defeated trainers' gates stay open after re-entry.

Script resolution now carries pending flag and scratch writes through independent choice branches while preserving the CPU condition of a bit test followed by a reset. Scripted battles read the imported object records for both trainers and standing wild Pokémon.

Cache format 128 requires cartridge reimport.

Validation:
- 512 affected unit tests.
- All 128 Cinnabar gate masks per cartridge compared against emulator block-write traces; all seven trainers checked after wins, losses, and re-entry.
- 618 integration tests; 33 deterministic replay routes with no failures.
- Gold and Silver story walks: 293 steps each; Crystal: 296 steps; all reach 16 badges.
- Every validation topic passes, with the Gen 1 corpus rerun after the final fix.
- Editor analyzer: zero warnings across 637 scripts.
- Closed/open gate screenshots inspected; deliberately corrupting a gate block makes the cartridge comparison fail.
- Boot smoke checks pass with and without mods; release gates pass.
