### PR TITLE
Walk a Generation 1 map's load body and the rows a fight leaves behind

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -1095,6 +1095,7 @@ const SCRIPT_INC_HL: int = 0x23
 const SCRIPT_INC_DE: int = 0x13
 const SCRIPT_DEC_B: int = 0x05
 const SCRIPT_CP_B: int = 0xB8
+const SCRIPT_CP_C: int = 0xB9
 const SCRIPT_LD_A_HL: int = 0x7E
 const SCRIPT_ADD_N: int = 0xC6
 const SCRIPT_LD_H_D: int = 0x62
@@ -1133,6 +1134,7 @@ const NPC_MOVEMENT_MAX: int = 32
 const SCRIPT_WRAM_BASE: int = 0xC000
 const SCRIPT_PREFIX: int = 0xCB
 const SCRIPT_JR: int = 0x18
+const SCRIPT_JR_NZ: int = 0x20
 const SCRIPT_JP: int = 0xC3
 const SCRIPT_RET: int = 0xC9
 const SCRIPT_CALL: int = 0xCD
@@ -1150,18 +1152,20 @@ const SCRIPT_PUSH_AF: int = 0xF5
 const SCRIPT_POP_AF: int = 0xF1
 const SCRIPT_PUSH_HL: int = 0xE5
 const SCRIPT_POP_HL: int = 0xE1
-const SCRIPT_STACK_HL: Array[int] = [SCRIPT_PUSH_HL, SCRIPT_POP_HL]
-## The opcode following a map-load gate, `size` its own length and `target`
-## whether the body is where it branches rather than the byte after it.
-const MAP_LOAD_GATE_BRANCHES: Dictionary = {
-	0xC8: {"size": 1, "target": false},
-	0x28: {"size": 2, "target": false},
-	0x20: {"size": 2, "target": true},
-	0xCA: {"size": 3, "target": false},
-	0xC2: {"size": 3, "target": true},
-	0xCC: {"size": 3, "target": false},
-	0xC4: {"size": 3, "target": true},
-}
+const SCRIPT_PUSH_BC: int = 0xC5
+const SCRIPT_POP_BC: int = 0xC1
+const SCRIPT_ADD_B: int = 0x80
+const SCRIPT_LD_D_A: int = 0x57
+const SCRIPT_LD_E_A: int = 0x5F
+const SCRIPT_ADC_B: int = 0x88
+const SCRIPT_SRL_A: int = 0x3F
+## Bytes a script writes and the world keeps by name, `Random` or not.
+const SCRIPT_STORED_BYTES: Array[String] = ["first_lock_trash_can", "lucky_slot_index"]
+const SCRIPT_RANDOM_SOURCES: Array[String] = ["random_add", "random_sub"]
+## BIT_CUR_MAP_LOADED_1 and BIT_CUR_MAP_LOADED_2, which `EnterMap` sets.
+const MAP_LOADED_1_BIT: int = 5
+const MAP_LOADED_2_BIT: int = 6
+const MAP_LOAD_BOTH: int = (1 << MAP_LOADED_1_BIT) | (1 << MAP_LOADED_2_BIT)
 ## A `dbmapcoord` list: `db y, x` rows under a terminator.
 const MAP_COORD_END: int = 0xFF
 const MAP_COORD_SIZE: int = 2
@@ -1186,7 +1190,7 @@ const SCRIPT_CALLS: Array[String] = [
 	"remove_item_from_inventory", "display_list_menu", "copy_to_string_buffer",
 	"delay_frames", "delay_3", "play_default_music", "check_map_trainers",
 	"player_coords_in_array", "start_trainer_battle", "end_trainer_battle",
-	"play_music", "stop_all_music",
+	"play_music", "stop_all_music", "random", "set_sprite_position_2", "set_sprite_image",
 	"set_sprite_facing", "set_sprite_facing_delay", "sprite_stay", "move_sprite",
 	"decode_rle", "decode_arrow_movement", "update_gym_gates",
 	"serial_connect", "fill_memory", "save_end_battle_text", "engage_map_trainer",
@@ -1208,8 +1212,15 @@ const FORCED_WARP_BIT: int = 2
 const NO_MAP_MUSIC_BIT: int = 1
 const NO_TEXT_DELAY_BIT: int = 6
 const SCRIPT_SCRATCH_BYTES: Array[String] = [
-	"which_trade", "rival_starter_ball", "trainer_header_flag_bit",
+	"which_trade", "rival_starter_ball", "trainer_header_flag_bit", "opponent_after_wrong_answer",
 ]
+## The scratch bytes a walk reads as a run-time value.
+const SCRIPT_RUNTIME_SCRATCH: Array[String] = [
+	"trainer_header_flag_bit", "opponent_after_wrong_answer", "sprite_index_wram",
+]
+## `PokemonTower7FNPCCoordMovementTable`: `map_coord_movement` rows, sixteen
+## bytes a rocket, matched against the player's cell.
+const OBJECT_COORD_ROWS: int = 4
 const SCRIPT_FLAG_ACTION_SOURCE: int = -101
 ## The row a hand-drawn menu's cursor stands on, read as an item id.
 const SCRIPT_MENU_ITEM_SOURCE: int = -102
@@ -1250,7 +1261,14 @@ const SCRIPT_SILENT_FLAGS: Dictionary = {
 		| (1 << TALKED_TO_TRAINER_BIT) | (1 << PRINT_END_BATTLE_TEXT_BIT),
 	"status_flags_6": 1 << DUNGEON_WARP_BIT,
 	"pikachu_map_script_flags": 0xFF,
+	## The champion fight turns battle animations on for itself; the sight walk
+	## owns BIT_SEEN_BY_TRAINER and the renderer BIT_NO_SPRITE_UPDATES.
+	"options": 1 << BATTLE_ANIMATION_BIT,
+	"misc_flags": (1 << SEEN_BY_TRAINER_BIT) | (1 << NO_SPRITE_UPDATES_BIT),
 }
+const BATTLE_ANIMATION_BIT: int = 7
+const SEEN_BY_TRAINER_BIT: int = 0
+const NO_SPRITE_UPDATES_BIT: int = 4
 const DUNGEON_WARP_BIT: int = 4
 const WARP_FROM_SCRIPT_BIT: int = 3
 const ON_DUNGEON_WARP_BIT: int = 4
@@ -1275,7 +1293,7 @@ const SCRIPT_VOLATILE_BITS: Dictionary = {
 const SCRIPT_TEMP_BYTES: Array[String] = ["object_to_hide", "object_to_show"]
 ## The sight walk owns engagement; dungeon warps are dispatched separately.
 const SCRIPT_ZERO_SOURCES: Array[String] = [
-	"trainer_header_flag_bit", "opponent_after_wrong_answer", "which_dungeon_warp",
+	"trainer_header_flag_bit", "which_dungeon_warp",
 ]
 ## `wIsInBattle` is LOST_BATTLE when the player lost and `wBattleResult` 2 when
 ## the wild was caught or ran, which is all a post-battle state asks.
@@ -1309,6 +1327,10 @@ const SCRIPT_SILENT_CALLS: Array[String] = [
 	"play_cry", "wait_for_sound", "wait_for_button",
 	"auto_textbox_on", "auto_textbox_off", "count_set_bits", "update_sprites",
 	"play_sound", "play_sound_wait", "load_gym_names",
+	"random",
+	## `SetSpritePosition2` puts back what `GetSpritePosition2` saved on the same
+	## visit, which the map's own table answers here; the image index is drawn.
+	"set_sprite_position_2", "set_sprite_image",
 	## Red and Blue spell `StopAllMusic` as `PlaySound`; only Yellow has a routine.
 	"play_music", "stop_all_music",
 	## A wait is frames of nothing and the map music is nobody's here. The three
@@ -1382,7 +1404,7 @@ const SCRIPT_SILENT_STORES: Array[String] = [
 	"current_menu_item", "max_menu_item", "top_menu_item_y", "top_menu_item_x",
 	"menu_watched_keys",
 	"last_menu_item", "menu_item_to_swap", "print_item_prices", "list_menu_id",
-	"filtered_bag_count", "opponent_after_wrong_answer",
+	"filtered_bag_count",
 ]
 ## The same over two bytes; `LoadItemList` already left the list itself.
 const SCRIPT_SILENT_WORDS: Array[String] = ["list_pointer"]
@@ -1402,13 +1424,15 @@ const TEXT_PREDEFS: Dictionary = {
 	"card_key_success": 0x01, "card_key_fail": 0x02,
 	"gym_statue": 0x0C, "gym_statue_badge": 0x0D, "found_hidden_item": 0x24,
 	"hidden_item_bag_full": 0x25, "found_hidden_coins": 0x2B,
-	"dropped_hidden_coins": 0x2C,
+	"dropped_hidden_coins": 0x2C, "trash": 0x26, "first_lock": 0x3B, "second_lock": 0x3D,
+	"reset": 0x3E,
 }
 const TEXT_PREDEFS_YELLOW: Dictionary = {
 	"card_key_success": 0x01, "card_key_fail": 0x02,
 	"gym_statue": 0x0E, "gym_statue_badge": 0x0F, "found_hidden_item": 0x26,
 	"hidden_item_bag_full": 0x27, "found_hidden_coins": 0x2D,
-	"dropped_hidden_coins": 0x2E,
+	"dropped_hidden_coins": 0x2E, "trash": 0x28, "first_lock": 0x3D, "second_lock": 0x3F,
+	"reset": 0x40,
 }
 ## `PrintCardKeyText`: a Silph Co. door draws either of two tiles, the top
 ## floor's own a third, and the block that opens one is $0E under it and $03
@@ -1419,7 +1443,6 @@ const CARD_KEY_OPEN_BLOCK: int = 0x0E
 const CARD_KEY_TOP_FLOOR_BLOCK: int = 0x03
 const SILPH_CO_TOP_FLOOR: int = 0xEB
 ## `SilphCoMapList`, ten floors under a terminator.
-const SILPH_MAP_LIST_MAX: int = 16
 ## The two packed-decimal buffers a price is written into, most significant
 ## byte first. `wPriceTemp` stands at `wWhichTrade`'s own address.
 const SCRIPT_BCD_BUFFERS: Array[String] = ["money_hram", "which_trade"]
@@ -1506,8 +1529,21 @@ const HIDDEN_COIN_AMOUNTS: Dictionary = {10: 10, 20: 20, 40: 20}
 const HIDDEN_COIN_DEFAULT: int = 100
 ## The hidden event routines that index a table of their own, read by hand.
 const HIDDEN_TABLE_ROUTINES: Array[String] = [
-	"hidden_items", "hidden_coins", "bench_guy_text", "gym_statues",
+	"hidden_items", "hidden_coins", "bench_guy_text", "gym_statues", "gym_trash",
 ]
+## EVENT_2ND_LOCK_OPENED and EVENT_1ST_LOCK_OPENED. `GymTrashCans` is a mask and
+## four cans a row, Yellow's a count and four pairs, and a draw reads past either.
+const LOCK_2ND_EVENT: int = 352
+const LOCK_1ST_EVENT: int = 353
+const TRASH_CANS: int = 15
+const TRASH_ROW_SIZE: int = 5
+const TRASH_ROW_SIZE_YELLOW: int = 9
+const TRASH_TABLE_TAIL: int = 256
+const TRASH_TABLE_TAIL_YELLOW: int = 512
+const TRASH_FIRST_MASK: int = 0x0E
+const TRASH_CAN_MASK: int = 0x0F
+const TRASH_THREE_THIRD: int = 0xFF / 3
+const TRASH_TEXTS: Array[String] = ["trash", "first_lock", "second_lock", "reset"]
 ## `bookshelf_tile` is a tileset, a tile and a `tx_pre` id; `MapBadgeFlags` a
 ## map and its `wBeatGymFlags` mask; `BenchGuyTextPointers` a map, a facing and
 ## a `tx_pre` id.
@@ -1766,6 +1802,7 @@ const RED_BLUE: Dictionary = {
 	"display_pokedex": 0x0349B,
 	"give_pokemon": 0x03E48,
 	"wait_for_sound": 0x3748,
+	"random": 0x3E5C,
 	"wait_for_button": 0x3865,
 	"auto_textbox_on": 0x3C3C,
 	"auto_textbox_off": 0x3C3F,
@@ -1828,6 +1865,7 @@ const RED_BLUE: Dictionary = {
 	"remove_item_from_inventory": 0x2BBB,
 	"item_to_remove": 0xFFDB,
 	"toggleable_index": 0xCC4D,
+	"toggleable_list": 0xD5CE,
 	"cur_party_species": 0xCF91,
 	"cur_map_script": 0xDA39,
 	"map_scripts": 0xD5F0,
@@ -1849,9 +1887,12 @@ const RED_BLUE: Dictionary = {
 	## `ReplaceTileBlock` writes `wNewTileBlockID` at the block `bc` names, and
 	## `SilphCoMapList` is the ten floors `PrintCardKeyText` answers on.
 	"map_script_flags": 0xD126,
+	"options": 0xD355,
 	"new_tile_block": 0xD09F,
 	"replace_tile_block": 0x0EE9E,
 	"card_key_door": 0xD73F,
+	"unlocked_silph_doors": 0xFFE0,
+	"first_lock_trash_can": 0xD743,
 	"silph_map_list": 0x526E3,
 	## `DaycareGentlemanText` and the head of its own stub run.
 	"day_care_script": 0x56254,
@@ -2019,6 +2060,8 @@ const RED_BLUE: Dictionary = {
 	"hidden_coins": 0x76799,
 	"bench_guy_text": 0x6245D,
 	"gym_statues": 0x62419,
+	"gym_trash": 0x5DDFC,
+	"gym_trash_cans": 0x5DE7D,
 	"print_predef_text": 0x3EF5,
 	"display_text_id": 0x2920,
 	"count_set_bits": 0x2B7F,
@@ -2050,6 +2093,7 @@ const RED_BLUE: Dictionary = {
 	"check_boulder_coords": 0x34E4,
 	"get_item_quantity": 0x0F8A5,
 	"update_gym_gates": 0x3EAD,
+	"update_gym_gates_far": 0x1EB0A,
 	"gym_gate_coords": 0x1EB48,
 	"sprite_pointer_1": 0x34FC,
 	"sprite_pointer_2": 0x3500,
@@ -2083,6 +2127,8 @@ const RED_BLUE: Dictionary = {
 	"sprite_map_y": 0xFFED,
 	"sprite_map_x": 0xFFEE,
 	"set_sprite_position": 0x32F9,
+	"set_sprite_position_2": 0x32FE,
+	"set_sprite_image": 0x34B9,
 	"get_sprite_position": 0x32EF,
 	"cur_map_text_ptr": 0xD36C,
 	"hall_of_fame_pc": 0x7405C,
@@ -2123,6 +2169,8 @@ const RED_BLUE: Dictionary = {
 	"beat_gym_flags": 0xD72A,
 	"gym_leader_no": 0xD05C,
 	"random_add": 0xFFD3,
+	"random_sub": 0xFFD4,
+	"lucky_slot_index": 0xCD05,
 	"oaks_aide_reward": 0xFFDC,
 	"get_item_name": 0x2FCF,
 	"get_mon_name": 0x2F9E,
@@ -2209,6 +2257,7 @@ const YELLOW: Dictionary = {
 	"display_pokedex": 0x0347D,
 	"give_pokemon": 0x03E59,
 	"wait_for_sound": 0x373E,
+	"random": 0x3E6D,
 	"wait_for_button": 0x3852,
 	"auto_textbox_on": 0x3C29,
 	"auto_textbox_off": 0x3C2C,
@@ -2266,6 +2315,7 @@ const YELLOW: Dictionary = {
 	"remove_item_from_inventory": 0x2ABD,
 	"item_to_remove": 0xFFDB,
 	"toggleable_index": 0xCC4D,
+	"toggleable_list": 0xD5CD,
 	"cur_party_species": 0xCF90,
 	"cur_map_script": 0xDA38,
 	"map_scripts": 0xD5EF,
@@ -2283,9 +2333,12 @@ const YELLOW: Dictionary = {
 	"obtained_badges": 0xD355,
 	"sprite_state_data": 0xC100,
 	"map_script_flags": 0xD125,
+	"options": 0xD354,
 	"new_tile_block": 0xD09E,
 	"replace_tile_block": 0x0ED1B,
 	"card_key_door": 0xD73E,
+	"unlocked_silph_doors": 0xFFE0,
+	"first_lock_trash_can": 0xD742,
 	"silph_map_list": 0x52645,
 	"day_care_script": 0x56244,
 	"day_care_text": 0x56441,
@@ -2430,6 +2483,8 @@ const YELLOW: Dictionary = {
 	"hidden_coins": 0x7608E,
 	"bench_guy_text": 0x6262C,
 	"gym_statues": 0x625E8,
+	"gym_trash": 0x5DE60,
+	"gym_trash_cans": 0xF2D31,
 	"print_predef_text": 0x3F3A,
 	"display_text_id": 0x2817,
 	"count_set_bits": 0x2A81,
@@ -2459,6 +2514,7 @@ const YELLOW: Dictionary = {
 	"check_boulder_coords": 0x34E1,
 	"get_item_quantity": 0x0F735,
 	"update_gym_gates": 0x3EF0,
+	"update_gym_gates_far": 0x1E4BF,
 	"gym_gate_coords": 0x1E503,
 	"gym_quiz_flags": 0xD474,
 	"sprite_pointer_1": 0x34F9,
@@ -2493,6 +2549,8 @@ const YELLOW: Dictionary = {
 	"sprite_map_y": 0xFFED,
 	"sprite_map_x": 0xFFEE,
 	"set_sprite_position": 0x3295,
+	"set_sprite_position_2": 0x329A,
+	"set_sprite_image": 0x349B,
 	"get_sprite_position": 0x328B,
 	"cur_map_text_ptr": 0xD36B,
 	"hall_of_fame_pc": 0xF0F26,
@@ -2538,6 +2596,8 @@ const YELLOW: Dictionary = {
 	"beat_gym_flags": 0xD729,
 	"gym_leader_no": 0xD05B,
 	"random_add": 0xFFD3,
+	"random_sub": 0xFFD4,
+	"lucky_slot_index": 0xCD05,
 	"oaks_aide_reward": 0xFFDC,
 	"get_item_name": 0x2EC4,
 	"get_mon_name": 0x2E93,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -2082,8 +2082,8 @@ static func _script_toggle_by_sprite(ctx: Dictionary, pc: int, state: Dictionary
 	for offset: int in TOGGLE_BY_SPRITE.size():
 		if TOGGLE_BY_SPRITE[offset] >= 0 and rom.u8(at + offset) != TOGGLE_BY_SPRITE[offset]:
 			return SCRIPT_UNREAD
-	if rom.u16le(at + 1) != int(layout["sprite_index_wram"]) \
-		or rom.u16le(at + 10) != int(layout["toggleable_index"]):
+	if rom.u16le(at + 1) != int(layout.get("sprite_index_wram", -1)) \
+		or rom.u16le(at + 10) != int(layout.get("toggleable_index", -1)):
 		return SCRIPT_UNREAD
 	state["toggle_from"] = int(layout["sprite_index_wram"])
 	return pc + Gen1Layout.SCRIPT_LONG_SIZE + TOGGLE_BY_SPRITE.size()
@@ -4569,9 +4569,9 @@ static func _script_shaped_routine(
 	var items: int = int(layout.get("filtered_bag_items", -1))
 	if rom.u8(at) == Gen1Layout.SCRIPT_LD_HL and rom.u16le(at + 1) == items:
 		return _script_filter_printed(ctx, at, state)
-	if _script_opens_with(rom, at + Gen1Layout.SCRIPT_LONG_SIZE, [
-		Gen1Layout.SCRIPT_LD_A_MEM, int(layout["sprite_index_wram"]) & 0xFF,
-		int(layout["sprite_index_wram"]) >> 8, Gen1Layout.SCRIPT_DEC_A,
+	var sprite_index: int = int(layout.get("sprite_index_wram", -1))
+	if sprite_index >= 0 and _script_opens_with(rom, at + Gen1Layout.SCRIPT_LONG_SIZE, [
+		Gen1Layout.SCRIPT_LD_A_MEM, sprite_index & 0xFF, sprite_index >> 8, Gen1Layout.SCRIPT_DEC_A,
 		Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_SWAP_A]):
 		return _script_object_coord_move(ctx, rom.u16le(at + 1), out)
 	if rom.u8(at) == Gen1Layout.SCRIPT_LD_HL and rom.u16le(at + 1) == int(layout.get("bag_items", -1)):
@@ -4600,7 +4600,7 @@ static func _script_card_key_call(
 	var layout: Dictionary = ctx["layout"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), target)
 	if rom.u8(at) == Gen1Layout.SCRIPT_PUSH_HL and rom.u8(at + 1) == Gen1Layout.SCRIPT_LD_HL \
-		and rom.u16le(at + 2) == int(layout["card_key_door"]):
+		and rom.u16le(at + 2) == int(layout.get("card_key_door", -1)):
 		if not state.has("hl"):
 			return SCRIPT_SHAPE_REFUSED
 		out.append({"op": "card_key_doors", "cells": _script_cell_list(ctx, int(state["hl"]))})

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -13,14 +13,10 @@ const LIST_END: int = Gen1Layout.TILESET_LIST_END
 ## and `_GivePokemon`'s.
 const GIFT_OPS: Array[String] = ["give_item", "give_pokemon"]
 
-## The gate's own two prefixed opcodes, and how many `push hl` it may hold a
-## copy of `hl` through.
-const MAP_LOAD_PREFIXES: Array[int] = [
-	Gen1Layout.SCRIPT_BIT_BASE, Gen1Layout.SCRIPT_RES_BASE,
+## `EnterMap` sets both bits; a script's own `set` asks for one bit's body.
+const MAP_LOAD_MASKS: Array[int] = [
+	Gen1Layout.MAP_LOAD_BOTH, 1 << Gen1Layout.MAP_LOADED_1_BIT, 1 << Gen1Layout.MAP_LOADED_2_BIT,
 ]
-const MAP_LOAD_HELD_LIMIT: int = 4
-## `ld hl, .GateCoordinates` and the two card key calls behind it.
-const CARD_KEY_PROLOGUE_SIZE: int = 3 * Gen1Layout.SCRIPT_LONG_SIZE
 ## Where a map header keeps its script pointer.
 const MAP_SCRIPT_AT: int = 7
 ## `jr nz, .fellDownHoleTo1F` hops the one `ld a, n` behind it, and how far past
@@ -134,16 +130,13 @@ static func read_world(
 		return overlap
 
 	var maps: Array = []
-	var card_key_floors: PackedByteArray = _read_list(
-		rom, int(layout["silph_map_list"]), Gen1Layout.SILPH_MAP_LIST_MAX
-	)
 	var map_count: int = Gen1Layout.map_count(rom.id)
 	var script_ends: Dictionary = _script_ends(rom, layout, map_count)
 	for map_id: int in map_count:
 		if not Gen1Layout.is_real_map(map_id):
 			continue
 		var map: Dictionary = _read_map(
-			rom, layout, tilesets, map_id, card_key_floors, int(script_ends[map_id])
+			rom, layout, tilesets, map_id, int(script_ends[map_id])
 		)
 		if not bool(map.get("ok", false)):
 			return map
@@ -151,6 +144,7 @@ static func read_world(
 		maps.append(map)
 		if on_progress.is_valid():
 			on_progress.call("maps", maps.size(), map_count - Gen1Layout.UNUSED_MAPS.size())
+	_reach_states_set_elsewhere(rom, layout, maps)
 
 	return {
 		"ok": true,
@@ -672,8 +666,7 @@ static func _bit_count(value: int) -> int:
 
 ## One map header, the blocks it draws and the object block behind it.
 static func _read_map(
-	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int,
-	card_key_floors: PackedByteArray, script_end: int
+	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int, script_end: int
 ) -> Dictionary:
 	var bank: int = Gen1Layout.map_bank(rom, layout, map_id)
 	var header: int = Gen1Layout.map_header_offset(rom, layout, map_id)
@@ -724,24 +717,20 @@ static func _read_map(
 	var texts: Array = _read_texts(rom, layout, bank, rom.u16le(header + 5), events)
 	_carry_trainer_headers(events["objects"], texts)
 	_carry_toggleable_objects(rom, layout, events["objects"], map_id)
-	var callback: Dictionary = _read_map_callback(
-		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), card_key_floors.has(map_id)
-	)
 	var states: Dictionary = _read_map_states(
 		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
 	)
 	## A row the table grew by may reach one higher still, which is how the
 	## Safari Zone gate's own six are read rather than its first four.
-	while _extend_texts(rom, layout, bank, rom.u16le(header + 5), texts, events, callback, states):
+	while _extend_texts(rom, layout, bank, rom.u16le(header + 5), texts, events, states):
 		states = _read_map_states(
 			rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
 		)
 	var hidden: Array = _read_hidden_events(
 		rom, layout, map_id, bank, rom.u16le(header + MAP_SCRIPT_AT)
 	)
-	for nodes: Array in [callback.get("nodes", []) as Array] \
-		+ hidden.map(func(row: Dictionary) -> Array: return row.get("script", []) as Array):
-		_bind_map_script_byte(nodes, int(states["byte"]))
+	for row: Dictionary in hidden:
+		_bind_map_script_byte(row.get("script", []) as Array, int(states["byte"]))
 
 	return {
 		"ok": true,
@@ -763,9 +752,11 @@ static func _read_map(
 			"bank": bank,
 			"address": rom.u16le(header + MAP_SCRIPT_AT),
 			"scenes": [],
-			"callbacks": [] if callback.is_empty() else [callback],
+			"callbacks": states["callbacks"],
 			"entry": states["entry"],
 			"states": states["states"],
+			"states_byte": states["byte"],
+			"texts_address": rom.u16le(header + 5),
 		},
 		"texts": texts,
 		"alternate_texts": _alternate_texts(rom, layout, bank, states, events),
@@ -778,7 +769,7 @@ static func _read_map(
 			"bg_events": events["bg_events"],
 			"objects": events["objects"],
 			"hidden_events": hidden,
-			"card_key": _card_key_doors(callback),
+			"card_key": _card_key_doors(states["callbacks"]),
 			"dungeon_holes": _read_dungeon_holes(
 				rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), script_end
 			),
@@ -862,25 +853,80 @@ static func _script_ends(rom: RomFile, layout: Dictionary, map_count: int) -> Di
 	return out
 
 
-## `RunMapScript` jumps to the map's own script every frame: what stands in
-## front of `CallFunctionInTable` runs each time and the table behind it holds
-## one body per state. No row records that table's length, so the states kept
-## are the reachable ones: index 0, and whatever a `set_map_script` names.
+## `AgathasRoomAgathaEndBattleScript` writes `wChampionsRoomCurScript`: a map
+## whose byte another map's script writes reads its states again, seeded.
+static func _reach_states_set_elsewhere(rom: RomFile, layout: Dictionary, maps: Array) -> void:
+	var written: Dictionary = {}
+	for map: Dictionary in maps:
+		var scripts: Dictionary = map["scripts"]
+		var own: int = int((scripts.get("states_byte", -1)))
+		for nodes: Array in _map_script_lists(map):
+			for row: Array in _map_script_stores(nodes):
+				if int(row[0]) != own:
+					written[int(row[0])] = (written.get(int(row[0]), []) as Array) + [int(row[1])]
+	for map: Dictionary in maps:
+		var scripts: Dictionary = map["scripts"]
+		var byte: int = int(scripts.get("states_byte", -1))
+		if byte < 0 or not written.has(byte):
+			continue
+		var states: Dictionary = _read_map_states(
+			rom, layout, int(scripts["bank"]), int(scripts["address"]), map["texts"],
+			written[byte] as Array
+		)
+		while _extend_texts(rom, layout, int(scripts["bank"]),
+			int(scripts["texts_address"]), map["texts"], map["events"], states):
+			states = _read_map_states(rom, layout, int(scripts["bank"]),
+				int(scripts["address"]), map["texts"], written[byte] as Array)
+		scripts["states"] = states["states"]
+	for map: Dictionary in maps:
+		(map["scripts"] as Dictionary).erase("states_byte")
+		(map["scripts"] as Dictionary).erase("texts_address")
+
+
+static func _map_script_lists(map: Dictionary) -> Array:
+	var scripts: Dictionary = map["scripts"]
+	var out: Array = [scripts["entry"]]
+	for row: Dictionary in (scripts["callbacks"] as Array) + (scripts["states"] as Array):
+		out.append(row["nodes"])
+	for row: Dictionary in (map["texts"] as Array) + ((map["events"] as Dictionary)["hidden_events"] as Array):
+		out.append(row.get("script", []))
+	return out
+
+
+## Every `set_map_script` under [param nodes], as `[byte, value]`.
+static func _map_script_stores(nodes: Array) -> Array:
+	var out: Array = []
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "set_map_script" and node.has("value"):
+			out.append([int(node["byte"]), int(node["value"])])
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
+				out.append_array(_map_script_stores(node[key] as Array))
+	return out
+
+
+## `RunMapScript` jumps to the map's own script every frame. No row records the
+## state table's length, so the states kept are the ones a store reaches.
 static func _read_map_states(
-	rom: RomFile, layout: Dictionary, bank: int, script: int, texts: Array
+	rom: RomFile, layout: Dictionary, bank: int, script: int, texts: Array, seeds: Array = []
 ) -> Dictionary:
 	var entry: Array = decode_script(rom, layout, bank, script)
+	var callbacks: Array = _map_load_walks(rom, layout, bank, script, entry)
 	var dispatch: Dictionary = _map_script_dispatch(entry)
 	if dispatch.is_empty():
-		return {"entry": entry, "states": [], "byte": MAP_SCRIPT_MIRROR}
+		return {"entry": entry, "callbacks": callbacks, "states": [], "byte": MAP_SCRIPT_MIRROR}
 	var byte: int = int(dispatch["byte"])
 	var bodies: Array = _map_script_bodies(rom, layout, bank, int(dispatch["table"]))
 	_bind_map_script_byte(entry, byte)
 	var pending: Array[int] = _map_script_successors(entry, byte)
+	## `CheckFightingMapTrainers` and `StartTrainerBattle` each step the byte by one.
+	pending.append_array(seeds + TRAINER_STATES)
+	for callback: Dictionary in callbacks:
+		_bind_map_script_byte(callback["nodes"] as Array, byte)
+		pending.append_array(_map_script_successors(callback["nodes"] as Array, byte))
 	for row: Dictionary in texts:
 		_bind_map_script_byte(row.get("script", []) as Array, byte)
 		pending.append_array(_map_script_successors(row.get("script", []) as Array, byte))
-	pending.append(0)
 	var reached: Dictionary = {}
 	while not pending.is_empty():
 		var index: int = pending.pop_back()
@@ -894,7 +940,19 @@ static func _read_map_states(
 	for index: int in bodies.size():
 		if reached.has(index) and bodies[index] != null:
 			rows.append({"id": index, "nodes": bodies[index]})
-	return {"entry": entry, "states": rows, "byte": byte}
+	return {"entry": entry, "callbacks": callbacks, "states": rows, "byte": byte}
+
+
+## The entry script under each [constant MAP_LOAD_MASKS] row, when it differs.
+static func _map_load_walks(
+	rom: RomFile, layout: Dictionary, bank: int, script: int, entry: Array
+) -> Array:
+	var out: Array = []
+	for mask: int in MAP_LOAD_MASKS:
+		var nodes: Array = decode_script(rom, layout, bank, script, {}, mask)
+		if not nodes.is_empty() and nodes != entry:
+			out.append({"mask": mask, "nodes": nodes})
+	return out
 
 
 ## Every body of one `<Map>_ScriptPointers` table, read while the word addresses
@@ -1016,141 +1074,35 @@ static func _dungeon_destinations(
 	return {}
 
 
-## `RunMapScript` runs the whole of a map's script every frame, so the work a map
-## does once is the body behind a `wCurrentMapScriptFlags` bit, decoded the way
-## a `text_asm` row is. [method _read_map_states] reads the rest.
-static func _read_map_callback(
-	rom: RomFile, layout: Dictionary, bank: int, script: int, card_key: bool
-) -> Dictionary:
-	var body: int = _map_load_gate(rom, layout, bank, script)
-	if body < 0:
-		return {}
-	var coordinates: Array = _card_key_coordinates(rom, bank, body) if card_key else []
-	if not coordinates.is_empty():
-		body += CARD_KEY_PROLOGUE_SIZE
-	var nodes: Array = decode_script(rom, layout, bank, body)
-	var calls: Array[int] = _map_load_calls(rom, layout, bank, script)
-	if not calls.is_empty():
-		nodes = []
-		for target: int in calls:
-			nodes.append_array(decode_script(rom, layout, bank, target))
-	return {"nodes": nodes, "coordinates": coordinates}
-
-
-static func _map_load_calls(rom: RomFile, layout: Dictionary, bank: int, script: int) -> Array[int]:
-	var at: int = Gen1Layout.banked(bank, script)
-	if rom.u8(at) == Gen1Layout.SCRIPT_CALL:
-		at = Gen1Layout.banked(bank, rom.u16le(at + 1))
-	var calls: Array[int] = []
-	if rom.u8(at) != Gen1Layout.SCRIPT_LD_HL or rom.u16le(at + 1) != int(layout["map_script_flags"]):
-		return calls
-	at += 3
-	var loaded: bool = false
-	for _step: int in 16:
-		var op: int = rom.u8(at)
-		if op == Gen1Layout.SCRIPT_PREFIX:
-			var code: int = rom.u8(at + 1)
-			if (code & 7) != Gen1Layout.SCRIPT_OPERAND_HL:
-				break
-			if code < Gen1Layout.SCRIPT_RES_BASE:
-				loaded = ((code - Gen1Layout.SCRIPT_BIT_BASE) / 8) in [5, 6]
-			at += 2
-		elif Gen1Layout.SCRIPT_STACK_HL.has(op):
-			at += 1
-		elif op in [0xC4, 0xCC]:
-			if loaded == (op == 0xC4):
-				calls.append(rom.u16le(at + 1))
-			at += 3
-		else:
-			break
-	return calls
-
-
-static func _map_load_gate(rom: RomFile, layout: Dictionary, bank: int, at: int) -> int:
-	var body: int = _map_load_body(rom, layout, bank, at)
-	if body >= 0:
-		return body
-	var entry: int = Gen1Layout.banked(bank, at)
-	if not rom.in_bounds(entry, Gen1Layout.SCRIPT_LONG_SIZE) \
-		or rom.u8(entry) != Gen1Layout.SCRIPT_CALL:
-		return -1
-	return _map_load_body(rom, layout, bank, rom.u16le(entry + 1))
-
-
-## `ld hl, wCurrentMapScriptFlags`, `bit`, `res` and the branch under them. -1
-## when the map opens on anything else.
-static func _map_load_body(rom: RomFile, layout: Dictionary, bank: int, at: int) -> int:
-	var pc: int = at
-	var opening: int = Gen1Layout.banked(bank, pc)
-	if not rom.in_bounds(opening, Gen1Layout.SCRIPT_LONG_SIZE) \
-		or rom.u8(opening) != Gen1Layout.SCRIPT_LD_HL \
-		or rom.u16le(opening + 1) != int(layout["map_script_flags"]):
-		return -1
-	pc += Gen1Layout.SCRIPT_LONG_SIZE
-	for base: int in MAP_LOAD_PREFIXES:
-		if not _map_load_prefixed(rom, bank, pc, base):
-			return -1
-		pc += Gen1Layout.SCRIPT_SHORT_SIZE
-	for held: int in MAP_LOAD_HELD_LIMIT:
-		if not Gen1Layout.SCRIPT_STACK_HL.has(rom.u8(Gen1Layout.banked(bank, pc))):
-			break
-		pc += 1
-	var branch: int = rom.u8(Gen1Layout.banked(bank, pc))
-	if not Gen1Layout.MAP_LOAD_GATE_BRANCHES.has(branch):
-		return -1
-	return _map_load_branch(rom, bank, pc, Gen1Layout.MAP_LOAD_GATE_BRANCHES[branch])
-
-
-static func _map_load_prefixed(rom: RomFile, bank: int, pc: int, base: int) -> bool:
-	var at: int = Gen1Layout.banked(bank, pc)
-	if not rom.in_bounds(at, Gen1Layout.SCRIPT_SHORT_SIZE) \
-		or rom.u8(at) != Gen1Layout.SCRIPT_PREFIX:
-		return false
-	var code: int = rom.u8(at + 1)
-	return code >= base and code < base + Gen1Layout.SCRIPT_PREFIX_BLOCK \
-		and (code & 7) == Gen1Layout.SCRIPT_OPERAND_HL
-
-
-static func _map_load_branch(rom: RomFile, bank: int, pc: int, row: Dictionary) -> int:
-	var size: int = int(row["size"])
-	if not bool(row["target"]):
-		return pc + size
-	var operand: int = Gen1Layout.banked(bank, pc) + 1
-	if size == Gen1Layout.SCRIPT_LONG_SIZE:
-		return rom.u16le(operand)
-	return pc + size + _script_hop(rom.u8(operand))
-
-
-## `SilphCo2F_SetCardKeyDoorYScript` and `<Map>_UnlockedDoorEventScript` both
-## loop over the gate table, so the pair is read by hand and the callback is
-## walked for the blocks behind them.
-static func _card_key_coordinates(rom: RomFile, bank: int, at: int) -> Array:
-	var opening: int = Gen1Layout.banked(bank, at)
-	if not rom.in_bounds(opening, CARD_KEY_PROLOGUE_SIZE) \
-		or rom.u8(opening) != Gen1Layout.SCRIPT_LD_HL:
-		return []
-	for call_index: int in 2:
-		var call_at: int = opening + Gen1Layout.SCRIPT_LONG_SIZE * (call_index + 1)
-		if rom.u8(call_at) != Gen1Layout.SCRIPT_CALL:
-			return []
-	var list: int = Gen1Layout.banked(bank, rom.u16le(opening + 1))
-	var out: Array = []
-	while rom.in_bounds(list, Gen1Layout.MAP_COORD_SIZE) \
-		and rom.u8(list) != Gen1Layout.MAP_COORD_END:
-		out.append({"x": rom.u8(list + 1), "y": rom.u8(list)})
-		list += Gen1Layout.MAP_COORD_SIZE
-	return out
-
-
 ## One card key door per gate coordinate: the block the callback puts back while
 ## the door's own flag is clear, in the order
 ## `<Map>_UnlockedDoorEventScript` numbers them.
-static func _card_key_doors(callback: Dictionary) -> Array:
-	if callback.is_empty() or (callback["coordinates"] as Array).is_empty():
+static func _card_key_doors(callbacks: Array) -> Array:
+	var coordinates: Array = []
+	for callback: Dictionary in callbacks:
+		coordinates = _take_card_key_coordinates(callback["nodes"] as Array, coordinates)
+	if coordinates.is_empty():
 		return []
 	var doors: Array = []
-	_card_key_walk(callback["nodes"], doors)
-	return doors if doors.size() == (callback["coordinates"] as Array).size() else []
+	for callback: Dictionary in callbacks:
+		if int(callback["mask"]) == 1 << Gen1Layout.MAP_LOADED_1_BIT:
+			_card_key_walk(callback["nodes"], doors)
+	return doors if doors.size() == coordinates.size() else []
+
+
+static func _take_card_key_coordinates(nodes: Array, found: Array) -> Array:
+	var index: int = 0
+	while index < nodes.size():
+		var node: Dictionary = nodes[index]
+		if String(node["op"]) == "card_key_doors":
+			found = node["cells"]
+			nodes.remove_at(index)
+			continue
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
+				found = _take_card_key_coordinates(node[key] as Array, found)
+		index += 1
+	return found
 
 
 static func _card_key_walk(nodes: Array, doors: Array) -> void:
@@ -1538,7 +1490,27 @@ static func _hidden_table_nodes(
 			return _bench_guy_nodes(rom, layout, bank, map_id)
 		"gym_statues":
 			return _gym_statue_nodes(rom, layout, bank, map_id, names)
+		"gym_trash":
+			return _gym_trash_nodes(rom, layout, bank, argument)
 	return []
+
+
+## `GymTrashScript`: the argument is the can and the four boxes its `tx_pre` rows.
+static func _gym_trash_nodes(rom: RomFile, layout: Dictionary, bank: int, can: int) -> Array:
+	var yellow: bool = rom.id == RomRegistry.YELLOW
+	var node: Dictionary = {
+		"op": "gym_trash", "can": can,
+		"row_size": Gen1Layout.TRASH_ROW_SIZE_YELLOW if yellow else Gen1Layout.TRASH_ROW_SIZE,
+		"table": Array(rom.slice(int(layout["gym_trash_cans"]), Gen1Layout.TRASH_CANS
+			* (Gen1Layout.TRASH_ROW_SIZE_YELLOW if yellow else Gen1Layout.TRASH_ROW_SIZE)
+			+ (Gen1Layout.TRASH_TABLE_TAIL_YELLOW if yellow else Gen1Layout.TRASH_TABLE_TAIL))),
+	}
+	for name: String in Gen1Layout.TRASH_TEXTS:
+		var nodes: Array = _predef_nodes(rom, layout, bank, Gen1Layout.text_predef(rom.id, name))
+		if nodes.is_empty():
+			return []
+		node[name] = nodes
+	return [node]
 
 
 ## `FindHiddenItemOrCoinsIndex`: a row's place in the list is its own flag bit.
@@ -1723,6 +1695,7 @@ static func _asm_operand(rom: RomFile, bank: int, at: int, target: int) -> int:
 ## [method _script_step] gives that are not an address.
 ## A `set_map_script` through `wCurMapScript`, whose byte the dispatch names.
 const MAP_SCRIPT_MIRROR: int = -1
+const TRAINER_STATES: Array = [0, 1, 2]
 const SCRIPT_BUDGET: int = 4096
 const SCRIPT_DEPTH: int = 8
 const SCRIPT_END: int = -2
@@ -1797,11 +1770,12 @@ const SCRIPT_STORED_REGISTERS: Dictionary = {
 ## choosing between them; a path reaching anything unread is dropped whole.
 ## [param known] is the argument byte a hidden event's own routine is handed.
 static func decode_script(
-	rom: RomFile, layout: Dictionary, bank: int, at: int, known: Dictionary = {}
+	rom: RomFile, layout: Dictionary, bank: int, at: int, known: Dictionary = {},
+	load_mask: int = 0
 ) -> Array:
 	var ctx: Dictionary = {
 		"rom": rom, "layout": layout, "bank": bank,
-		"budget": [SCRIPT_BUDGET], "calls": [0],
+		"budget": [SCRIPT_BUDGET], "calls": [0], "map_load_mask": load_mask,
 	}
 	var walked: Variant = _walk_script(ctx, at, known.duplicate(), 0)
 	return walked as Array if walked is Array else []
@@ -1919,6 +1893,8 @@ static func _script_step(
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
 	match rom.u8(at):
 		Gen1Layout.SCRIPT_LD_HL:
+			if rom.u16le(at + 1) == int((ctx["layout"] as Dictionary).get("toggleable_list", -1)):
+				return _script_toggle_by_sprite(ctx, pc, state)
 			state["hl"] = rom.u16le(at + 1)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
 		Gen1Layout.SCRIPT_LD_DE:
@@ -2021,11 +1997,14 @@ static func _script_step_more(
 		Gen1Layout.SCRIPT_LD_D:
 			var filtered: int = _script_filtered_index(ctx, pc, at, state)
 			return filtered if filtered != SCRIPT_UNREAD else _script_table_register(ctx, pc, at, state)
-		Gen1Layout.SCRIPT_LD_E, Gen1Layout.SCRIPT_ADD_HL_DE, \
-		Gen1Layout.SCRIPT_LD_H_HL, Gen1Layout.SCRIPT_LD_L_A, Gen1Layout.SCRIPT_INC_H:
+		Gen1Layout.SCRIPT_LD_E, Gen1Layout.SCRIPT_ADD_HL_DE, Gen1Layout.SCRIPT_LD_D_A, \
+		Gen1Layout.SCRIPT_LD_E_A, Gen1Layout.SCRIPT_LD_H_HL, Gen1Layout.SCRIPT_LD_L_A, \
+		Gen1Layout.SCRIPT_INC_H:
 			return _script_table_register(ctx, pc, at, state)
 		Gen1Layout.SCRIPT_CP_B:
 			return _script_compared_b(ctx, pc, state)
+		Gen1Layout.SCRIPT_CP_C:
+			return _script_compared_c(ctx, pc, state)
 	return _script_step_registers(ctx, pc, at, state, out, depth)
 
 
@@ -2073,6 +2052,8 @@ static func _script_step_registers(
 			_script_test_bit(ctx, state, -1)
 			state["tests_and_a"] = true
 			return pc + 1
+		Gen1Layout.SCRIPT_ADD_B, Gen1Layout.SCRIPT_ADC_B:
+			return _script_added_b(ctx, pc, state)
 		Gen1Layout.SCRIPT_DEC_B:
 			if not state.has("b"):
 				return SCRIPT_UNREAD
@@ -2086,6 +2067,38 @@ static func _script_step_registers(
 			state.erase("b")
 			return pc + 1
 	return _script_flow(ctx, pc, at, state, out, depth)
+
+
+## `PokemonTower7FHideNPCScript`'s loop over `wToggleableObjectList`, by its bytes.
+const TOGGLE_BY_SPRITE: Array[int] = [
+	Gen1Layout.SCRIPT_LD_A_MEM, -1, -1, Gen1Layout.SCRIPT_LD_B_A, Gen1Layout.SCRIPT_LD_A_HLI,
+	Gen1Layout.SCRIPT_CP_B, Gen1Layout.SCRIPT_LD_A_HLI, Gen1Layout.SCRIPT_JR_NZ, 0xFB,
+	Gen1Layout.SCRIPT_LD_MEM_A, -1, -1,
+]
+static func _script_toggle_by_sprite(ctx: Dictionary, pc: int, state: Dictionary) -> int:
+	var rom: RomFile = ctx["rom"]
+	var layout: Dictionary = ctx["layout"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc) + Gen1Layout.SCRIPT_LONG_SIZE
+	for offset: int in TOGGLE_BY_SPRITE.size():
+		if TOGGLE_BY_SPRITE[offset] >= 0 and rom.u8(at + offset) != TOGGLE_BY_SPRITE[offset]:
+			return SCRIPT_UNREAD
+	if rom.u16le(at + 1) != int(layout["sprite_index_wram"]) \
+		or rom.u16le(at + 10) != int(layout["toggleable_index"]):
+		return SCRIPT_UNREAD
+	state["toggle_from"] = int(layout["sprite_index_wram"])
+	return pc + Gen1Layout.SCRIPT_LONG_SIZE + TOGGLE_BY_SPRITE.size()
+
+
+## Yellow's trash can seed: a sum of two random bytes is as random as either.
+static func _script_added_b(ctx: Dictionary, pc: int, state: Dictionary) -> int:
+	var layout: Dictionary = ctx["layout"]
+	if not _script_random_source(layout, state) \
+		or int(state.get("b_source", -1)) != int(layout.get("random_add", -2)):
+		return SCRIPT_UNREAD
+	_script_untested(state)
+	state.erase("mask")
+	state.erase("shift")
+	return pc + 1
 
 
 ## `ld a, [hli] / or [hl] / inc hl / or [hl]` over `wPlayerMoney`: Z is raised
@@ -2134,6 +2147,14 @@ static func _script_table_register(ctx: Dictionary, pc: int, at: int, state: Dic
 		state["de"] = (int(state.get("de", 0)) & mask) \
 			| (rom.u8(at + 1) << (8 if high else 0))
 		return pc + 2
+	if op in [Gen1Layout.SCRIPT_LD_D_A, Gen1Layout.SCRIPT_LD_E_A]:
+		if not _script_known_a(state):
+			return SCRIPT_UNREAD
+		var high: bool = op == Gen1Layout.SCRIPT_LD_D_A
+		var mask: int = 0x00FF if high else 0xFF00
+		state["de"] = (int(state.get("de", 0)) & mask) \
+			| ((int(state["a"]) & 0xFF) << (8 if high else 0))
+		return pc + 1
 	if not state.has("hl"):
 		return SCRIPT_UNREAD
 	match op:
@@ -2223,6 +2244,17 @@ static func _script_compared_b(ctx: Dictionary, pc: int, state: Dictionary) -> i
 	return pc + 1
 
 
+## `cp c` over `wCurrentMenuItem`: YES is 0, so a `c` of 1 turns the choice about.
+static func _script_compared_c(ctx: Dictionary, pc: int, state: Dictionary) -> int:
+	var layout: Dictionary = ctx["layout"]
+	if int(state.get("source", -1)) != int(layout["current_menu_item"]) \
+		or not state.has("c") or int(state["c"]) > 1:
+		return SCRIPT_UNREAD
+	_script_test_bit(ctx, state, -1)
+	state["choice_inverted"] = int(state["c"]) == 1
+	return pc + 1
+
+
 static func _script_stored_immediate(
 	ctx: Dictionary, pc: int, at: int, state: Dictionary, out: Array
 ) -> int:
@@ -2259,20 +2291,31 @@ static func _script_flow(
 		Gen1Layout.SCRIPT_LD_HLI_A:
 			return _script_stored_hli(ctx, pc, state, out)
 		Gen1Layout.SCRIPT_AND_A:
-			_script_test_bit(ctx, state, -1)
-			if Gen1Layout.script_zero_source(
+			var zero: bool = Gen1Layout.script_zero_source(
 				ctx["layout"], int(state.get("source", -1))
-			):
+			)
+			if state.has("a_runtime") and not zero:
+				state["scratch_test"] = [int(state["a_runtime"]), (-int(state["a"])) & 0xFF]
+				_script_tested(state, SCRIPT_TESTS_SCRATCH)
+				return pc + 1
+			_script_test_bit(ctx, state, -1)
+			if zero:
 				state["known_zero"] = true
 			state["tests_and_a"] = true
 			return pc + 1
 		Gen1Layout.SCRIPT_RRCA:
 			return _script_rotated(ctx, pc, state, int(state.get("rotated", 0)))
 		Gen1Layout.SCRIPT_ADD_A:
+			if _script_known_a(state):
+				_script_computed(state, (int(state["a"]) * 2) & 0xFF)
+				return pc + 1
 			return _script_rotated(ctx, pc, state, Gen1Layout.SCRIPT_HIGH_BIT)
 		Gen1Layout.SCRIPT_CP_N:
 			return _script_compared(ctx, pc, state, rom.u8(at + 1))
 		Gen1Layout.SCRIPT_AND_N:
+			if _script_known_a(state):
+				_script_computed(state, int(state["a"]) & rom.u8(at + 1))
+				return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 			## `CheckEitherEventSet`, whose two flags share a byte and a mask.
 			_script_tested(state, _script_mask(ctx, state, rom.u8(at + 1)))
 			state["mask"] = rom.u8(at + 1)
@@ -2307,6 +2350,14 @@ static func _script_jumped(
 			return pc + 1
 		Gen1Layout.SCRIPT_PUSH_AF:
 			_script_push(state, "af", _script_pushed_af(state))
+			return pc + 1
+		Gen1Layout.SCRIPT_PUSH_BC:
+			_script_push(state, "bc", _script_pushed_bc(state))
+			return pc + 1
+		Gen1Layout.SCRIPT_POP_BC:
+			if (state.get("bc", []) as Array).is_empty():
+				return SCRIPT_UNREAD
+			_script_popped_bc(state, _script_pop(state, "bc"))
 			return pc + 1
 		Gen1Layout.SCRIPT_POP_AF:
 			return SCRIPT_UNREAD if (state.get("af", []) as Array).is_empty() \
@@ -2345,6 +2396,23 @@ static func _script_pop(state: Dictionary, key: String) -> Variant:
 	var value: Variant = stack.pop_back()
 	state[key] = stack
 	return value
+
+
+const SCRIPT_BC_KEYS: Array[String] = [
+	"b", "c", "b_source", "c_source", "b_runtime", "c_runtime", "b_symbolic", "c_symbolic",
+]
+static func _script_pushed_bc(state: Dictionary) -> Dictionary:
+	var saved: Dictionary = {}
+	for key: String in SCRIPT_BC_KEYS:
+		if state.has(key):
+			saved[key] = state[key]
+	return saved
+
+
+static func _script_popped_bc(state: Dictionary, saved: Dictionary) -> void:
+	for key: String in SCRIPT_BC_KEYS:
+		state.erase(key)
+	state.merge(saved)
 
 
 static func _script_pushed_af(state: Dictionary) -> Dictionary:
@@ -2437,45 +2505,54 @@ static func _script_wrote_a(state: Dictionary) -> void:
 	state.erase("a_runtime")
 
 
+## `ld a, [nn]`: the reads whose byte the walk holds under a state key.
+const SCRIPT_LOADED_STATE: Array = [
+	["cur_party_species", "species_index"], ["which_trade", "hidden_argument"],
+	["which_trade", "which_badge"], ["sprite_index_wram", "sprite_index_wram"],
+]
+
+
 ## `ld a, [nn]`. `ShowPokedexDataInternal` leaves `wPokedexNum` in
-## `wCurPartySpecies`, which the Fighting Dojo's two gifts read the species from.
+## `wCurPartySpecies`, and `wHiddenEventFunctionArgument` is `wWhichTrade`'s byte.
 static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> void:
 	_script_wrote_a(state)
 	state.erase("a")
 	state["source"] = address
 	var layout: Dictionary = ctx["layout"]
-	if address == int(layout.get("text_id_hram", -1)) and state.has("map_text"):
-		state["a"] = int(state["map_text"])
-		state.erase("source")
-	if address == int(layout["cur_party_species"]) and state.has("species_index"):
-		state["a"] = int(state["species_index"])
-	## `wHiddenEventFunctionArgument` is `wWhichTrade`'s own byte.
-	if address == int(layout.get("which_trade", -1)) and state.has("hidden_argument"):
-		state["a"] = int(state["hidden_argument"])
+	for row: Array in SCRIPT_LOADED_STATE:
+		if address == int(layout.get(row[0], -1)) and state.has(row[1]):
+			state["a"] = int(state[row[1]])
 	if address == int(layout.get("npc_sprite_offset", -1)) and state.has("npc_path"):
 		state["a"] = 0
 		state["a_symbolic"] = "npc_y_distance"
-	if address == int(layout.get("trainer_header_flag_bit", -1)):
+	elif address == int(layout.get("which_trade", -1)) and state.has("coord_array"):
+		state["a"] = 0
+		state["a_symbolic"] = Gen1Layout.SCRIPT_SYMBOLIC_COORD_INDEX
+	if _script_address_name(layout, address, Gen1Layout.SCRIPT_RUNTIME_SCRATCH) != "" \
+		and not state.has("a"):
 		state["a"] = 0
 		state["a_runtime"] = address
+	_script_loaded_known(layout, address, state)
+
+
+## The reads the row itself answers. `hOaksAideResult` shares `hGymGateIndex`'s
+## byte, and `wChannelSoundIDs` is spun on until a jingle ends, silence here.
+static func _script_loaded_known(layout: Dictionary, address: int, state: Dictionary) -> void:
 	var temps: Dictionary = state.get("mem", {})
 	if temps.has(address):
 		state["a"] = int(temps[address])
 		state.erase("a_runtime")
 		state.erase("source")
-	if address == int(layout.get("which_trade", -1)) and state.has("coord_array"):
-		state["a"] = 0
-		state["a_symbolic"] = Gen1Layout.SCRIPT_SYMBOLIC_COORD_INDEX
-	elif address == int(layout.get("which_trade", -1)) and state.has("which_badge"):
-		state["a"] = int(state["which_badge"])
-	if address == int(layout.get("sprite_index_wram", -1)) and state.has("sprite_index_wram"):
-		state["a"] = int(state["sprite_index_wram"])
-	## `wChannelSoundIDs`, spun on until a jingle ends: silence here.
+	if address == int(layout.get("text_id_hram", -1)) and state.has("map_text_from"):
+		state["a"] = int(state["map_text_offset"])
+		state["a_runtime"] = int(state["map_text_from"])
+		state.erase("source")
+	for row: Array in [["text_id_hram", "map_text"], ["item_to_remove", "aide_outcome"]]:
+		if address == int(layout.get(row[0], -1)) and state.has(row[1]):
+			state["a"] = int(state[row[1]])
+			state.erase("source")
 	if address == int(layout.get("channel_sound_ids", -1)):
 		state["a"] = 0
-		state.erase("source")
-	if address == int(layout["item_to_remove"]) and state.has("aide_outcome"):
-		state["a"] = int(state["aide_outcome"])
 		state.erase("source")
 
 
@@ -2486,6 +2563,10 @@ static func _script_jump(
 ) -> int:
 	var layout: Dictionary = ctx["layout"]
 	if target == int(layout["text_script_end"]):
+		return SCRIPT_END
+	var special: Variant = _script_special_body(ctx, target)
+	if special != null:
+		out.append_array(special as Array)
 		return SCRIPT_END
 	if _script_routine(layout, target).is_empty() \
 		and _script_banked_routine(layout, int(ctx["bank"]), target).is_empty():
@@ -2521,35 +2602,22 @@ static func _script_stored(
 		return _script_map_script_mirror(state, out)
 	var byte: int = _map_script_byte(layout, address)
 	if byte >= 0:
-		## `wNextSafariZoneGateScript` is a union over `wSavedCoordIndex`.
-		if not state.has("a"):
-			if int(state.get("source", -1)) != int(layout.get("saved_coord_index", -1)):
-				return false
-			out.append({"op": "set_map_script", "byte": byte, "from": "saved_coord_index"})
-			return true
-		out.append({"op": "set_map_script", "byte": byte, "value": int(state["a"])})
-		return true
+		return _script_stored_map_script(layout, byte, address, state, out)
 	if address == int(layout["do_not_wait"]):
-		if int(state.get("a", 0)) == 0:
-			state.erase("no_press")
-			return true
-		if int(state.get("a", 0)) != 1:
-			return false
-		state["no_press"] = true
-		return true
-	var named: int = _script_stored_named(ctx, layout, address, state, out)
-	if named >= 0:
-		return named == STORE_OK
+		return _script_stored_no_press(state)
+	for stored: int in [
+		_script_stored_byte(layout, address, state, out),
+		_script_stored_temp(layout, address, state),
+		_script_stored_named(ctx, layout, address, state, out),
+	]:
+		if stored != STORE_NOT_NAMED:
+			return stored == STORE_OK
 	## `ResetEventRange` and `SetEventRange` inside one byte.
 	if _script_flag(ctx, address, 0) >= 0:
 		return _script_stored_flag_byte(ctx, address, state, out)
-	for name: String in SCRIPT_STORED_REGISTERS:
-		if address != int(layout.get(name, -1)):
-			continue
-		if not state.has("a"):
-			return false
-		state[String(SCRIPT_STORED_REGISTERS[name])] = int(state["a"])
-		return true
+	var register: int = _script_stored_register(layout, address, state)
+	if register != STORE_NOT_NAMED:
+		return register == STORE_OK
 	if address == int(layout["facing_direction"]) and state.has("a") \
 		and Gen1Layout.FACING_STEPS.has(int(state["a"])):
 		out.append({"op": "player_facing", "facing": int(state["a"])})
@@ -2560,6 +2628,77 @@ static func _script_stored(
 	if _script_stored_silently(layout, address):
 		return true
 	return _script_stored_more(ctx, layout, address, state, out)
+
+
+## `wNextSafariZoneGateScript` is a union over `wSavedCoordIndex`.
+static func _script_stored_map_script(
+	layout: Dictionary, byte: int, address: int, state: Dictionary, out: Array
+) -> bool:
+	if state.has("a"):
+		out.append({"op": "set_map_script", "byte": byte, "value": int(state["a"])})
+		return true
+	if bool(state.get("map_script_returned", false)) and int(state.get("source", -1)) == address:
+		return true
+	if int(state.get("source", -1)) != int(layout.get("saved_coord_index", -1)):
+		return false
+	out.append({"op": "set_map_script", "byte": byte, "from": "saved_coord_index"})
+	return true
+
+
+static func _script_stored_no_press(state: Dictionary) -> bool:
+	if int(state.get("a", 0)) == 0:
+		state.erase("no_press")
+		return true
+	if int(state.get("a", 0)) != 1:
+		return false
+	state["no_press"] = true
+	return true
+
+
+## `hGymGateIndex`, `hGymGateAnswer` and `hBackupGymGateIndex`, read back by their row.
+static func _script_stored_temp(layout: Dictionary, address: int, state: Dictionary) -> int:
+	if not _script_known_a(state) or address not in [
+		int(layout["item_to_remove"]), int(layout.get("oaks_aide_reward", -1)),
+		int(layout.get("unlocked_silph_doors", -1))]:
+		return STORE_NOT_NAMED
+	var temps: Dictionary = (state.get("mem", {}) as Dictionary).duplicate()
+	temps[address] = int(state["a"])
+	state["mem"] = temps
+	return STORE_OK if address == int(layout.get("unlocked_silph_doors", -1)) else STORE_NOT_NAMED
+
+
+static func _script_stored_register(layout: Dictionary, address: int, state: Dictionary) -> int:
+	var name: String = _script_address_name(layout, address, SCRIPT_STORED_REGISTERS.keys())
+	if name.is_empty():
+		return STORE_NOT_NAMED
+	if not state.has("a"):
+		return STORE_REFUSED
+	## `wOpponentAfterWrongAnswer` into `hSpriteIndex`: the object is the run's.
+	if name == "text_id_hram" and state.has("a_runtime"):
+		state.erase("map_text")
+		state["map_text_from"] = int(state["a_runtime"])
+		state["map_text_offset"] = int(state["a"])
+		return STORE_OK
+	state.erase("map_text_from")
+	state[String(SCRIPT_STORED_REGISTERS[name])] = int(state["a"])
+	return STORE_OK
+
+
+## A [constant Gen1Layout.SCRIPT_STORED_BYTES] row, known or `Random` under a mask.
+static func _script_stored_byte(
+	layout: Dictionary, address: int, state: Dictionary, out: Array
+) -> int:
+	var name: String = _script_address_name(layout, address, Gen1Layout.SCRIPT_STORED_BYTES)
+	if name.is_empty():
+		return STORE_NOT_NAMED
+	if _script_known_a(state):
+		out.append({"op": "store_byte", "name": name, "value": int(state["a"])})
+		return STORE_OK
+	if not _script_random_source(layout, state):
+		return STORE_REFUSED
+	out.append({"op": "store_byte", "name": name, "random": true,
+		"mask": int(state.get("mask", 0xFF)), "shift": int(state.get("shift", 0))})
+	return STORE_OK
 
 
 ## The held buttons, the automatic box, `wJoyIgnore`, a redraw gate and the list
@@ -2760,12 +2899,17 @@ static func _script_stored_scratch(
 	layout: Dictionary, address: int, state: Dictionary, out: Array
 ) -> int:
 	for name: String in Gen1Layout.SCRIPT_SCRATCH_BYTES:
+		if address == int(layout.get(name, -1)) and state.has("a_runtime"):
+			out.append({"op": "scratch", "address": address,
+				"from": int(state["a_runtime"]), "offset": int(state["a"])})
+			return STORE_OK
 		if address == int(layout.get(name, -1)) and state.has("a"):
 			out.append({"op": "scratch", "address": address, "value": int(state["a"])})
 			if name == "trainer_header_flag_bit":
 				var temps: Dictionary = (state.get("mem", {}) as Dictionary).duplicate()
 				temps[address] = int(state["a"])
 				state["mem"] = temps
+			if Gen1Layout.SCRIPT_RUNTIME_SCRATCH.has(name):
 				return STORE_OK
 	return _script_stored_sprite({}, layout, address, state, out)
 
@@ -3123,6 +3267,8 @@ static func _script_prefix(
 	)
 	var bit: int = (code >> 3) & 7
 	var operand: int = code & 7
+	if code == Gen1Layout.SCRIPT_SRL_A:
+		return _script_shifted(ctx, pc, state)
 	if code == Gen1Layout.SCRIPT_SWAP_A:
 		if not state.has("a"):
 			return SCRIPT_UNREAD
@@ -3149,14 +3295,8 @@ static func _script_prefix(
 			out.append({"op": "volatile", "name": volatile,
 				"set": code >= Gen1Layout.SCRIPT_SET_BASE})
 		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
-	## `wCurrentMapScriptFlags` is clear on every frame but the one a map is
-	## loaded on, which [method _read_map_callback] reads instead, so the gate
-	## in front of a per-frame script tests false and its `res` spends nothing.
 	if int(state.get("hl", -1)) == int((ctx["layout"] as Dictionary)["map_script_flags"]):
-		if code < Gen1Layout.SCRIPT_RES_BASE:
-			_script_untested(state)
-			state["known_zero"] = true
-		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+		return _script_map_load_bit(ctx, pc, code, bit, state, out)
 	if code < Gen1Layout.SCRIPT_RES_BASE:
 		## `CheckEventHL` names its flag in `hl` where `CheckEvent` loads it.
 		state["source"] = int(state.get("hl", -1))
@@ -3177,6 +3317,48 @@ static func _script_prefix(
 	_script_snapshot_flags(ctx, state, out)
 	out.append(node)
 	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+
+
+## `wCurrentMapScriptFlags`: `bit` reads the walk's mask, `set` asks for a re-run.
+static func _script_map_load_bit(
+	ctx: Dictionary, pc: int, code: int, bit: int, state: Dictionary, out: Array
+) -> int:
+	if code < Gen1Layout.SCRIPT_RES_BASE:
+		_script_untested(state)
+		state["known_zero"] = (int(ctx.get("map_load_mask", 0)) & (1 << bit)) == 0
+	elif code >= Gen1Layout.SCRIPT_SET_BASE:
+		out.append({"op": "map_load_bit", "bit": bit})
+	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+
+
+static func _script_shifted(ctx: Dictionary, pc: int, state: Dictionary) -> int:
+	if _script_known_a(state):
+		_script_computed(state, int(state["a"]) >> 1)
+	elif _script_random_source(ctx["layout"], state):
+		state["shift"] = int(state.get("shift", 0)) + 1
+	else:
+		return SCRIPT_UNREAD
+	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+
+
+static func _script_computed(state: Dictionary, value: int) -> void:
+	_script_wrote_a(state)
+	_script_untested(state)
+	state["a"] = value
+	state["known_zero"] = value == 0
+
+
+static func _script_known_a(state: Dictionary) -> bool:
+	return state.has("a") and not state.has("a_symbolic") and not state.has("a_runtime")
+
+
+static func _script_random_source(layout: Dictionary, state: Dictionary) -> bool:
+	if state.has("a"):
+		return false
+	for name: String in Gen1Layout.SCRIPT_RANDOM_SOURCES:
+		if int(state.get("source", -1)) == int(layout.get(name, -2)):
+			return true
+	return false
 
 
 static func _script_zero_bit(layout: Dictionary, address: int, bit: int) -> bool:
@@ -3271,7 +3453,8 @@ static func _script_special_body(ctx: Dictionary, pc: int) -> Variant:
 	var layout: Dictionary = ctx["layout"]
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
-	if pc == int(layout.get("update_gym_gates", -1)):
+	if pc == int(layout.get("update_gym_gates", -1)) \
+		or at == int(layout.get("update_gym_gates_far", -1)):
 		return _script_gym_gates(ctx)
 	if at != int(layout.get("route23_default_script", -1)):
 		return null
@@ -3319,6 +3502,8 @@ static func _script_call(
 	if routine in Gen1Layout.SCRIPT_SILENT_CALLS:
 		return next
 	var shaped: int = _script_shaped_routine(ctx, target, state, out)
+	if shaped == SCRIPT_NOT_SHAPED:
+		shaped = _script_card_key_call(ctx, target, state, out)
 	if shaped != SCRIPT_NOT_SHAPED:
 		return next if shaped == SCRIPT_SHAPE_READ else SCRIPT_UNREAD
 	match routine:
@@ -3385,9 +3570,9 @@ static func _script_called(
 		"player_coords_in_array":
 			return _script_coord_array(ctx, state, next)
 		"call_function_in_table":
-			return _script_map_script_table(ctx, state, out, int(state.get("hl", -1)))
+			return _script_map_script_table(ctx, state, out, int(state.get("hl", -1)), next)
 		"execute_map_script":
-			return _script_map_script_table(ctx, state, out, int(state.get("de", -1)))
+			return _script_map_script_table(ctx, state, out, int(state.get("de", -1)), next)
 		"load_item_list":
 			if not state.has("hl"):
 				return SCRIPT_UNREAD
@@ -3636,48 +3821,58 @@ static func _script_sprite_called(
 
 
 ## `hSpriteIndex` counts the player as slot 0, so an object is one below it.
-static func _script_sprite_object(state: Dictionary) -> int:
-	return int(state.get("map_text", 0)) - 1 if state.has("map_text") else -1
+static func _script_sprite_object(state: Dictionary) -> Dictionary:
+	if state.has("map_text_from"):
+		return {"object_from": int(state["map_text_from"]),
+			"object_offset": int(state["map_text_offset"]) - 1}
+	if state.has("map_text"):
+		return {"object": int(state["map_text"]) - 1}
+	return {}
 
 
 static func _script_object_facing(state: Dictionary, out: Array, next: int) -> int:
-	var object: int = _script_sprite_object(state)
+	var object: Dictionary = _script_sprite_object(state)
 	var facing: int = int(state.get("sprite_facing", -1))
-	if object < 0 or not Gen1Layout.FACING_STEPS.has(facing):
+	if object.is_empty() or not Gen1Layout.FACING_STEPS.has(facing):
 		return SCRIPT_UNREAD
-	out.append({"op": "object_facing", "object": object, "facing": facing})
+	out.append(_script_object_node({"op": "object_facing", "facing": facing}, object))
 	return next
+
+
+static func _script_object_node(node: Dictionary, object: Dictionary) -> Dictionary:
+	node.merge(object)
+	return node
 
 
 ## `SetSpriteMovementBytesToFF` puts STAY over the map's own template: the
 ## object stops walking and turns where it stands.
 static func _script_object_stay(state: Dictionary, out: Array, next: int) -> int:
-	var object: int = _script_sprite_object(state)
-	if object < 0:
+	var object: Dictionary = _script_sprite_object(state)
+	if object.is_empty():
 		return SCRIPT_UNREAD
-	out.append({"op": "object_stay", "object": object})
+	out.append(_script_object_node({"op": "object_stay"}, object))
 	return next
 
 
 static func _script_object_move(
 	ctx: Dictionary, state: Dictionary, out: Array, next: int
 ) -> int:
-	var object: int = _script_sprite_object(state)
-	if object < 0:
+	var object: Dictionary = _script_sprite_object(state)
+	if object.is_empty():
 		return SCRIPT_UNREAD
 	if int(state.get("de", -1)) == int((ctx["layout"] as Dictionary).get("npc_movement_directions", -1)):
 		if not state.has("npc_path_ready"):
 			return SCRIPT_UNREAD
 		var path: Dictionary = state["npc_path"]
-		out.append({"op": "object_path", "object": object, "target": int(path["target"]),
-			"perspective": int(path["perspective"]), "y_adjust": int(path["y_adjust"])})
+		out.append(_script_object_node({"op": "object_path", "target": int(path["target"]),
+			"perspective": int(path["perspective"]), "y_adjust": int(path["y_adjust"])}, object))
 		state.erase("npc_path")
 		state.erase("npc_path_ready")
 		return next
 	var moves: Array = _script_movement_list(ctx, int(state.get("de", -1)))
 	if moves.is_empty():
 		return SCRIPT_UNREAD
-	out.append({"op": "object_move", "object": object, "moves": moves})
+	out.append(_script_object_node({"op": "object_move", "moves": moves}, object))
 	return next
 
 
@@ -3832,11 +4027,10 @@ static func _script_coord_array(ctx: Dictionary, state: Dictionary, next: int) -
 	return next
 
 
-## `CallFunctionInTable` and `ExecuteCurMapScriptInTable`: the map's own state
-## machine, whose table is in `hl` for one and `de` for the other and whose
-## index is the `w<Map>CurScript` byte the `ld a` above it read.
+## `CallFunctionInTable` and `ExecuteCurMapScriptInTable`: the table is in `hl`
+## or `de`, the index the `w<Map>CurScript` byte read above, answered back in `a`.
 static func _script_map_script_table(
-	ctx: Dictionary, state: Dictionary, out: Array, table: int
+	ctx: Dictionary, state: Dictionary, out: Array, table: int, next: int
 ) -> int:
 	var byte: int = _map_script_byte(ctx["layout"], int(state.get("source", -1)))
 	if table < 0:
@@ -3850,7 +4044,12 @@ static func _script_map_script_table(
 	if byte < 0:
 		return SCRIPT_UNREAD
 	out.append({"op": "map_script_table", "table": table, "byte": byte})
-	return SCRIPT_END
+	var source: int = int(state["source"])
+	_script_wrote_a(state)
+	state.erase("a")
+	state["source"] = source
+	state["map_script_returned"] = true
+	return next
 
 
 ## `<Map>_Script` copies `wCurMapScript` into the map's own byte on the next
@@ -4216,8 +4415,14 @@ static func _script_predef(
 	if named >= 0:
 		return next if named == STORE_OK else SCRIPT_UNREAD
 	var hidden: bool = target == int(layout["hide_object"])
-	if not state.has("toggle") \
-		or (not hidden and target != int(layout["show_object"])):
+	if not hidden and target != int(layout["show_object"]):
+		return SCRIPT_UNREAD
+	if state.has("toggle_from"):
+		out.append({"op": "toggle_object", "object_from": int(state["toggle_from"]),
+			"object_offset": -1, "hidden": hidden})
+		state.erase("toggle_from")
+		return next
+	if not state.has("toggle"):
 		return SCRIPT_UNREAD
 	out.append({"op": "toggle_object", "index": int(state["toggle"]), "hidden": hidden})
 	state.erase("toggle")
@@ -4364,6 +4569,11 @@ static func _script_shaped_routine(
 	var items: int = int(layout.get("filtered_bag_items", -1))
 	if rom.u8(at) == Gen1Layout.SCRIPT_LD_HL and rom.u16le(at + 1) == items:
 		return _script_filter_printed(ctx, at, state)
+	if _script_opens_with(rom, at + Gen1Layout.SCRIPT_LONG_SIZE, [
+		Gen1Layout.SCRIPT_LD_A_MEM, int(layout["sprite_index_wram"]) & 0xFF,
+		int(layout["sprite_index_wram"]) >> 8, Gen1Layout.SCRIPT_DEC_A,
+		Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_SWAP_A]):
+		return _script_object_coord_move(ctx, rom.u16le(at + 1), out)
 	if rom.u8(at) == Gen1Layout.SCRIPT_LD_HL and rom.u16le(at + 1) == int(layout.get("bag_items", -1)):
 		return _script_bag_scan(ctx, at, out)
 	if rom.u8(at) != Gen1Layout.SCRIPT_XOR_A \
@@ -4379,6 +4589,51 @@ static func _script_shaped_routine(
 	if rows.is_empty():
 		return SCRIPT_SHAPE_REFUSED
 	state["filtered"] = rows
+	return SCRIPT_SHAPE_READ
+
+
+## `<Map>_SetCardKeyDoorYScript` and `<Map>_UnlockedDoorEventScript`, both loops.
+static func _script_card_key_call(
+	ctx: Dictionary, target: int, state: Dictionary, out: Array
+) -> int:
+	var rom: RomFile = ctx["rom"]
+	var layout: Dictionary = ctx["layout"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), target)
+	if rom.u8(at) == Gen1Layout.SCRIPT_PUSH_HL and rom.u8(at + 1) == Gen1Layout.SCRIPT_LD_HL \
+		and rom.u16le(at + 2) == int(layout["card_key_door"]):
+		if not state.has("hl"):
+			return SCRIPT_SHAPE_REFUSED
+		out.append({"op": "card_key_doors", "cells": _script_cell_list(ctx, int(state["hl"]))})
+		return SCRIPT_SHAPE_READ
+	var read: int = at + (Gen1Layout.SCRIPT_LONG_SIZE if rom.u8(at) == Gen1Layout.SCRIPT_LD_HL else 0)
+	if rom.u8(read) == Gen1Layout.SCRIPT_LDH_A_MEM \
+		and Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(read + 1) == int(layout["unlocked_silph_doors"]):
+		return SCRIPT_SHAPE_READ
+	return SCRIPT_NOT_SHAPED
+
+
+static func _script_opens_with(rom: RomFile, at: int, bytes: Array) -> bool:
+	for offset: int in bytes.size():
+		if rom.u8(at + offset) != int(bytes[offset]):
+			return false
+	return true
+
+
+## `PokemonTower7FRocketLeaveMovementScript`: `(wSpriteIndex - 1) << 4` picks the
+## rocket's four rows and the player's cell one of them.
+static func _script_object_coord_move(ctx: Dictionary, table: int, out: Array) -> int:
+	var rom: RomFile = ctx["rom"]
+	var rows: Array = []
+	while rows.size() < Gen1Layout.ARROW_TILE_MAX:
+		var at: int = Gen1Layout.banked(int(ctx["bank"]), table + rows.size() * Gen1Layout.ARROW_ROW_SIZE)
+		var moves: Array = _script_movement_list(ctx, rom.u16le(at + Gen1Layout.MAP_COORD_SIZE))
+		if moves.is_empty():
+			break
+		rows.append({"y": rom.u8(at), "x": rom.u8(at + 1), "moves": moves})
+	if rows.is_empty() or rows.size() % Gen1Layout.OBJECT_COORD_ROWS != 0:
+		return SCRIPT_SHAPE_REFUSED
+	out.append({"op": "object_coord_move", "object_from": int((ctx["layout"] as Dictionary)["sprite_index_wram"]),
+		"object_offset": -1, "rows": rows})
 	return SCRIPT_SHAPE_READ
 
 
@@ -4766,17 +5021,17 @@ static func _script_compared_byte(
 		int(layout.get("random_add", -1)): ["random_below", SCRIPT_TESTS_RANDOM, 0],
 		int(layout.get("sprite_index_wram", -1)): ["talking", SCRIPT_TESTS_TALKING, -1],
 	}
-	if source in [int(layout.get("rival_starter_ball", -1)),
-		int(layout.get("trainer_header_flag_bit", -1))]:
+	if tests.has(source) and source >= 0:
+		var row: Array = tests[source]
+		state[String(row[0])] = value + int(row[2])
+		_script_tested(state, int(row[1]), int(row[1]) == SCRIPT_TESTS_RANDOM)
+		return true
+	if source == int(layout.get("rival_starter_ball", -1)) \
+		or _script_address_name(layout, source, Gen1Layout.SCRIPT_RUNTIME_SCRATCH) != "":
 		state["scratch_test"] = [source, value]
 		_script_tested(state, SCRIPT_TESTS_SCRATCH)
 		return true
-	if not tests.has(source) or source < 0:
-		return false
-	var row: Array = tests[source]
-	state[String(row[0])] = value + int(row[2])
-	_script_tested(state, int(row[1]), int(row[1]) == SCRIPT_TESTS_RANDOM)
-	return true
+	return false
 
 
 ## `PrintPredefTextID`: `TextPredefs` counts from 1 and a row is read in the
@@ -4829,6 +5084,11 @@ static func _script_text_row(
 
 ## `ldh [hTextID], a` and `jp DisplayTextID`: one of the map's own text rows.
 static func _script_map_text(state: Dictionary, out: Array, next: int) -> int:
+	if state.has("map_text_from"):
+		out.append({"op": "map_text", "from": int(state["map_text_from"]),
+			"offset": int(state["map_text_offset"])})
+		state.erase("map_text_from")
+		return next
 	if not state.has("map_text"):
 		return SCRIPT_UNREAD
 	out.append({"op": "map_text", "text": int(state["map_text"])})
@@ -4878,6 +5138,8 @@ static func _script_node(
 				"index_source": int(action[2]), "index_offset": int(action[3]),
 				"then": taken, "else": fell}
 		SCRIPT_TESTS_CHOICE:
+			if bool(state.get("choice_inverted", false)):
+				return {"op": "choice", "no": fell, "yes": taken}
 			return {"op": "choice", "no": taken, "yes": fell}
 		SCRIPT_TESTS_CARRY:
 			return _script_receipt(out, taken, fell)
@@ -5081,10 +5343,10 @@ static func _read_mart_items(rom: RomFile, at: int) -> Array:
 ## nerd's line. True when the table grew and the states want reading again.
 static func _extend_texts(
 	rom: RomFile, layout: Dictionary, bank: int, address: int, texts: Array,
-	events: Dictionary, callback: Dictionary, states: Dictionary
+	events: Dictionary, states: Dictionary
 ) -> bool:
-	var scripts: Array = [states["entry"], callback.get("nodes", [])]
-	for row: Dictionary in (states["states"] as Array) + texts:
+	var scripts: Array = [states["entry"]]
+	for row: Dictionary in (states["callbacks"] as Array) + (states["states"] as Array) + texts:
 		scripts.append(row.get("script", row.get("nodes", [])))
 	for row: Dictionary in events.get("hidden_events", []) as Array:
 		scripts.append(row.get("script", []))
@@ -5106,7 +5368,7 @@ static func _highest_map_text(nodes: Array) -> int:
 	var highest: int = 0
 	for node: Dictionary in nodes:
 		if String(node["op"]) == "map_text":
-			highest = maxi(highest, int(node["text"]))
+			highest = maxi(highest, int(node.get("text", 0)))
 		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
 			if node.has(key):
 				highest = maxi(highest, _highest_map_text(node[key] as Array))

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3618,26 +3618,16 @@ func tile_indices_in_window(origin: Vector2i, size: Vector2i) -> PackedInt32Arra
 	return out
 
 
-## The block a tile is drawn from, which is not always the block that is there.
-##
-## `LoadMetatiles` (`home/map.asm:120`) substitutes `wMapBorderBlock` for any
-## block byte of `$00`, and the padding `ChangeMap` puts around the map is that
-## same border block wherever no connection fills it. Both are graphics only:
-## `GetCoordTileCollision` (`home/map.asm:2065`) reads the raw byte and answers
-## -1 for `$00`, which is why [method block_at] is left alone and the collision
-## path never comes through here.
+## `LoadMetatiles` (`home/map.asm:120`) draws `wMapBorderBlock` for a `$00`
+## block and `ChangeMap`'s padding, graphics only: `GetCoordTileCollision`
+## (`home/map.asm:2065`) reads the raw byte, so [method block_at] is left alone.
 func drawn_block_at(block_x: int, block_y: int) -> int:
 	return drawn_block_for(data, current_map, block_x, block_y, _block_overrides)
 
 
-## [method drawn_block_at] for a view wider than the hardware's own.
-##
-## Inside `wOverworldMapBlocks` this is [method drawn_block_at] byte for byte,
-## so nothing a 20x18 screen can reach changes. Past it the cartridge holds
-## nothing at all, and a view that reaches further would show border block to
-## the horizon; the connection graph places whole neighbouring maps there
-## instead ([method map_placements]), and the border block still fills what no
-## map covers.
+## [method drawn_block_at] for a view wider than the hardware's own: past
+## `wOverworldMapBlocks` the neighbouring maps stand where the cartridge holds
+## nothing ([method map_placements]), and the border block fills the rest.
 func expanded_block_at(block_x: int, block_y: int) -> int:
 	if current_map == null:
 		return 0
@@ -3715,14 +3705,9 @@ static func placements_around(
 	return out
 
 
-## Where [param target] sits, in [param source]'s block coordinates, for a
-## connection running [param connection] out of [param source].
-##
-## The four cases are `_connected_drawn_block_at`'s own arithmetic read the
-## other way round: it takes a padding block to a cell of the target, and this
-## takes the target's own origin to a block of the source. Both come from
-## `FillMapConnections`' pointer sums, and having them in one place is what
-## keeps a strip and the map behind it from disagreeing by a block.
+## Where [param target] sits in [param source]'s block coordinates:
+## `_connected_drawn_block_at`'s arithmetic the other way round, both out of
+## `FillMapConnections`' pointer sums so a strip and its map agree.
 static func connection_origin_blocks(
 	source: Gen2WorldMap, target: Gen2WorldMap, connection: Dictionary
 ) -> Vector2i:
@@ -3913,6 +3898,8 @@ var _gen1_saved_coord_index: int = 0
 var _gen1_safari_game_over: bool = false
 var _gen1_safari_admitted: Dictionary = {}
 var _gen1_entry_steps: Array = []
+## `wCurrentMapScriptFlags` bits a script set back for the next `RunMapScript`.
+var _gen1_map_load_pending: int = 0
 var _gen1_volatile: Dictionary = {}
 var _gen1_last_boulder: int = -1
 var _gen1_last_sprite_index: int = -1
@@ -3996,6 +3983,10 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"movement_script_running": &"_gen1_node_movement_script_running",
 	"npc_movement_script": &"_gen1_node_npc_movement_script",
 	"volatile": &"_gen1_node_volatile",
+	"map_load_bit": &"_gen1_node_map_load_bit",
+	"store_byte": &"_gen1_node_store_byte",
+	"gym_trash": &"_gen1_node_gym_trash",
+	"object_coord_move": &"_gen1_node_object_coord_move",
 	"volatile_test": &"_gen1_node_volatile_test",
 	"boulder_on": &"_gen1_node_boulder_on",
 	"coord_lookup": &"_gen1_node_coord_lookup",
@@ -4218,8 +4209,16 @@ func _gen1_run(event: Dictionary) -> Dictionary:
 		"bag": state.items() if state != null else {}, "named": "", "object": event,
 		"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
 		"coins": state.coins() if state != null else 0,
-		"flags": {}, "engine_flags": {}, "flag_tests": {}, "scratch": _gen1_scratch.duplicate(),
+		"flags": {}, "engine_flags": {}, "flag_tests": {}, "scratch": _gen1_run_scratch(),
 	}
+
+
+## `wSpriteIndex` counts objects from one.
+func _gen1_run_scratch() -> Dictionary:
+	var scratch: Dictionary = _gen1_scratch.duplicate()
+	if data != null and _gen1_last_sprite_index >= 0:
+		scratch[int(Gen1Layout.for_id(data.id)["sprite_index_wram"])] = _gen1_last_sprite_index + 1
+	return scratch
 
 
 ## [param run] is the bag the row is walked against, carrying what its own gifts
@@ -4395,10 +4394,10 @@ func _gen1_node_player_in_array(
 ## One object's own byte of `wSpriteStateData1`, which a script writes by hand
 ## to turn an NPC where `applymovement` would turn one on Generation 2.
 func _gen1_node_object_facing(
-	node: Dictionary, steps: Array, _run: Dictionary
+	node: Dictionary, steps: Array, run: Dictionary
 ) -> bool:
 	steps.append({
-		"type": &"object_facing", "index": int(node["object"]),
+		"type": &"object_facing", "index": _gen1_object_index(node, run),
 		"facing": facing_for_direction(Gen1Layout.FACING_STEPS[int(node["facing"])]),
 	})
 	return true
@@ -4424,11 +4423,9 @@ func _gen1_node_map_script_table(
 ) -> bool:
 	if state == null or current_map == null:
 		return false
-	var index: int = state.gen1_map_script(int(node["byte"]))
-	for row: Dictionary in current_map.scripts.get("states", []) as Array:
-		if int(row.get("id", -1)) == index:
-			return _gen1_resolve_script(row.get("nodes", []) as Array, steps, run)
-	return true
+	return _gen1_resolve_script(
+		_gen1_map_state_nodes(state.gen1_map_script(int(node["byte"]))), steps, run
+	)
 
 
 ## The two Snorlax and the Pokemon Tower's Marowak, fought once a state returns.
@@ -4461,6 +4458,19 @@ func _gen1_node_arrow_movement(node: Dictionary, steps: Array, run: Dictionary) 
 	return _gen1_resolve_side(node, false, steps, run)
 
 
+func _gen1_node_object_coord_move(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var object: int = _gen1_object_index(node, run)
+	var rows: Array = node["rows"]
+	for index: int in range(object * Gen1Layout.OBJECT_COORD_ROWS,
+		mini(rows.size(), (object + 1) * Gen1Layout.OBJECT_COORD_ROWS)):
+		var row: Dictionary = rows[index]
+		if player_cell != Vector2i(int(row["x"]), int(row["y"])):
+			continue
+		steps.append({"type": &"object_move", "index": object, "moves": (row["moves"] as Array).duplicate()})
+		return true
+	return true
+
+
 func _gen1_node_walk(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	var moves: Array = (node["moves"] as Array).duplicate(true)
 	if node.has("steps_offset"):
@@ -4474,16 +4484,16 @@ func _gen1_node_walk(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 
 ## `MoveSprite` returns as soon as it has copied the list, so its steps are
 ## drawn behind the script rather than in front of it.
-func _gen1_node_object_move(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_object_move(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	steps.append({
-		"type": &"object_move", "index": int(node["object"]),
+		"type": &"object_move", "index": _gen1_object_index(node, run),
 		"moves": (node["moves"] as Array).duplicate(),
 	})
 	return true
 
 
-func _gen1_node_object_stay(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
-	steps.append({"type": &"object_stay", "index": int(node["object"])})
+func _gen1_node_object_stay(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	steps.append({"type": &"object_stay", "index": _gen1_object_index(node, run)})
 	return true
 
 
@@ -4782,9 +4792,21 @@ func _gen1_node_name_badge(node: Dictionary, _steps: Array, run: Dictionary) -> 
 
 
 func _gen1_node_scratch(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	(run["scratch"] as Dictionary)[int(node["address"])] = int(node["value"])
-	steps.append({"type": &"scratch", "address": int(node["address"]), "value": int(node["value"])})
+	var value: int = int(node["value"]) if node.has("value") \
+		else _gen1_scratch_read(run, int(node["from"]), int(node["offset"]))
+	(run["scratch"] as Dictionary)[int(node["address"])] = value
+	steps.append({"type": &"scratch", "address": int(node["address"]), "value": value})
 	return true
+
+
+func _gen1_scratch_read(run: Dictionary, address: int, offset: int) -> int:
+	return (int((run["scratch"] as Dictionary).get(address, 0)) + offset) & 0xFF
+
+
+func _gen1_object_index(node: Dictionary, run: Dictionary) -> int:
+	if node.has("object"):
+		return int(node["object"])
+	return _gen1_scratch_read(run, int(node["object_from"]), int(node["object_offset"]))
 
 
 func _gen1_node_scratch_test(node: Dictionary, steps: Array, run: Dictionary) -> bool:
@@ -4794,13 +4816,11 @@ func _gen1_node_scratch_test(node: Dictionary, steps: Array, run: Dictionary) ->
 
 
 func _gen1_node_random(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	var roll: int = script_random.randi_range(0, 255) if script_random != null else 0
-	return _gen1_resolve_side(node, roll < int(node["below"]), steps, run)
+	return _gen1_resolve_side(node, _gen1_roll() < int(node["below"]), steps, run)
 
 
 func _gen1_node_random_bit(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	var roll: int = script_random.randi_range(0, 255) if script_random != null else 0
-	return _gen1_resolve_side(node, roll & (1 << int(node["bit"])) != 0, steps, run)
+	return _gen1_resolve_side(node, _gen1_roll() & (1 << int(node["bit"])) != 0, steps, run)
 
 
 func _gen1_node_talking_to(node: Dictionary, steps: Array, run: Dictionary) -> bool:
@@ -4866,6 +4886,70 @@ func _gen1_node_npc_movement_script(node: Dictionary, steps: Array, _run: Dictio
 	return true
 
 
+func _gen1_node_store_byte(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	var value: int = int(node.get("value", 0))
+	if bool(node.get("random", false)):
+		value = (_gen1_roll() & int(node["mask"])) >> int(node["shift"])
+	steps.append({"type": &"byte", "name": String(node["name"]), "value": value})
+	return true
+
+
+## `GymTrashScript`, whose second lock sets `VermilionGymSetDoorTile`'s bit.
+func _gen1_node_gym_trash(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var can: int = int(node["can"])
+	var side: String = "trash"
+	if state != null and not _gen1_run_flag(Gen1Layout.LOCK_2ND_EVENT, run):
+		if not _gen1_run_flag(Gen1Layout.LOCK_1ST_EVENT, run):
+			if can == state.gen1_byte(GEN1_FIRST_LOCK):
+				_gen1_node_flag({"flag": Gen1Layout.LOCK_1ST_EVENT, "set": true}, steps, run)
+				_gen1_draw_second_can(node, steps)
+				side = "first_lock"
+		elif can in [state.gen1_byte(GEN1_SECOND_LOCK), state.gen1_byte(GEN1_SECOND_LOCK_ALT)]:
+			_gen1_node_flag({"flag": Gen1Layout.LOCK_2ND_EVENT, "set": true}, steps, run)
+			steps.append({"type": &"map_load", "bit": Gen1Layout.MAP_LOADED_2_BIT})
+			side = "second_lock"
+		else:
+			_gen1_node_flag({"flag": Gen1Layout.LOCK_1ST_EVENT, "set": false}, steps, run)
+			steps.append({"type": &"byte", "name": GEN1_FIRST_LOCK,
+				"value": _gen1_roll() & Gen1Layout.TRASH_FIRST_MASK})
+			side = "reset"
+	return _gen1_resolve_script(node[side] as Array, steps, run)
+
+
+## Where `CheckFightingMapTrainers`' two increments leave a map's script.
+const GEN1_END_BATTLE_STATE: int = 2
+const GEN1_FIRST_LOCK: String = "first_lock_trash_can"
+const GEN1_SECOND_LOCK: String = "second_lock_trash_can"
+const GEN1_SECOND_LOCK_ALT: String = "second_lock_trash_can_alt"
+
+
+func _gen1_draw_second_can(node: Dictionary, steps: Array) -> void:
+	var table: Array = node["table"]
+	var row: int = int(node["can"]) * int(node["row_size"])
+	var roll: int = _gen1_roll()
+	var swapped: int = ((roll & 0xF) << 4) | (roll >> 4)
+	if int(node["row_size"]) == Gen1Layout.TRASH_ROW_SIZE:
+		var masked: int = ((int(table[row]) & swapped) - 1) & 0xFF
+		steps.append({"type": &"byte", "name": GEN1_SECOND_LOCK,
+			"value": int(table[row + 1 + masked]) & Gen1Layout.TRASH_CAN_MASK})
+		steps.append({"type": &"byte", "name": GEN1_SECOND_LOCK_ALT, "value": 0})
+		return
+	var pair: int = {2: roll & 1, 3: swapped, 4: roll & 3}.get(int(table[row]), 0)
+	steps.append({"type": &"byte", "name": GEN1_SECOND_LOCK,
+		"value": int(table[row + 1 + 2 * pair])})
+	steps.append({"type": &"byte", "name": GEN1_SECOND_LOCK_ALT,
+		"value": int(table[row + 2 + 2 * pair])})
+
+
+func _gen1_roll() -> int:
+	return script_random.randi_range(0, 255) if script_random != null else 0
+
+
+func _gen1_node_map_load_bit(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"map_load", "bit": int(node["bit"])})
+	return true
+
+
 func _gen1_node_volatile(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
 	steps.append({"type": &"volatile", "name": String(node["name"]), "set": bool(node["set"])})
 	return true
@@ -4905,9 +4989,9 @@ func _gen1_node_emote(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
 	return true
 
 
-func _gen1_node_object_path(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_object_path(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	steps.append({
-		"type": &"object_path", "index": int(node["object"]), "target": int(node["target"]),
+		"type": &"object_path", "index": _gen1_object_index(node, run), "target": int(node["target"]),
 		"perspective": int(node["perspective"]), "y_adjust": int(node["y_adjust"]),
 	})
 	return true
@@ -5041,7 +5125,13 @@ func _gen1_node_badges_byte(node: Dictionary, steps: Array, run: Dictionary) -> 
 func _gen1_node_map_text(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	if current_map == null:
 		return false
-	var row: Dictionary = gen1_text_at(int(node["text"]))
+	var row: Dictionary = gen1_text_at(int(node["text"]) if node.has("text") \
+		else _gen1_scratch_read(run, int(node["from"]), int(node["offset"])))
+	## `DisplayTextID` over a trainer's row is `TalkToTrainer` after the fight.
+	var trainer: Array = _gen1_trainer_steps(row, {})
+	if not trainer.is_empty():
+		steps.append_array(trainer)
+		return true
 	var nodes: Variant = row.get("script", [])
 	if nodes is Array and not (nodes as Array).is_empty():
 		return _gen1_resolve_script(nodes as Array, steps, run)
@@ -5072,10 +5162,11 @@ func _gen1_node_coin_box(_node: Dictionary, steps: Array, _run: Dictionary) -> b
 	return true
 
 
-func _gen1_node_toggle(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+func _gen1_node_toggle(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	steps.append({
 		"type": &"toggle",
-		"index": int(node["index"]),
+		"index": int(node["index"]) if node.has("index") \
+			else _gen1_toggle_index(_gen1_object_index(node, run)),
 		"hidden": bool(node["hidden"]),
 	})
 	return true
@@ -5970,18 +6061,20 @@ func _gen1_sight() -> Array:
 	var ended: Array = _gen1_safari_check()
 	if not ended.is_empty():
 		return ended
+	## A script that only wrote blocks holds nothing, and the trainer check follows.
 	var running: Array = _gen1_map_script()
-	if not running.is_empty():
+	if _gen1_holding():
 		return running
 	var request: Dictionary = _find_sight_request()
 	if request.is_empty():
-		return []
+		return running
 	var event: Dictionary = request["event"]
+	_gen1_last_sprite_index = int(request["object_index"])
 	var steps: Array = _gen1_trainer_steps(
 		current_map.text_at(int(event.get("text", 0))), event
 	)
 	if steps.is_empty():
-		return []
+		return running
 	_gen1_steps = [{"type": &"request", "values": {
 		"kind": &"trainer_approach_requested",
 		"values": {
@@ -5990,7 +6083,15 @@ func _gen1_sight() -> Array:
 			"distance": int(request["distance"]),
 		},
 	}}] + steps
-	return _gen1_result()
+	return _gen1_joined(running, _gen1_result())
+
+
+func _gen1_joined(first: Array, second: Array) -> Array:
+	if first.is_empty() or second.is_empty():
+		return first + second
+	(second[0] as Dictionary)["events"] = (first[0] as Dictionary).get("events", []) \
+		+ (second[0] as Dictionary).get("events", [])
+	return second
 
 
 ## `CheckEvent EVENT_IN_SAFARI_ZONE`, which gates the counter and the window.
@@ -6066,12 +6167,25 @@ func _gen1_safari_box(name: String) -> Dictionary:
 func gen1_safari_gate_byte() -> int:
 	var gate: Gen2WorldMap = data.world_map(0, Gen1Layout.SAFARI_ZONE_GATE_MAP) \
 		if data != null else null
-	if gate == null:
-		return -1
-	for node: Dictionary in (gate.scripts.get("entry", []) as Array):
+	return _gen1_dispatch_byte(gate) if gate != null else -1
+
+
+func _gen1_map_script_byte() -> int:
+	return _gen1_dispatch_byte(current_map) if current_map != null else -1
+
+
+func _gen1_dispatch_byte(map: Gen2WorldMap) -> int:
+	for node: Dictionary in map.scripts.get("entry", []) as Array:
 		if String(node.get("op", "")) == "map_script_table":
 			return int(node["byte"])
 	return -1
+
+
+func _gen1_map_state_nodes(index: int) -> Array:
+	for row: Dictionary in current_map.scripts.get("states", []) as Array:
+		if int(row.get("id", -1)) == index:
+			return row.get("nodes", []) as Array
+	return []
 
 
 ## `RunMapScript`, which `JoypadOverworld` runs every frame: what stands in
@@ -6083,7 +6197,8 @@ func _gen1_map_script() -> Array:
 		_gen1_steps = _gen1_entry_steps
 		_gen1_entry_steps = []
 		return _gen1_result()
-	var entry: Array = current_map.scripts.get("entry", [])
+	var entry: Array = _gen1_map_script_nodes(_gen1_map_load_pending)
+	_gen1_map_load_pending = 0
 	if entry.is_empty():
 		return []
 	var steps: Array = []
@@ -6247,6 +6362,12 @@ func _gen1_kept(step: Dictionary, events: Array) -> bool:
 			return true
 		&"volatile":
 			_gen1_volatile[String(step["name"])] = bool(step["set"])
+			return true
+		&"map_load":
+			_gen1_map_load_pending |= 1 << int(step["bit"])
+			return true
+		&"byte":
+			state.set_gen1_byte(String(step["name"]), int(step["value"]))
 			return true
 		&"text_table":
 			_gen1_text_table = int(step["table"])
@@ -6549,13 +6670,18 @@ func _gen1_ride_elevator(result: Dictionary) -> void:
 
 
 ## `EndTrainerBattle` flags a beaten opponent, and its `cp OPP_ID_OFFSET` skips
-## `HideObject` for a trainer, so only a standing wild goes off the map.
+## `HideObject` for a trainer, so only a standing wild goes off the map. It sets
+## both map-load bits, and `StartTrainerBattle` left the map's script on row 2.
 func _gen1_battle_won(step: Dictionary, result: Dictionary) -> void:
 	if result.has("outcome"):
 		_gen1_battle_outcome = StringName(result["outcome"])
 	var flag: int = int(step.get("trainer_flag", -1))
-	if flag < 0 or state == null:
+	if flag < 0 or state == null or not result.has("outcome"):
 		return
+	_gen1_map_load_pending = Gen1Layout.MAP_LOAD_BOTH
+	var byte: int = _gen1_map_script_byte()
+	if byte >= 0 and not _gen1_map_state_nodes(GEN1_END_BATTLE_STATE).is_empty():
+		state.set_gen1_map_script(byte, GEN1_END_BATTLE_STATE)
 	if StringName(result.get("outcome", &"")) not in GEN1_TRAINER_BEATEN:
 		return
 	state.set_event_flag(flag)
@@ -7356,14 +7482,10 @@ func _queue_map_callbacks(callback_type: int) -> void:
 	if current_map == null:
 		return
 	if _gen1:
-		_run_gen1_map_callback()
-		## `RunMapScript` runs once on the first frame behind `EnterMap`, so what
-		## it writes stands before the player may move and what it shows waits for
-		## the step dispatch. The rest of that one run is kept rather than resolved
-		## again: `CheckAndResetEvent` answers differently the second time.
-		_gen1_entry_steps = _spend_gen1_nodes(
-			current_map.scripts.get("entry", []) as Array
-		)
+		_unlock_gen1_card_key_door()
+		## `RunMapScript`'s first frame behind `EnterMap`: its writes stand before a
+		## step, its boxes wait for one, and `CheckAndResetEvent` answers only once.
+		_gen1_entry_steps = _spend_gen1_nodes(_gen1_map_script_nodes(Gen1Layout.MAP_LOAD_BOTH))
 		return
 	var bank: int = int(current_map.scripts.get("bank", 0))
 	for callback: Dictionary in current_map.scripts.get("callbacks", []):
@@ -7379,14 +7501,16 @@ func _queue_map_callbacks(callback_type: int) -> void:
 		})
 
 
-## The body behind a map's `wCurrentMapScriptFlags` bit. Running it again writes
-## the same blocks, so the second call a map entry makes says nothing new.
-func _run_gen1_map_callback() -> void:
-	var callbacks: Array = current_map.scripts.get("callbacks", [])
-	if callbacks.is_empty():
-		return
-	_unlock_gen1_card_key_door()
-	_spend_gen1_nodes(callbacks[0]["nodes"] as Array)
+## The map's script with [param mask] standing in `wCurrentMapScriptFlags`.
+func _gen1_map_script_nodes(mask: int) -> Array:
+	for callback: Dictionary in current_map.scripts.get("callbacks", []) as Array:
+		if int(callback.get("mask", 0)) == mask:
+			return callback["nodes"] as Array
+	return current_map.scripts.get("entry", []) as Array
+
+
+func gen1_map_load_pending() -> bool:
+	return _gen1_map_load_pending != 0
 
 
 ## Spends every step of [param nodes] that takes no turn of its own, stopping
@@ -9671,6 +9795,7 @@ func _apply_map(
 	_record_escape_points(target_map, from_warp)
 	_gen1_steps = []
 	_gen1_entry_steps = []
+	_gen1_map_load_pending = 0
 	_gen1_money_window = false
 	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
 	## and that is the map a `LAST_MAP` warp comes back out to.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1114,16 +1114,14 @@ func _advance_waits(map_pass: bool) -> void:
 	_advance_audio_wait()
 
 
-## `RunMapScript` runs on every frame `JoypadOverworld` reads, so a state that
-## opens `ret nz` on a walk still being drawn gets its turn the frame the walk
-## ends. An ordinary step reaches the map script through
-## [method _after_map_settled]; a scripted walk has no step behind it, so this
-## is the frame it lands on.
+## `RunMapScript` runs on every frame `JoypadOverworld` reads: a state opening
+## `ret nz` on a walk gets its turn the frame the walk ends, and a
+## `wCurrentMapScriptFlags` bit a row set back is read the frame its box closes.
 func _run_settled_gen1_map_script() -> void:
 	if _world == null or not _world.is_gen1():
 		return
 	var running: bool = _world.scripted_movement_in_progress()
-	var settled: bool = _gen1_movement_drawn and not running
+	var settled: bool = (_gen1_movement_drawn and not running) or _world.gen1_map_load_pending()
 	_gen1_movement_drawn = running
 	if not settled or _world.script_busy() or not _map_fade.is_empty():
 		return

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -323,6 +323,8 @@ var _safari_steps: int = 0
 ## first. Both bytes open at zero, so block (0, 0) is "no door".
 const NO_CARD_KEY_DOOR: Vector2i = Vector2i.ZERO
 var _card_key_door: Vector2i = NO_CARD_KEY_DOOR
+## Bytes a Generation 1 script writes by name; zero is cleared WRAM and is not kept.
+var _gen1_bytes: Dictionary = {}
 ## `wRegisteredItem`. `wWhichRegisteredItem`'s pocket and slot number have no
 ## counterpart in the flat item model: `CheckRegisteredItem` uses them to find
 ## the entry again in its packed pocket array and clears both when the item is
@@ -551,6 +553,7 @@ func to_dict() -> Dictionary:
 		"safari_balls": _safari_balls,
 		"safari_steps": _safari_steps,
 		"card_key_door": [_card_key_door.x, _card_key_door.y],
+		"gen1_bytes": _gen1_bytes.duplicate(),
 		"npc_trades": _npc_trades.duplicate(),
 		"registered_item": _registered_item,
 		"day_care_man": _day_care_man,
@@ -612,6 +615,9 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._card_key_door = _vector_from_value(
 		source.get("card_key_door", [NO_CARD_KEY_DOOR.x, NO_CARD_KEY_DOOR.y])
 	)
+	var bytes: Dictionary = _map(source, "gen1_bytes")
+	for name: String in bytes:
+		restored.set_gen1_byte(name, int(bytes[name]))
 	_seed_flags(restored._npc_trades, _map(source, "npc_trades"), 0)
 	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
 		source.get("yanma_swarm_map", [-1, -1])
@@ -771,6 +777,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_safari_steps = restored._safari_steps
 	_gen1_starters = restored._gen1_starters.duplicate()
 	_card_key_door = restored._card_key_door
+	_gen1_bytes = restored._gen1_bytes.duplicate()
 	_npc_trades = restored._npc_trades.duplicate()
 	_registered_item = restored._registered_item
 	_day_care_man = restored._day_care_man
@@ -1725,6 +1732,21 @@ func set_kurt_apricorn_quantity(quantity: int) -> void:
 
 func card_key_door() -> Vector2i:
 	return _card_key_door
+
+
+func gen1_byte(name: String) -> int:
+	return int(_gen1_bytes.get(name, 0))
+
+
+func set_gen1_byte(name: String, value: int) -> void:
+	var next_value: int = clampi(value, 0, 0xFF)
+	if gen1_byte(name) == next_value:
+		return
+	if next_value == 0:
+		_gen1_bytes.erase(name)
+	else:
+		_gen1_bytes[name] = next_value
+	changed.emit()
 
 
 func set_card_key_door(cell: Vector2i) -> void:

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -58,6 +58,9 @@ const LAYOUT: Dictionary = {
 	"print_predef_text": 0x0290,
 	"display_text_id": 0x02A0,
 	"count_set_bits": 0x02B0,
+	"random": 0x02C8,
+	"random_sub": 0xFFD4,
+	"first_lock_trash_can": 0xD743,
 	"text_predefs": 0x0400,
 	"text_id_hram": 0xFF8C,
 	"joy_held": 0xFFB4,
@@ -233,15 +236,69 @@ func test_a_map_script_store_the_walk_cannot_value_answers_nothing() -> void:
 ## the gate in front of a per-frame script tests false and the body it would
 ## have called is not read at all.
 func test_the_map_load_gate_is_walked_past() -> void:
-	var gate: Array = _load_hl(int(LAYOUT["map_script_flags"])) \
-		+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_BIT_BASE + Gen1Layout.SCRIPT_OPERAND_HL,
-			Gen1Layout.SCRIPT_PREFIX,
-			Gen1Layout.SCRIPT_RES_BASE + Gen1Layout.SCRIPT_OPERAND_HL,
-			CALL_NZ, UNREAD_CALL & 0xFF, UNREAD_CALL >> 8]
 	var script: Array = _decode(
-		gate + _print(HELLO) + _call(int(LAYOUT["text_script_end"])), _boxes()
+		_map_load_gate(UNREAD_CALL) + _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
 	)
 	assert_eq(script, [{"op": "text", "text": "HI"}])
+
+
+## The same gate on `EnterMap`'s frame, with the bit known set.
+func test_the_map_load_gate_is_taken_with_its_bit_set() -> void:
+	var body: int = 0x1400
+	var program: Array = _map_load_gate(body) + _print(HELLO) \
+		+ _call(int(LAYOUT["text_script_end"]))
+	var raw: Dictionary = {}
+	var routine: Array = _print(BYE) + [Gen1Layout.SCRIPT_RET]
+	for offset: int in routine.size():
+		raw[body + offset] = routine[offset]
+	var script: Array = Gen1WorldImporter.decode_script(
+		_rom(program, _boxes(), raw), LAYOUT, 0, AT, {}, 1 << Gen1Layout.MAP_LOADED_1_BIT
+	)
+	assert_eq(script, [{"op": "text", "text": "BYE"}, {"op": "text", "text": "HI"}])
+	assert_eq(Gen1WorldImporter.decode_script(
+		_rom(program, _boxes(), raw), LAYOUT, 0, AT, {}, 1 << Gen1Layout.MAP_LOADED_2_BIT
+	), [{"op": "text", "text": "HI"}])
+
+
+## A script setting the bit back is asking for that body on the next frame.
+func test_setting_a_map_load_bit_is_kept() -> void:
+	var script: Array = _decode(
+		_load_hl(int(LAYOUT["map_script_flags"]))
+			+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_SET_BASE
+				+ 8 * Gen1Layout.MAP_LOADED_2_BIT + Gen1Layout.SCRIPT_OPERAND_HL,
+			Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [{"op": "map_load_bit", "bit": Gen1Layout.MAP_LOADED_2_BIT}])
+
+
+## `.setFirstLockTrashCanIndex`: `call Random`, `ldh a, [hRandomSub]`, `and $e`
+## and the store, which the world rolls itself.
+func test_a_byte_stored_from_random_is_a_masked_roll() -> void:
+	var script: Array = _decode(
+		_call(int(LAYOUT["random"]))
+			+ [Gen1Layout.SCRIPT_LDH_A_MEM, int(LAYOUT["random_sub"]) & 0xFF,
+				Gen1Layout.SCRIPT_AND_N, 0x0E,
+				Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_SRL_A]
+			+ _store_a(int(LAYOUT["first_lock_trash_can"])) + [Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [{
+		"op": "store_byte", "name": "first_lock_trash_can", "random": true, "mask": 0x0E, "shift": 1,
+	}])
+	assert_eq(_decode(
+		[Gen1Layout.SCRIPT_LD_A, 0x0C, Gen1Layout.SCRIPT_AND_N, 0x0A]
+			+ _store_a(int(LAYOUT["first_lock_trash_can"])) + [Gen1Layout.SCRIPT_RET]
+	), [{"op": "store_byte", "name": "first_lock_trash_can", "value": 0x08}])
+
+
+## `ld hl, wCurrentMapScriptFlags`, `bit 5, [hl]`, `res 5, [hl]`, `call nz, body`.
+func _map_load_gate(body: int) -> Array:
+	return _load_hl(int(LAYOUT["map_script_flags"])) \
+		+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_BIT_BASE
+			+ 8 * Gen1Layout.MAP_LOADED_1_BIT + Gen1Layout.SCRIPT_OPERAND_HL,
+			Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_RES_BASE
+			+ 8 * Gen1Layout.MAP_LOADED_1_BIT + Gen1Layout.SCRIPT_OPERAND_HL,
+			CALL_NZ, body & 0xFF, body >> 8]
 
 
 func test_a_coordinate_list_becomes_the_cells_it_holds() -> void:

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -180,6 +180,20 @@ func test_strength_active_flag_is_profile_split_and_is_not_a_badge() -> void:
 	assert_eq(state.badge_count(false), 0)
 
 
+## `wFirstLockTrashCanIndex` and its two neighbours are saved player data; a
+## byte written back to zero is the cleared WRAM a new game starts on.
+func test_gen1_bytes_ride_the_snapshot_by_name() -> void:
+	var state := Gen2WorldState.new()
+	state.set_gen1_byte("first_lock_trash_can", 12)
+	state.set_gen1_byte("second_lock_trash_can", 0x1FF)
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.gen1_byte("first_lock_trash_can"), 12)
+	assert_eq(restored.gen1_byte("second_lock_trash_can"), 0xFF)
+	assert_eq(restored.gen1_byte("second_lock_trash_can_alt"), 0)
+	restored.set_gen1_byte("first_lock_trash_can", 0)
+	assert_false(restored.to_dict()["gen1_bytes"].has("first_lock_trash_can"))
+
+
 ## Snapshots and MapSetupScript_ReloadMap do not run a warp's ResetBikeFlags.
 func test_strength_active_flag_survives_round_trip_and_map_reload() -> void:
 	var state := Gen2WorldState.new()

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -115,9 +115,9 @@ const PALETTE_CENSUS: Dictionary = {
 ## byte that opens it. Yellow's six bare `text_end`s are Jessie and James, whose
 ## two ids share one on three maps.
 const TEXT_CENSUS: Dictionary = {
-	&"red": {0x08: 637, 0x17: 517, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"blue": {0x08: 637, 0x17: 517, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"yellow": {0x08: 686, 0x17: 493, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14,
+	&"red": {0x08: 638, 0x17: 521, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"blue": {0x08: 638, 0x17: 521, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"yellow": {0x08: 687, 0x17: 495, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14,
 		0xFF: 12},
 }
 
@@ -130,14 +130,14 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
+	&"red": {"rows": 318, "text": 597, "branch": 158, "choice": 39, "flag": 243,
 		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 0, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 35, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 37, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
-		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
+		"name_species": 14, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
 		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
 		"spend_money": 4, "menu": 3, "menu_cancel": 3, "menu_row": 1, "guard_drink": 4,
 		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
@@ -145,15 +145,15 @@ const SCRIPT_CENSUS: Dictionary = {
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
 		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
-		"flag_test": 3},
-	&"blue": {"rows": 317, "text": 596, "branch": 158, "choice": 39, "flag": 243,
+		"flag_test": 3, "map_load_bit": 2},
+	&"blue": {"rows": 318, "text": 597, "branch": 158, "choice": 39, "flag": 243,
 		"give_item": 42, "has_item": 18, "take_item": 11, "unknown": 0, "pokedex": 13,
 		"give_pokemon": 33, "saved_coord_index": 1, "badges_byte": 1, "walk": 20,
 		"player_facing": 10, "set_map_script": 113, "npc_movement_script": 2,
 		"toggle_object": 49, "trainer_battle_object": 21, "random": 5, "facing": 12,
-		"player_in_array": 1, "pick_up_item": 105, "scratch": 35, "name_badge": 7,
+		"player_in_array": 1, "pick_up_item": 105, "scratch": 37, "name_badge": 7,
 		"heal_party": 2, "object_facing": 9, "talking_to": 32, "set_starter": 9,
-		"name_species": 13, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
+		"name_species": 14, "dex_rating": 2, "dex_count": 2, "map_text": 24, "trade": 9,
 		"name_item": 7, "oaks_aide": 3, "player_coord": 4, "money_box": 6, "has_money": 4,
 		"spend_money": 4, "menu": 3, "menu_cancel": 3, "menu_row": 1, "guard_drink": 4,
 		"day_care": 1, "random_bit": 2, "volatile": 1, "filtered_bag": 2, "menu_item": 4,
@@ -161,13 +161,13 @@ const SCRIPT_CENSUS: Dictionary = {
 		"starter": 2, "trainer_battle": 3, "safari_balls": 1, "safari_steps": 1,
 		"save_coord_index": 2, "copy_name": 4, "set_fossil": 6, "list_menu": 1,
 		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
-		"flag_test": 3},
-	&"yellow": {"rows": 370, "text": 601, "branch": 160, "choice": 34, "flag": 221,
+		"flag_test": 3, "map_load_bit": 2},
+	&"yellow": {"rows": 371, "text": 602, "branch": 160, "choice": 34, "flag": 221,
 		"give_item": 41, "has_item": 15, "take_item": 9, "unknown": 5, "pokedex": 10,
 		"give_pokemon": 8, "saved_coord_index": 1, "badges_byte": 1, "walk": 23,
 		"set_map_script": 99, "npc_movement_script": 2, "toggle_object": 22,
 		"trainer_battle_object": 27, "random": 5, "facing": 12, "player_in_array": 1,
-		"name_species": 6, "pick_up_item": 109, "scratch": 27, "name_badge": 7,
+		"name_species": 7, "pick_up_item": 109, "scratch": 29, "name_badge": 7,
 		"player_facing": 15, "heal_party": 2, "emote": 7, "dex_rating": 2, "dex_count": 6,
 		"map_text": 24, "trade": 7, "name_item": 7, "oaks_aide": 3, "player_coord": 4,
 		"money_box": 6, "has_money": 5, "spend_money": 4, "menu": 3, "menu_cancel": 3,
@@ -177,7 +177,7 @@ const SCRIPT_CENSUS: Dictionary = {
 		"safari_steps": 3, "safari_admission": 2, "save_coord_index": 2, "talking_to": 14,
 		"copy_name": 4, "set_fossil": 6, "list_menu": 1,
 		"party_menu": 1, "name_party_mon": 1, "mon_ot": 1, "name_mon": 1,
-		"flag_test": 6, "volatile_test": 6},
+		"flag_test": 6, "volatile_test": 6, "map_load_bit": 2},
 }
 ## `SilphCo11FPorygonText` is a `call DisplayPokedex` the disassembly marks
 ## unreferenced. The `trade` rows are the eight `predef DoInGameTradeDialogue`
@@ -198,76 +198,75 @@ const TOGGLE_CENSUS: Dictionary = {
 ## One row of each list stands on UNUSED_MAP_6F, which has no header and so no
 ## record: the table holds 217 rows on Red and Blue and 213 on Yellow.
 const HIDDEN_CENSUS: Dictionary = {
-	&"red": {"rows": 216, "silent": 70, "text": 210, "branch": 69, "flag": 66,
-		"facing": 56, "name_item": 53, "give_item": 53, "facility": 21,
+	&"red": {"rows": 216, "silent": 49, "text": 234, "branch": 111, "flag": 72,
+		"facing": 62, "name_item": 53, "give_item": 53, "facility": 21,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
-	&"blue": {"rows": 216, "silent": 70, "text": 210, "branch": 69, "flag": 66,
-		"facing": 56, "name_item": 53, "give_item": 53, "facility": 21,
+		"map_text": 5, "choice": 9, "unknown": 1, "dex_count": 1, "gym_trash": 15, "scratch": 12, "map_load_bit": 6, "replace_block": 72},
+	&"blue": {"rows": 216, "silent": 49, "text": 234, "branch": 111, "flag": 72,
+		"facing": 62, "name_item": 53, "give_item": 53, "facility": 21,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
-	&"yellow": {"rows": 212, "silent": 69, "text": 212, "branch": 70, "flag": 67,
-		"facing": 52, "name_item": 54, "give_item": 54, "facility": 17,
+		"map_text": 5, "choice": 9, "unknown": 1, "dex_count": 1, "gym_trash": 15, "scratch": 12, "map_load_bit": 6, "replace_block": 72},
+	&"yellow": {"rows": 212, "silent": 48, "text": 236, "branch": 112, "flag": 73,
+		"facing": 58, "name_item": 54, "give_item": 54, "facility": 17,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
+		"map_text": 5, "choice": 9, "unknown": 1, "dex_count": 1, "gym_trash": 15, "scratch": 12, "volatile": 12, "map_load_bit": 6, "replace_block": 72},
 }
 ## Of `BookshelfTileIDs`' 17 rows, all but one decode: the Indigo Plateau
 ## statues read `wXCoord` for which of their two boxes they answer with.
 const BOOKSHELF_COUNTS: Dictionary = {&"red": 16, &"blue": 16, &"yellow": 16}
 const CARD_KEY_FLOORS: int = 10
-## `gated` is every map whose script opens on `wCurrentMapScriptFlags` and
-## `read` the ones whose body decodes whole; `blocks` counts the
-## `ReplaceTileBlock` writes on every branch of those bodies.
+## `gated` is every map `wCurrentMapScriptFlags` changes the script of, `walks`
+## its load-time walks, and `blocks` the writes on the walk `EnterMap` runs.
 const CALLBACK_CENSUS: Dictionary = {
-	&"red": {"gated": 36, "read": 26, "blocks": 99, "doors": 20, "floors": 10},
-	&"blue": {"gated": 36, "read": 26, "blocks": 99, "doors": 20, "floors": 10},
-	&"yellow": {"gated": 34, "read": 24, "blocks": 96, "doors": 20, "floors": 10},
+	&"red": {"gated": 30, "walks": 63, "blocks": 107, "doors": 20, "floors": 10},
+	&"blue": {"gated": 30, "walks": 63, "blocks": 107, "doors": 20, "floors": 10},
+	&"yellow": {"gated": 29, "walks": 61, "blocks": 104, "doors": 20, "floors": 10},
 }
 
 ## The maps with a state machine, the states reachable from index 0 and from
 ## every `set_map_script` already read, and the bodies the walker gets whole.
 const STATE_CENSUS: Dictionary = {
-	&"red": {"tables": 98, "states": 203, "read": 144, "branch": 65, "player_coord": 33,
-		"player_facing": 40, "flag": 254, "set_map_script": 227, "save_coord_index": 9,
-		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
-		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
-		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
-		"player_in_array": 30, "riding": 4, "object_move": 52, "object_position": 8,
-		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
-		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
+	&"red": {"tables": 98, "states": 362, "read": 173, "branch": 67, "player_coord": 35,
+		"player_facing": 43, "flag": 255, "set_map_script": 266, "save_coord_index": 9,
+		"map_text": 123, "toggle_object": 141, "object_facing": 54, "set_player_coord": 1,
+		"object_path": 1, "movement_running": 60, "npc_movement_script": 1,
+		"movement_script_running": 4, "badges_byte": 1, "walk": 37, "wild_battle": 4,
+		"player_in_array": 31, "riding": 4, "object_move": 58, "object_position": 12,
+		"coord_index": 18, "starter": 18, "trainer_battle": 24, "battle_outcome": 34,
+		"object_stay": 11, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
 		"badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
 		"trainer_battle_object": 1,
-		"flag_test": 15, "replace_block": 24},
-	&"blue": {"tables": 98, "states": 203, "read": 144, "branch": 65, "player_coord": 33,
-		"player_facing": 40, "flag": 254, "set_map_script": 227, "save_coord_index": 9,
-		"map_text": 109, "toggle_object": 134, "object_facing": 48, "set_player_coord": 1,
-		"object_path": 1, "movement_running": 50, "npc_movement_script": 1,
-		"movement_script_running": 2, "badges_byte": 1, "walk": 32, "wild_battle": 4,
-		"player_in_array": 30, "riding": 4, "object_move": 52, "object_position": 8,
-		"coord_index": 17, "starter": 16, "trainer_battle": 21, "battle_outcome": 28,
-		"object_stay": 9, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
+		"flag_test": 15, "replace_block": 24, "map_load_bit": 10, "scratch": 9, "scratch_test": 2, "object_coord_move": 1},
+	&"blue": {"tables": 98, "states": 362, "read": 173, "branch": 67, "player_coord": 35,
+		"player_facing": 43, "flag": 255, "set_map_script": 266, "save_coord_index": 9,
+		"map_text": 123, "toggle_object": 141, "object_facing": 54, "set_player_coord": 1,
+		"object_path": 1, "movement_running": 60, "npc_movement_script": 1,
+		"movement_script_running": 4, "badges_byte": 1, "walk": 37, "wild_battle": 4,
+		"player_in_array": 31, "riding": 4, "object_move": 58, "object_position": 12,
+		"coord_index": 18, "starter": 18, "trainer_battle": 24, "battle_outcome": 34,
+		"object_stay": 11, "facing": 3, "has_item": 4, "emote": 2, "saved_coord_index": 16,
 		"badge_guards": 1, "give_item": 9, "arrow_movement": 3,
 		"guard_drink": 4, "boulder_on": 3, "hall_of_fame": 1, "set_blackout_map": 1,
 		"save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1, "set_last_map": 1,
 		"safari_balls": 1, "volatile": 1, "volatile_test": 1, "coord_lookup": 3,
 		"trainer_battle_object": 1,
-		"flag_test": 15, "replace_block": 24},
-	&"yellow": {"tables": 98, "states": 207, "read": 152, "branch": 84, "player_coord": 46,
-		"flag": 280, "player_facing": 39, "set_map_script": 240, "save_coord_index": 11,
-		"map_text": 125, "object_position": 6, "toggle_object": 153, "object_facing": 50,
-		"set_player_coord": 1, "object_path": 1, "movement_running": 50, "wild_battle": 6,
-		"npc_movement_script": 1, "movement_script_running": 2, "badges_byte": 2, "walk": 35,
-		"object_move": 53, "player_in_array": 33, "riding": 4, "coord_index": 17,
-		"trainer_battle": 7, "battle_outcome": 28, "object_stay": 10, "facing": 4,
+		"flag_test": 15, "replace_block": 24, "map_load_bit": 10, "scratch": 9, "scratch_test": 2, "object_coord_move": 1},
+	&"yellow": {"tables": 98, "states": 361, "read": 177, "branch": 88, "player_coord": 52,
+		"flag": 282, "player_facing": 44, "set_map_script": 271, "save_coord_index": 11,
+		"map_text": 138, "object_position": 6, "toggle_object": 157, "object_facing": 55,
+		"set_player_coord": 1, "object_path": 1, "movement_running": 58, "wild_battle": 6,
+		"npc_movement_script": 1, "movement_script_running": 2, "badges_byte": 3, "walk": 41,
+		"object_move": 57, "player_in_array": 34, "riding": 4, "coord_index": 18,
+		"trainer_battle": 8, "battle_outcome": 33, "object_stay": 12, "facing": 4,
 		"has_item": 4, "emote": 2, "saved_coord_index": 18, "starter": 1, "set_starter": 1,
 		"badge_guards": 1, "give_item": 9, "arrow_movement": 3, "guard_drink": 4,
-		"unknown": 1, "volatile_test": 2, "volatile": 5, "boulder_on": 3, "hall_of_fame": 1,
+		"unknown": 1, "volatile_test": 3, "volatile": 7, "boulder_on": 3, "hall_of_fame": 1,
 		"set_blackout_map": 1, "save_game": 1, "reset_game": 1, "heal_party": 1, "warp_to": 1,
 		"set_last_map": 1, "safari_balls": 1, "coord_lookup": 3, "trainer_battle_object": 2,
-		"flag_test": 18, "replace_block": 36, "scratch_test": 1},
+		"flag_test": 18, "replace_block": 36, "scratch_test": 3, "map_load_bit": 10, "scratch": 8, "random": 1},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -597,21 +596,24 @@ func _scripts(font: Gen2Font) -> void:
 
 func _map_callbacks() -> void:
 	var census: Dictionary = {
-		"gated": 0, "read": 0, "blocks": 0, "doors": 0, "floors": 0,
+		"gated": 0, "walks": 0, "blocks": 0, "doors": 0, "floors": 0,
 	}
 	var wrong: Array[String] = []
 	for map: Gen2WorldMap in _maps.values():
 		var doors: Array = map.events["card_key"] as Array
 		census["floors"] += 1 if not doors.is_empty() else 0
 		census["doors"] += doors.size()
+		_check_doors(map, doors, wrong)
 		var callbacks: Array = map.scripts["callbacks"] as Array
 		if callbacks.is_empty():
 			continue
-		var nodes: Array = callbacks[0]["nodes"] as Array
 		census["gated"] += 1
-		census["read"] += 1 if not nodes.is_empty() else 0
-		census["blocks"] += _blocks_written(nodes)
-		_check_doors(map, callbacks[0], doors, wrong)
+		census["walks"] += callbacks.size()
+		for callback: Dictionary in callbacks:
+			_r.check(not (callback["nodes"] as Array).is_empty(),
+				"map %d keeps an empty walk for mask %d." % [map.number, int(callback["mask"])])
+			if int(callback["mask"]) == Gen1Layout.MAP_LOAD_BOTH:
+				census["blocks"] += _blocks_written(callback["nodes"] as Array)
 	_r.check(wrong.is_empty(), "card key doors are wrong: %s." % [wrong])
 	_r.check(census == CALLBACK_CENSUS[_r.game_id],
 		"the map callbacks read %s." % [census])
@@ -673,29 +675,32 @@ func _blocks_written(nodes: Array) -> int:
 	return written
 
 
-## A floor's doors stand on its own `.GateCoordinates`, each under a flag of its
-## own.
-func _check_doors(
-	map: Gen2WorldMap, callback: Dictionary, doors: Array, wrong: Array[String]
-) -> void:
-	var coordinates: Array = callback["coordinates"] as Array
-	if coordinates.is_empty():
-		return
+## A floor's doors each stand under their own flag, on a cell the load walk locks.
+func _check_doors(map: Gen2WorldMap, doors: Array, wrong: Array[String]) -> void:
 	var flags: Dictionary = {}
-	for index: int in doors.size():
-		var door: Dictionary = doors[index]
-		var gate: Dictionary = coordinates[index]
-		if (int(door["x"]) != int(gate["x"]) or int(door["y"]) != int(gate["y"])) \
-			and wrong.size() < 4:
-			wrong.append("map %d door %d stands on %d,%d, not %d,%d" % [
-				map.number, index, int(door["x"]), int(door["y"]),
-				int(gate["x"]), int(gate["y"]),
-			])
+	var locked: Dictionary = {}
+	for callback: Dictionary in map.scripts["callbacks"] as Array:
+		if int(callback["mask"]) == Gen1Layout.MAP_LOAD_BOTH:
+			_locked_cells(callback["nodes"] as Array, locked)
+	for door: Dictionary in doors:
 		flags[int(door["flag"])] = true
+		if not locked.has(Vector2i(int(door["x"]), int(door["y"]))) and wrong.size() < 4:
+			wrong.append("map %d's door at %d,%d is never locked by its load walk" % [
+				map.number, int(door["x"]), int(door["y"]),
+			])
 	if flags.size() != doors.size() and wrong.size() < 4:
 		wrong.append("map %d has %d doors under %d flags" % [
 			map.number, doors.size(), flags.size(),
 		])
+
+
+func _locked_cells(nodes: Array, locked: Dictionary) -> void:
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "replace_block":
+			locked[Vector2i(int(node["x"]), int(node["y"]))] = true
+		for side: String in ["then", "else"]:
+			if node.has(side):
+				_locked_cells(node[side] as Array, locked)
 
 
 func _walk_script(

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -15,9 +15,9 @@ const CLASS_COUNT: int = 47
 ## `text_asm` rows, the ones reaching `TalkToTrainer`, and the objects naming
 ## one: a trainer class above `OPP_ID_OFFSET`, or a standing wild below it.
 const HEADER_CENSUS: Dictionary = {
-	&"red": {"text_asm": 637, "headers": 322, "trainers": 310, "wilds": 12},
-	&"blue": {"text_asm": 637, "headers": 322, "trainers": 310, "wilds": 12},
-	&"yellow": {"text_asm": 686, "headers": 317, "trainers": 305, "wilds": 12},
+	&"red": {"text_asm": 638, "headers": 322, "trainers": 310, "wilds": 12},
+	&"blue": {"text_asm": 638, "headers": 322, "trainers": 310, "wilds": 12},
+	&"yellow": {"text_asm": 687, "headers": 317, "trainers": 305, "wilds": 12},
 }
 
 ## `view_range << 4` is a pixel distance, so the stored range is a nibble.
@@ -128,10 +128,11 @@ func _one_sight_line(
 
 ## `dispatch_sight_events` from one cell, answering which object engaged and
 ## spending `TalkToTrainer` behind it so the next cell starts on an idle world.
+## The map's own script runs first and may redraw a gate behind the last fight.
 func _engaged_at(world: Gen2WorldAPI, cell: Vector2i) -> int:
 	world.player_cell = cell
 	var opened: Array = world.dispatch_sight_events()
-	if opened.is_empty():
+	if opened.is_empty() or not world.script_busy():
 		return -1
 	var request: Dictionary = (opened[0].get("event", {}) as Dictionary).get("request", {})
 	world.complete_runtime_request({"ok": true})

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -471,6 +471,7 @@ func _one_game() -> void:
 	_check_a_hidden_object()
 	_check_a_pc_opens()
 	_check_a_hidden_item()
+	_check_the_trash_cans()
 	_check_a_gym_statue()
 	_check_a_bench_guy()
 	_check_a_bookshelf()
@@ -501,6 +502,9 @@ func _one_game() -> void:
 	_check_the_cycling_road_gate_walk()
 	_check_the_viridian_gym_door()
 	_check_the_tower_warp()
+	if _r.game_id != RomRegistry.YELLOW:
+		_check_the_tower_rocket_leaves()
+	_check_the_champion()
 	_check_the_silph_rival()
 	_check_a_seafoam_boulder_hole()
 	_check_the_safari_zone()
@@ -2198,6 +2202,83 @@ func _check_a_hidden_item() -> void:
 	_r.check(world.interact().is_empty(), "the taken POTION answered twice.")
 
 
+func _check_the_trash_cans() -> void:
+	var city: Gen2WorldAPI = _r.open_world(0, VERMILION_CITY, VERMILION_GYM_DOOR)
+	if city == null:
+		return
+	city.script_random = RandomNumberGenerator.new()
+	city.script_random.seed = TRASH_SEED
+	city.dispatch_map_entry()
+	var first: int = city.state.gen1_byte(Gen2WorldAPI.GEN1_FIRST_LOCK)
+	_r.check(first % 2 == 0 and first < Gen1Layout.TRASH_CANS,
+		"the city rolled can %d for the first lock." % first)
+	var gym: Gen2WorldAPI = _r.open_world(0, VERMILION_GYM, VERMILION_GYM_MAT, city.state)
+	if gym == null:
+		return
+	gym.script_random = city.script_random
+	gym.dispatch_map_entry()
+	_r.check(gym.block_at(VERMILION_GYM_DOOR_BLOCK.x, VERMILION_GYM_DOOR_BLOCK.y)
+		== VERMILION_GYM_DOOR_LOCKED, "the gym's door opened before the locks.")
+	var cans: Dictionary = _trash_cans(gym)
+	if not _r.check(cans.size() == Gen1Layout.TRASH_CANS, "%d cans answer." % cans.size()):
+		return
+	_r.check(_trash_said(gym, cans, (first + 1) % Gen1Layout.TRASH_CANS) == TRASH_NOTHING,
+		"a wrong first can did not say so.")
+	_r.check(_trash_said(gym, cans, first).begins_with(TRASH_FIRST_OPENED),
+		"the first lock did not open.")
+	_r.check(gym.event_flag_active(Gen1Layout.LOCK_1ST_EVENT), "EVENT_1ST_LOCK_OPENED is clear.")
+	var second: int = gym.state.gen1_byte(Gen2WorldAPI.GEN1_SECOND_LOCK)
+	var wrong: int = (second + 1) % Gen1Layout.TRASH_CANS
+	while wrong == gym.state.gen1_byte(Gen2WorldAPI.GEN1_SECOND_LOCK_ALT):
+		wrong = (wrong + 1) % Gen1Layout.TRASH_CANS
+	_r.check(_trash_said(gym, cans, wrong).begins_with(TRASH_RESET), "a wrong second can did not reset.")
+	_r.check(not gym.event_flag_active(Gen1Layout.LOCK_1ST_EVENT), "the reset kept the first lock.")
+	first = gym.state.gen1_byte(Gen2WorldAPI.GEN1_FIRST_LOCK)
+	_r.check(_trash_said(gym, cans, first).begins_with(TRASH_FIRST_OPENED),
+		"the first lock did not open again.")
+	second = gym.state.gen1_byte(Gen2WorldAPI.GEN1_SECOND_LOCK)
+	if not _r.check(cans.has(second), "the second lock is under can %d." % second):
+		return
+	_r.check(_trash_said(gym, cans, second).begins_with(TRASH_DONE), "the second lock did not open.")
+	_r.check(gym.event_flag_active(Gen1Layout.LOCK_2ND_EVENT), "EVENT_2ND_LOCK_OPENED is clear.")
+	_r.check(gym.gen1_map_load_pending(), "the door's own bit was not set back.")
+	gym.dispatch_sight_events()
+	_r.check(gym.block_at(VERMILION_GYM_DOOR_BLOCK.x, VERMILION_GYM_DOOR_BLOCK.y)
+		== VERMILION_GYM_DOOR_OPEN, "the door stayed shut behind the second lock.")
+	_r.check(_trash_said(gym, cans, first) == TRASH_NOTHING, "a can still answers after the door.")
+	_r.note("gen1 trash cans: first %d, second %d, door open" % [first, second])
+
+
+func _trash_cans(gym: Gen2WorldAPI) -> Dictionary:
+	var cans: Dictionary = {}
+	for row: Dictionary in gym.current_map.events["hidden_events"] as Array:
+		for node: Dictionary in row.get("script", []) as Array:
+			if String(node["op"]) == "gym_trash":
+				cans[int(node["can"])] = Vector2i(int(row["x"]), int(row["y"]))
+	return cans
+
+
+func _trash_said(gym: Gen2WorldAPI, cans: Dictionary, can: int) -> String:
+	gym.player_cell = (cans[can] as Vector2i) + Vector2i.DOWN
+	gym.player_facing = Gen2WorldSprite.FACING_UP
+	var said: Array[String] = _spoken(gym)
+	return "\n".join(said)
+
+
+const VERMILION_CITY: int = 5
+const VERMILION_GYM: int = 92
+const VERMILION_GYM_DOOR := Vector2i(12, 20)
+const VERMILION_GYM_MAT := Vector2i(4, 16)
+const VERMILION_GYM_DOOR_BLOCK := Vector2i(2, 2)
+const VERMILION_GYM_DOOR_LOCKED: int = 0x24
+const VERMILION_GYM_DOOR_OPEN: int = 0x05
+const TRASH_SEED: int = 7
+const TRASH_NOTHING: String = "Nope, there's\nonly trash here."
+const TRASH_FIRST_OPENED: String = "Hey! There's a\nswitch under the"
+const TRASH_RESET: String = "Nope! There's\nonly trash here."
+const TRASH_DONE: String = "The 2nd electric\nlock opened!"
+
+
 ## `GymStatues` reads `wBeatGymFlags`, and Pewter's bit is BOULDERBADGE.
 func _check_a_gym_statue() -> void:
 	var boxes: Array[String] = []
@@ -3079,6 +3160,91 @@ func _check_the_silph_rival() -> void:
 	_r.note("gen1 walk SILPH_CO_7F's rival fought as party %d" % int(SILPH_RIVAL_PARTY[_r.game_id]))
 
 
+## `PokemonTower7FEndBattleScript` walks the beaten rocket off along the table
+## row the player stands on, and `PokemonTower7FHideNPCScript` hides it.
+const TOWER_7F_ROCKET: int = 0
+const TOWER_7F_ROCKET_CELL := Vector2i(9, 11)
+const TOWER_7F_BESIDE_ROCKET := Vector2i(10, 11)
+const TOWER_7F_HIDE_STATE: int = 3
+
+
+func _check_the_tower_rocket_leaves() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, POKEMON_TOWER_7F, TOWER_7F_BESIDE_ROCKET)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var results: Array = world.interact()
+	var passes: int = 0
+	while world.pending_runtime_request().is_empty() and not results.is_empty() \
+		and passes < SCRIPTED_WALK_PASSES:
+		results = world.run_event_queue(true)
+		passes += 1
+	if not _r.check(StringName(world.pending_runtime_request().get("kind", &"")) == &"battle_requested",
+		"the rocket never asked for a fight."):
+		return
+	world.complete_runtime_request({"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON})
+	_r.check(world.state.gen1_map_script(TOWER_7F_BYTE) == Gen2WorldAPI.GEN1_END_BATTLE_STATE,
+		"the fight left the tower on state %d." % world.state.gen1_map_script(TOWER_7F_BYTE))
+	_press_past_boxes(world)
+	world.dispatch_sight_events()
+	_press_past_boxes(world)
+	var rocket: Gen2WorldObject = world.objects[TOWER_7F_ROCKET]
+	_r.check(world.scripted_movement_in_progress() or rocket.cell != TOWER_7F_ROCKET_CELL,
+		"the beaten rocket stood still.")
+	_r.check(world.state.gen1_map_script(TOWER_7F_BYTE) == TOWER_7F_HIDE_STATE,
+		"the tower stands on state %d behind the walk." % world.state.gen1_map_script(TOWER_7F_BYTE))
+	for _pass: int in SCRIPTED_WALK_PASSES:
+		world.advance_scripted_steps_pass()
+		world.dispatch_sight_events()
+		if not rocket.active:
+			break
+	_r.check(not rocket.active, "the rocket never left the map.")
+	_r.check(world.state.gen1_map_script(TOWER_7F_BYTE) == 0,
+		"the tower stayed on state %d." % world.state.gen1_map_script(TOWER_7F_BYTE))
+	_r.note("gen1 walk POKEMON_TOWER_7F's rocket walked off and hid")
+
+
+## `ChampionsRoomPlayerEntersScript`, which Agatha's own end-battle state sets.
+const CHAMPIONS_ROOM_BYTE: int = 92
+const CHAMPIONS_ROOM_ENTRANCE := Vector2i(3, 7)
+const CHAMPIONS_ROOM_WALKED := Vector2i(4, 3)
+const CHAMPIONS_ROOM_PLAYER_ENTERS: int = 1
+const CHAMPION_CLASS: int = 43
+const BEAT_CHAMPION_RIVAL_FLAG: int = 2305
+
+
+func _check_the_champion() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CHAMPIONS_ROOM, CHAMPIONS_ROOM_ENTRANCE)
+	if world == null:
+		return
+	world.state.set_gen1_starter("rival", int(SILPH_RIVAL_STARTER[_r.game_id]))
+	world.state.set_gen1_map_script(CHAMPIONS_ROOM_BYTE, CHAMPIONS_ROOM_PLAYER_ENTERS)
+	world.dispatch_map_entry()
+	var passes: int = 0
+	while world.pending_runtime_request().is_empty() and passes < SCRIPTED_WALK_PASSES:
+		world.advance_player_step_pass()
+		world.dispatch_sight_events()
+		world.run_event_queue(true)
+		passes += 1
+	_r.check(world.player_cell == CHAMPIONS_ROOM_WALKED,
+		"the player was walked to %s." % [world.player_cell])
+	var request: Dictionary = world.pending_runtime_request()
+	var values: Dictionary = request.get("values", {}) as Dictionary
+	if not _r.check(StringName(request.get("kind", &"")) == &"battle_requested"
+		and int(values.get("trainer_class", 0)) == CHAMPION_CLASS,
+		"the champion asked for %s." % [request]):
+		return
+	world.complete_runtime_request({"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON})
+	passes = 0
+	while not world.event_flag_active(BEAT_CHAMPION_RIVAL_FLAG) and passes < SCRIPTED_WALK_PASSES:
+		world.dispatch_sight_events()
+		world.run_event_queue(true)
+		passes += 1
+	_r.check(world.event_flag_active(BEAT_CHAMPION_RIVAL_FLAG),
+		"EVENT_BEAT_CHAMPION_RIVAL is clear after the win.")
+	_r.note("gen1 walk CHAMPIONS_ROOM's rival fought after the entrance walk")
+
+
 const SEAFOAM_B1F_HOLE := Vector2i(18, 6)
 const SEAFOAM_B1F_BOULDER: int = 0
 const SEAFOAM2_BOULDER1_FLAG: int = 2496
@@ -3269,6 +3435,100 @@ func _check_cinnabar_gates() -> void:
 		for won: bool in [false, true]:
 			_check_cinnabar_trainer(trainer, won)
 	_r.note("gen1 Cinnabar: seven trainers, both battle outcomes, six gates and re-entry")
+	_check_the_cinnabar_quiz()
+
+
+func _check_the_cinnabar_quiz() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CINNABAR_GYM, Vector2i(17, 3))
+	if world == null:
+		return
+	world.dispatch_map_entry()
+	var machines: Array = _quiz_machines(world)
+	if not _r.check(machines.size() == CINNABAR_GATES.size(), "%d quiz machines answer." % machines.size()):
+		return
+	var right: Dictionary = machines[0]
+	_r.check(_quiz_asked(world, right).begins_with(QUIZ_INTRO), "the first quiz opened on the wrong box.")
+	_r.check(_quiz_answered(world, int(right["answer"])).begins_with(QUIZ_RIGHT),
+		"the right answer was not taken.")
+	_r.check(world.event_flag_active(CINNABAR_GATE_FLAG), "the first gate's flag is clear.")
+	_r.check(world.block_at(CINNABAR_GATES[0].x, CINNABAR_GATES[0].y) == CINNABAR_GATE_OPEN,
+		"the first gate did not open on the spot.")
+	var wrong: Dictionary = machines[1]
+	_r.check(_quiz_asked(world, wrong).begins_with(QUIZ_SHORT_INTRO), "the second quiz opened on the wrong box.")
+	_r.check(_quiz_answered(world, 1 - int(wrong["answer"])).begins_with(QUIZ_WRONG),
+		"the wrong answer was not refused.")
+	_r.check(world.block_at(CINNABAR_GATES[1].x, CINNABAR_GATES[1].y) == CINNABAR_GATE_LOCKED,
+		"a wrong answer opened the gate.")
+	var trainer: Gen2WorldObject = world.objects[QUIZ_TRAINER_OBJECT]
+	var stood: Vector2i = trainer.cell
+	world.dispatch_sight_events()
+	_r.check(world.scripted_movement_in_progress() or trainer.cell != stood,
+		"the trainer did not walk up after a wrong answer.")
+	for _pass: int in SCRIPTED_WALK_PASSES:
+		if not world.pending_runtime_request().is_empty():
+			break
+		world.advance_scripted_steps_pass()
+		world.dispatch_sight_events()
+		world.run_event_queue(true)
+	_r.check(StringName(world.pending_runtime_request().get("kind", &"")) == &"battle_requested",
+		"the trainer never asked for a fight after the wrong answer.")
+	_r.note("gen1 Cinnabar quiz: a right answer opens gate 1, a wrong one brings trainer %d" % [
+		QUIZ_TRAINER_OBJECT,
+	])
+
+
+func _quiz_machines(world: Gen2WorldAPI) -> Array:
+	var machines: Array = []
+	for row: Dictionary in world.current_map.events["hidden_events"] as Array:
+		var choice: Dictionary = _first_node(row.get("script", []) as Array, "choice")
+		if choice.is_empty():
+			continue
+		var answer: int = 0 if not _first_node(choice["yes"] as Array, "flag").is_empty() else 1
+		machines.append({"cell": Vector2i(int(row["x"]), int(row["y"])), "answer": answer})
+	return machines
+
+
+func _first_node(nodes: Array, op: String) -> Dictionary:
+	for node: Dictionary in nodes:
+		if String(node["op"]) == op:
+			return node
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
+				var found: Dictionary = _first_node(node[key] as Array, op)
+				if not found.is_empty():
+					return found
+	return {}
+
+
+func _quiz_asked(world: Gen2WorldAPI, machine: Dictionary) -> String:
+	world.player_cell = (machine["cell"] as Vector2i) + Vector2i.DOWN
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var results: Array = world.interact()
+	var said: Array[String] = []
+	while not results.is_empty() and StringName(world.pending_script_input().get("type", &"")) != &"choice" \
+		and said.size() < Gen1Layout.MAX_OBJECT_EVENTS:
+		said.append(_event_text(results))
+		results = world.run_event_queue(true)
+	return "\n".join(said)
+
+
+func _quiz_answered(world: Gen2WorldAPI, choice: int) -> String:
+	var results: Array = world.choose_script_input(choice)
+	var said: Array[String] = []
+	while not results.is_empty() and said.size() < Gen1Layout.MAX_OBJECT_EVENTS:
+		said.append(_event_text(results))
+		results = world.run_event_queue(true)
+	return "\n".join(said)
+
+
+const CINNABAR_GATE_FLAG: int = 681
+const CINNABAR_GATE_OPEN: int = 0x0E
+const CINNABAR_GATE_LOCKED: int = 0x54
+const QUIZ_TRAINER_OBJECT: int = 3
+const QUIZ_INTRO: String = "POKéMON Quiz!"
+const QUIZ_SHORT_INTRO: String = "POKéMON Quiz!"
+const QUIZ_RIGHT: String = "You're absolutely\ncorrect!"
+const QUIZ_WRONG: String = "Sorry! Bad call!"
 
 
 func _check_cinnabar_trainer(trainer: int, won: bool) -> void:


### PR DESCRIPTION
## Changed
- A Generation 1 map's load-time work is its entry script walked with `EnterMap`'s `wCurrentMapScriptFlags` bits known set, one walk per mask, kept beside the entry script when it differs. A script's own `set` on a bit is a `map_load_bit` node the world hands to the next `RunMapScript`, which the screen runs on the frame the row's box closes. 30 maps of Red and Blue and 29 of Yellow read differently under a bit, every one whole, against 26 and 24 bodies before: Vermilion City's trash can seed and SS Anne walk, the Game Corner's hideout door, Indigo Plateau's Elite Four reset, Lance's room, Silph Co. 6F, 8F, 10F and 11F among the ones that had not decoded.
- `EndTrainerBattle` sets both bits back and leaves the map's script on row 2, so every state table's first three rows are reachable, a state another map's script writes is seeded from that store, and a map with a body of its own on row 2 runs it after a header trainer fight. Red and Blue read 173 state bodies of 362 reachable, Yellow 177 of 361, against 148 of 206 and 156 of 210.
- The walker reads `push bc`, `pop bc`, `srl a`, `adc b`, `ld d, a`, `ld e, a`, `cp c` over `wCurrentMenuItem`, `and`, `add a` and `srl a` on a known byte, a store of a `Random` byte under its mask (`store_byte`), the three HRAM temps `hGymGateIndex`, `hGymGateAnswer` and `hBackupGymGateIndex`, a `jp` onto a special body as a tail call, the routine behind `ExecuteCurMapScriptInTable`, and a scratch byte handed to `hSpriteIndex` or `hTextID` (`object_from`, `map_text` `from`).

## Added
- Vermilion Gym's fifteen trash cans: `GymTrashScript` as a `gym_trash` node, the first lock rolled by Vermilion City's load, the second drawn out of the can's `GymTrashCans` row with the bytes past the table the source's own draws read, and the door opened by `VermilionGymSetDoorTile` on the frame after the second lock. The three lock bytes ride the world snapshot as `gen1_bytes`.
- Cinnabar Gym's six quiz machines: the right answer opens the gate on the spot, the wrong one leaves `wOpponentAfterWrongAnswer` for `CinnabarGymDefaultScript` to walk that trainer up and the next state to fight him, on Yellow through the bit his row wants.
- `PokemonTower7FEndBattleScript`'s rocket saying its line and walking off along the `map_coord_movement` row the player stands on (`object_coord_move`), and `PokemonTower7FHideNPCScript`'s loop over `wToggleableObjectList`.
- The Champion's Room whole, eleven states from Agatha's own end-battle store, and Pewter City's museum and gym guides.
- `tools/checks/gen1_walk.gd` finds both locks and the door, answers a quiz right and wrong and is fought by the trainer the wrong answer brings, fights the tower's rocket and watches it leave, and walks into the Champion's Room and its fight; `gen1_maps.gd` pins the new censuses.

## Fixed
- `_map_script_successors` followed only a map's own stores, so the Champion's Room, whose byte Agatha's room writes, kept one state of eleven.
- `_gen1_sight` took a map script that only wrote blocks as holding the world, so a gate redrawn behind a fight hid the next sighting.
- A `map_text` node over a trainer's row is `TalkToTrainer` after the fight rather than an empty box.