### PR TITLE
Run Red, Blue and Yellow's own Hall of Fame and credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 </p>
 
 A native [Godot 4](https://godotengine.org) reimplementation of the Game Boy
-Pokémon games. Gold, Silver and Crystal are playable end to end; Red, Blue and
-Yellow are read and cached, and their world is being built. It is written from
+Pokémon games. Gold, Silver, Crystal, Red, Blue and Yellow are playable from the
+bedroom to the Hall of Fame and their own credits. It is written from
 scratch in GDScript, not an emulator, static recompilation or disassembly. A
 user-supplied cartridge dump is SHA-1 verified, decoded once into a cache, then
 released. No game data ships here: bring your own ROM.
@@ -80,12 +80,9 @@ godot --headless --path . -s res://tools/verify_rom.gd
 Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
 cartridges import their species, move, type, item and trainer tables, every map
-and tileset, and every map text, and a wild fight, a trainer battle and a
-standing wild Pokemon on one of their maps are all fought on the battle screen.
-An NPC's in-game trade is offered, refused and taken.
-The START menu is the cartridge's own list and opens its one-pocket bag; the
-launcher seats one and does not offer Play until its map scripts are
-interpreted.
+and tileset, every map text and script, and `AnimateHallOfFame`'s induction with
+`HallOfFamePC`'s credits behind it; their START menu is the cartridge's own list
+over a one-pocket bag.
 
 | Game | SHA-1 |
 |---|---|
@@ -128,7 +125,7 @@ whatever shape it is, with a way back to the shipped art. It is kept under
 | Font, borders, HUD | 128 glyphs, eight text-box frames, HP/EXP bars and panels |
 | Splash, title, intro | Each cartridge's opening art, tilemaps and palette runs, including Crystal's 35-entry intro section |
 | Region map | Three graphics sheets, both region tilemaps, the per-tile palette map and 96 landmarks |
-| Prof Oak's PC, credits | The 19 `OakRatings` rows and their texts; `CreditsScript`'s whole command stream |
+| Prof Oak's PC, credits | The 19 `OakRatings` rows and their texts; `CreditsScript`'s whole command stream, or Generation 1's `CreditsOrder`, its strings, `CreditsMons` and `TheEndGfx` |
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Grass, water and swarm tables, 13 fishing groups, the roaming graph, rates, slots and repel checks |
 | World services | Menus, marts, fruit trees, phone contacts, special calls, bounded scripts and text, music, SFX and cries |
@@ -366,10 +363,10 @@ or a group, or `all`; with no argument it lists them.
 | `terrain` | Ledge hops, side walls, every map's drawn blocks, the story's map ids |
 | `johto` | Radio Tower, the Rising Badge, command queues, item balls, Route 27, the Magnet Train and long scripted scenes |
 | `kanto` | Each city, its gym and the way in, from Vermilion to Mt. Silver |
-| `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
+| `art` | Both intro movies, the credits of all six cartridges, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, the key-item and usable-item tables behind the bag, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, and all 202 or 203 battle animations |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, the key-item and usable-item tables behind the bag, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, all 202 or 203 battle animations, and the Hall of Fame's own pages |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1806,10 +1806,10 @@ func _build_matchups(rows: Array) -> void:
 ## The four colours a species is drawn with, in index order.
 func palette(number: int, shiny: bool = false) -> PackedColorArray:
 	var entry: Dictionary = species(number)
-	if entry.is_empty():
+	var entry_palette: Dictionary = entry.get("palette", {})
+	if entry_palette.is_empty():
 		return PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 
-	var entry_palette: Dictionary = entry["palette"]
 	# Generation 1's `SuperPalettes` row is all four colours and has no shiny
 	# half; Generation 2 stores only the two that sit between white and black.
 	if entry_palette.has("colors"):
@@ -2276,6 +2276,39 @@ func credits_string(index: int) -> PackedByteArray:
 ## string printed from column 2. -1 on a cache without the credits.
 func credits_index(name: String) -> int:
 	return int(_credits.get(name, -1))
+
+
+## Generation 1's own `db -n` column per string; -1 outside the table.
+func credits_string_column(index: int) -> int:
+	var stored: Variant = _credits.get("columns", [])
+	if not stored is Array or index < 0 or index >= (stored as Array).size():
+		return -1
+	return int((stored as Array)[index])
+
+
+## `CreditsMons` by dex number, one per `_MON` command in the order.
+func credits_mons() -> PackedInt32Array:
+	var stored: Variant = _credits.get("mons", [])
+	var out := PackedInt32Array()
+	if stored is Array:
+		for number: Variant in stored as Array:
+			out.append(int(number))
+	return out
+
+
+## `CopyrightTextString`'s rows of `LoadCopyrightTiles` codes.
+func credits_copyright_rows() -> Array:
+	var stored: Variant = _credits.get("copyright_rows", [])
+	var out: Array = []
+	if not stored is Array:
+		return out
+	for row: Variant in stored as Array:
+		var codes := PackedByteArray()
+		if row is Array:
+			for code: Variant in row as Array:
+				codes.append(int(code) & 0xFF)
+		out.append(codes)
+	return out
 
 
 ## Whether this cache carries `CrystalIntro`'s art. False on Gold and Silver,

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -140,6 +140,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_battle_anims,
 	_verify_facility_text,
 	_verify_dex_ratings,
+	_verify_credits,
 	_verify_overworld_coords,
 	_verify_field_moves,
 	_verify_intro,
@@ -200,10 +201,12 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"bills_pc_2": ["bills_pc_release_text", Gen1Layout.BILLS_PC_RELEASE_TEXT_AT],
 	"oaks_pc": ["oaks_pc_text", Gen1Layout.OAKS_PC_TEXT_AT],
 	"hof_pc": ["hof_pc_text", Gen1Layout.HOF_PC_TEXT_AT],
+	"hall_of_fame": ["hof_dex_text", Gen1Layout.HOF_DEX_TEXT_AT],
 	"change_box": ["change_box_text", Gen1Layout.CHANGE_BOX_TEXT_AT],
 	"choose_box": ["choose_box_text", Gen1Layout.CHOOSE_BOX_TEXT_AT],
 	"oaks_aide": ["oaks_aide_text", Gen1Layout.OAKS_AIDE_TEXT_AT],
 }
+const CREDITS_ORDER_MAX: int = 256
 const CARD_KEY_TEXT_NAMES: Array[String] = ["card_key_success", "card_key_fail"]
 
 const INTRO_TEXT_RUNS: Dictionary = {
@@ -614,6 +617,41 @@ static func _verify_dex_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return _ok()
 
 
+## `CreditsOrder` ends on `CRED_THE_END`, names only `NUM_CRED_STRINGS`
+## pointers, and `CreditsMons` holds one species per `_MON` command.
+static func _verify_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var order: PackedByteArray = read_credits_order(rom, layout)
+	if order.is_empty() or order[order.size() - 1] != Gen1Layout.CREDITS_THE_END:
+		return _fail("CreditsOrder does not end on CRED_THE_END.")
+	var count: int = Gen1Layout.credits_string_count(rom.id)
+	var table: int = int(layout["credits_text_pointers"])
+	var bank: int = RomFile.bank_of(table)
+	var first: int = -1
+	for index: int in count:
+		var at: int = Gen1Layout.banked(bank, rom.u16le(table + index * Gen1Layout.POINTER_SIZE))
+		first = at if first < 0 else mini(first, at)
+		if read_credits_string(rom, at).is_empty():
+			return _fail("Credits string %d does not decode." % index)
+	if first != table + count * Gen1Layout.POINTER_SIZE:
+		return _fail("CreditsTextPointers holds %d rows, not %d." % [
+			(first - table) / Gen1Layout.POINTER_SIZE, count
+		])
+	var mons: int = 0
+	for command: int in order:
+		if command < count:
+			continue
+		if command == Gen1Layout.CREDITS_TEXT_MON or command == Gen1Layout.CREDITS_TEXT_FADE_MON:
+			mons += 1
+		elif command < Gen1Layout.CREDITS_THE_END:
+			return _fail("CreditsOrder names string %d of %d." % [command, count])
+	for slot: int in mons:
+		if Gen1Layout.dex_of_index(rom, layout, rom.u8(int(layout["credits_mons"]) + slot)) < 1:
+			return _fail("CreditsMons row %d is no species." % slot)
+	if read_copyright_rows(rom, layout).size() != Gen1Layout.COPYRIGHT_ROWS:
+		return _fail("CopyrightTextString is not three rows.")
+	return _ok()
+
+
 ## `CutTreeBlockSwaps` and `DisplayPCMainMenu`'s own `CheckEvent`: two tables the
 ## rest of the field moves are read through, each pinned against the dump so a
 ## number here can never be the only thing that says what the cartridge does.
@@ -946,6 +984,7 @@ func import_rom(
 		"day_care_text": _import_day_care_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
 		"oak_ratings": _import_dex_ratings(rom, layout),
+		"credits": read_credits(rom, layout),
 		"vending": _import_vending(rom, layout, items),
 		"prizes": _import_prizes(rom, layout),
 		"town_map": _import_town_map(rom, layout),
@@ -1531,6 +1570,76 @@ func _import_dex_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 	}
 
 
+## `engine/movie/credits.asm`'s four tables, in the shape `GameData.credits_*`
+## reads.
+static func read_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var order: PackedByteArray = read_credits_order(rom, layout)
+	var table: int = int(layout["credits_text_pointers"])
+	var bank: int = RomFile.bank_of(table)
+	var strings: Array = []
+	var columns: Array = []
+	for index: int in Gen1Layout.credits_string_count(rom.id):
+		var at: int = Gen1Layout.banked(bank, rom.u16le(table + index * Gen1Layout.POINTER_SIZE))
+		strings.append(Array(read_credits_string(rom, at)))
+		## `ld b, -1 / add hl, bc`: the byte counts back from `hlcoord 9, 6`.
+		columns.append(Gen1Layout.CREDITS_CENTRE_COLUMN + (rom.u8(at) - 0x100))
+	var mons: Array = []
+	for command: int in order:
+		if command == Gen1Layout.CREDITS_TEXT_MON or command == Gen1Layout.CREDITS_TEXT_FADE_MON:
+			mons.append(Gen1Layout.dex_of_index(
+				rom, layout, rom.u8(int(layout["credits_mons"]) + mons.size())
+			))
+	return {
+		"script": Array(order),
+		"strings": strings,
+		"columns": columns,
+		"mons": mons,
+		"copyright_rows": read_copyright_rows(rom, layout),
+	}
+
+
+static func read_credits_order(rom: RomFile, layout: Dictionary) -> PackedByteArray:
+	var out := PackedByteArray()
+	var at: int = int(layout["credits_order"])
+	while rom.in_bounds(at, 1) and out.size() < CREDITS_ORDER_MAX:
+		var command: int = rom.u8(at)
+		out.append(command)
+		at += 1
+		if command == Gen1Layout.CREDITS_THE_END:
+			return out
+	return PackedByteArray()
+
+
+## One `db -n, "TEXT@"` row past its offset byte; empty with no terminator.
+static func read_credits_string(rom: RomFile, at: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	for index: int in Gen1Layout.CREDITS_STRING_MAX + 1:
+		var read: int = at + 1 + index
+		if not rom.in_bounds(read, 1):
+			return PackedByteArray()
+		var code: int = rom.u8(read)
+		if code == Gen1Text.TERMINATOR:
+			return out
+		out.append(code)
+	return PackedByteArray()
+
+
+static func read_copyright_rows(rom: RomFile, layout: Dictionary) -> Array:
+	var rows: Array = [[]]
+	var at: int = int(layout["copyright_text"])
+	for index: int in Gen2Layout.COPYRIGHT_STRING_MAX:
+		if not rom.in_bounds(at + index, 1):
+			return []
+		var code: int = rom.u8(at + index)
+		if code == Gen1Text.TERMINATOR:
+			return rows
+		if code == Gen1Text.NEXT_LINE:
+			rows.append([])
+			continue
+		(rows[rows.size() - 1] as Array).append(code)
+	return []
+
+
 ## `InGameTradeTextPointers`' three tables of five and the two boxes the swap
 ## prints, in the one run both generations' trades are read from.
 func _import_trade_text(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -1918,6 +2027,18 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"tiles": 1,
 			"first_code": Gen1Layout.CHAR_ED,
 			"bits": 1,
+		},
+		"copyright": {
+			"offset": int(layout["copyright_tiles"]),
+			"tiles": Gen1Layout.copyright_tiles(rom.id),
+			"first_code": Gen1Layout.CREDITS_TILES_FIRST_CODE,
+			"bits": 2,
+		},
+		"credits_the_end": {
+			"offset": int(layout["credits_the_end"]),
+			"tiles": Gen1Layout.CREDITS_THE_END_TILES,
+			"first_code": Gen1Layout.CREDITS_TILES_FIRST_CODE,
+			"bits": 2,
 		},
 	}
 	for sheet: String in BATTLE_TILE_SHEETS:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -709,6 +709,7 @@ const OAKS_PC_TEXT_AT: Dictionary = {
 }
 ## `engine/menus/league_pc.asm`'s one.
 const HOF_PC_TEXT_AT: Dictionary = {"accessed": 0x00}
+const HOF_DEX_TEXT_AT: Dictionary = {"seen_owned": 0x00, "rating": TEXT_FAR_STUB_BYTES}
 
 ## `ChangeBox`'s two, pinned apart because Yellow's own boxes move the second.
 const CHANGE_BOX_TEXT_AT: Dictionary = {"warning": 0x00}
@@ -756,6 +757,26 @@ const DEX_RATING_STEP: int = 10
 ## `PokeballTileGraphics`' four; only the ball itself is drawn here.
 const BALL_TILES: int = 4
 const DEX_COMPLETION_TEXT_AT: int = -TEXT_FAR_STUB_BYTES
+
+## `CreditsOrder`'s six commands; anything below is a `CreditsTextPointers`
+## index, of which there are `NUM_CRED_STRINGS`.
+const CREDITS_TEXT_FADE_MON: int = 0xFF
+const CREDITS_TEXT_MON: int = 0xFE
+const CREDITS_TEXT_FADE: int = 0xFD
+const CREDITS_TEXT: int = 0xFC
+const CREDITS_COPYRIGHT: int = 0xFB
+const CREDITS_THE_END: int = 0xFA
+const CREDITS_STRINGS_RED_BLUE: int = 64
+const CREDITS_STRINGS_YELLOW: int = 86
+const CREDITS_STRING_MAX: int = 32
+const CREDITS_CENTRE_COLUMN: int = 9
+## `TheEndGfx` and `LoadCopyrightTiles`' run both land at `vChars2 tile $60`;
+## Yellow's run reaches `NineTile`, which its `CopyrightTextString` uses.
+const CREDITS_THE_END_TILES: int = 10
+const CREDITS_TILES_FIRST_CODE: int = 0x60
+const COPYRIGHT_TILES_RED_BLUE: int = 28
+const COPYRIGHT_TILES_YELLOW: int = 30
+const COPYRIGHT_ROWS: int = 3
 
 ## `LoadPokedexTilePatterns`: `PokedexTileGraphics` at `vChars2 tile $60`, over
 ## the text box sheet, with `PokeballTileGraphics`' first tile at $72 behind it.
@@ -1973,6 +1994,14 @@ const RED_BLUE: Dictionary = {
 	"bills_pc_release_text": 0x2181B,
 	"oaks_pc_text": 0x1E93B,
 	"hof_pc_text": 0x76683,
+	## `DexSeenOwnedText`, then the credits' four tables and the copyright run.
+	"hof_dex_text": 0x703FA,
+	"credits_mons": 0x74131,
+	"credits_order": 0x74243,
+	"credits_text_pointers": 0x742C3,
+	"credits_the_end": 0x7473E,
+	"copyright_tiles": 0x120C8,
+	"copyright_text": 0x04556,
 	"change_box_text": 0x73909,
 	"choose_box_text": 0x739D4,
 	"dex_ratings": 0x441D1,
@@ -2424,6 +2453,13 @@ const YELLOW: Dictionary = {
 	"bills_pc_release_text": 0x2185D,
 	"oaks_pc_text": 0x1E2D4,
 	"hof_pc_text": 0x75F02,
+	"hof_dex_text": 0x70452,
+	"credits_mons": 0xF1028,
+	"credits_order": 0xF1171,
+	"credits_text_pointers": 0xF11E3,
+	"credits_the_end": 0xF181B,
+	"copyright_tiles": 0x10C48,
+	"copyright_text": 0x04355,
 	"change_box_text": 0x73C52,
 	"choose_box_text": 0x73D10,
 	"dex_ratings": 0x441D1,
@@ -2721,6 +2757,7 @@ const BLUE_SHIFT: Dictionary = {
 	"hidden_item_coords": 1,
 	"hidden_coin_coords": 1,
 	"hof_pc_text": 1,
+	"credits_the_end": 1,
 }
 
 static var _blue: Dictionary = _shifted_for_blue()
@@ -2937,6 +2974,14 @@ static func map_count(id: StringName) -> int:
 ## sleep, where Red and Blue clear it and print `PlayedFluteNoEffectText` anyway.
 static func flute_counts_wild(id: StringName) -> bool:
 	return id == RomRegistry.YELLOW
+
+
+static func credits_string_count(id: StringName) -> int:
+	return CREDITS_STRINGS_YELLOW if id == RomRegistry.YELLOW else CREDITS_STRINGS_RED_BLUE
+
+
+static func copyright_tiles(id: StringName) -> int:
+	return COPYRIGHT_TILES_YELLOW if id == RomRegistry.YELLOW else COPYRIGHT_TILES_RED_BLUE
 
 
 static func player_backpics(layout: Dictionary) -> Array[String]:

--- a/game/gen1/gen1_text.gd
+++ b/game/gen1/gen1_text.gd
@@ -94,6 +94,7 @@ const ARROW_DOWN: int = 0xEE
 const WORD_TILES: Dictionary = {
 	"<PKMN>": [0xE1, 0xE2],
 }
+static var _words: Dictionary = {}
 
 ## The longest sequence one tile stands for: a ligature is two characters.
 ## [constant WORD_TILES]' spelling is longer and is matched ahead of this run.
@@ -204,12 +205,13 @@ static func encode(text: String) -> PackedByteArray:
 	var codes: Dictionary = _encodings()
 	var out: PackedByteArray = PackedByteArray()
 	var at: int = 0
+	var words: Dictionary = _word_tiles()
 	while at < text.length():
 		var taken: int = 0
-		for spelling: String in WORD_TILES:
+		for spelling: String in words:
 			if text.substr(at, spelling.length()) != spelling:
 				continue
-			for code: int in WORD_TILES[spelling] as Array:
+			for code: int in words[spelling] as Array:
 				out.append(code)
 			taken = spelling.length()
 			break
@@ -259,6 +261,20 @@ static func _characters() -> Dictionary:
 	return _table
 
 
+## [constant WORD_TILES] and the $60 run's bracketed names, so a decoded
+## `<COLON>` writes its tile back.
+static func _word_tiles() -> Dictionary:
+	if not _words.is_empty():
+		return _words
+	var words: Dictionary = WORD_TILES.duplicate()
+	for byte: int in FONT_EXTRA_CHARACTERS:
+		var extra: String = FONT_EXTRA_CHARACTERS[byte]
+		if extra.begins_with("<") and not words.has(extra):
+			words[extra] = [byte]
+	_words = words
+	return _words
+
+
 ## Built once. Where two codes draw the same character the first wins, which is
 ## why $F2's decimal point does not displace $E8's.
 static func _encodings() -> Dictionary:
@@ -272,7 +288,7 @@ static func _encodings() -> Dictionary:
 		if not codes.has(glyph):
 			codes[glyph] = byte
 	# The $60 run is below FIRST_PRINTABLE and still drawn. A bracketed name in it
-	# stays decode-only, being wider than one window of the loop above.
+	# is wider than one window of the loop above and goes through _word_tiles.
 	for byte: int in FONT_EXTRA_CHARACTERS:
 		var extra: String = FONT_EXTRA_CHARACTERS[byte]
 		if extra.length() <= MAX_LIGATURE and not codes.has(extra):

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 132
+const FORMAT_VERSION: int = 133
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/credits_page.gd
+++ b/game/render/credits_page.gd
@@ -2,13 +2,11 @@ class_name Gen2CreditsPage
 extends RefCounted
 
 ## The credits screen, on the tile grid the hardware uses. [Gen2Credits] owns the
-## BG map and the attribute map, because `ConstructCreditsTilemap` and
-## `ParseCredits` are what write them; this resolves a tile number to pixels and
+## BG map and the attribute map; this resolves a tile number to pixels and
 ## colours it through `CreditsPalettes`. The VRAM window is the banner's 4x4 mon
 ## cell at $00, `CreditsBorderGFX` at $20, `TheEndGFX` at $40, `CopyrightGFX` at
-## $60 and the font untouched from $80. The two border bands are the only thing
-## that scrolls: `Credits_LYOverride` fills eight scanlines of `wLYOverrides` per
-## band, so those rows are sampled through an offset walking two pixels a cycle.
+## $60 and the font from $80. `Credits_LYOverride` scrolls the two border bands
+## alone, two pixels a cycle.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = Gen2Credits.COLUMNS
@@ -24,6 +22,11 @@ const BANNER_TILES: int = Gen2Layout.CREDITS_MON_FRAME_TILES
 var font: Gen2Font = null
 ## The VRAM window, as one indices strip per tile number.
 var _tiles: Dictionary = {}
+## Generation 1 loads its copyright and `TheEndGfx` at the same $60 in turn,
+## so its sheets are kept by name and the frame says which is loaded.
+var _gen1: bool = false
+var _gen1_sheets: Dictionary = {}
+var _gen1_colors: PackedColorArray = PackedColorArray()
 ## `CreditsMonsGFX` whole, which a block indexes into.
 var _mons: PackedByteArray = PackedByteArray()
 var _mons_width: int = 0
@@ -37,6 +40,13 @@ static func from_data(data: GameData) -> Gen2CreditsPage:
 		return null
 	var out := Gen2CreditsPage.new()
 	out.font = glyphs
+	if data.generation == RomRegistry.GEN1:
+		out._gen1 = true
+		for name: String in [Gen1Credits.SHEET_COPYRIGHT, Gen1Credits.SHEET_THE_END]:
+			out._gen1_sheets[name] = _cells(data, name)
+		## The player's `SET_PAL_POKEMON_WHOLE_SCREEN`, species 0, is PAL_MEWMON.
+		out._gen1_colors = data.world_palette(Gen1Layout.PAL_MEWMON)
+		return out
 	out._load_sheet(data, "credits_border", Gen2Layout.CREDITS_BORDER_FIRST_CODE)
 	out._load_sheet(data, "credits_the_end", Gen2Layout.CREDITS_THE_END_FIRST_CODE)
 	out._load_sheet(data, "copyright", Gen2Layout.COPYRIGHT_FIRST_CODE)
@@ -46,6 +56,9 @@ static func from_data(data: GameData) -> Gen2CreditsPage:
 
 
 func ready() -> bool:
+	if _gen1:
+		return font != null and _gen1_colors.size() >= Gen2Layout.CREDITS_PALETTE_COLORS \
+			and not (_gen1_sheets.get(Gen1Credits.SHEET_THE_END, []) as Array).is_empty()
 	return font != null and _mons_width > 0 \
 		and _tiles.has(Gen2Layout.CREDITS_BORDER_FIRST_CODE) \
 		and _tiles.has(Gen2Layout.CREDITS_THE_END_FIRST_CODE)
@@ -53,6 +66,8 @@ func ready() -> bool:
 
 ## The whole 160x144 screen. [param state] is [method Gen2Credits.frame_state].
 func image(data: GameData, state: Dictionary) -> Image:
+	if _gen1:
+		return _image_gen1(data, state)
 	var map: PackedInt32Array = state.get("map", PackedInt32Array())
 	var slots: PackedInt32Array = state.get("attributes", PackedInt32Array())
 	var indices: PackedByteArray = compose(map, int(state.get("block", -1)))
@@ -137,19 +152,9 @@ func _blit_banner(
 
 
 func _load_sheet(data: GameData, name: String, first_tile: int) -> void:
-	var indices: PackedByteArray = data.tile_indices(name)
-	if indices.is_empty():
-		return
-	var width: int = indices.size() / TILE
-	@warning_ignore("integer_division")
-	var count: int = width / TILE
-	for tile: int in count:
-		var cell := PackedByteArray()
-		cell.resize(TILE * TILE)
-		for y: int in TILE:
-			for x: int in TILE:
-				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
-		_tiles[first_tile + tile] = cell
+	var cells: Array = _cells(data, name)
+	for tile: int in cells.size():
+		_tiles[first_tile + tile] = cells[tile]
 
 
 func _blit(indices: PackedByteArray, cell: PackedByteArray, at: Vector2i) -> void:
@@ -162,3 +167,107 @@ func _fill(indices: PackedByteArray, at: Vector2i, index: int) -> void:
 	for y: int in TILE:
 		for x: int in TILE:
 			indices[(at.y + y) * WIDTH + at.x + x] = index
+
+
+## The tilemap through `rBGP`, the middle rows scrolled by the slide with the
+## next mon riding in from BG column 20.
+func _image_gen1(data: GameData, state: Dictionary) -> Image:
+	var out: PackedInt32Array = Gen2PicImage.canvas(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	var map: PackedInt32Array = state.get("map", PackedInt32Array())
+	if map.size() < COLUMNS * ROWS:
+		return Gen2PicImage.canvas_image(out, Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	var indices: PackedByteArray = compose_gen1(map, StringName(state.get("sheet", &"")))
+	var mon: Dictionary = _gen1_mon_cell(data, int(state.get("mon", 0)))
+	var scroll: int = int(state.get("scroll", 0))
+	var table: PackedInt32Array = Gen2PicImage.lookup(
+		Gen2WorldPalette.fade_palette(_gen1_colors, int(state.get("bgp", 0)))
+	)
+	for y: int in Gen2Screen.HEIGHT:
+		@warning_ignore("integer_division")
+		var row: int = y / TILE
+		var middle: bool = row >= Gen1Credits.MIDDLE_FIRST_ROW \
+			and row < Gen1Credits.BAND_BOTTOM_ROW
+		var line: int = y * WIDTH
+		for x: int in WIDTH:
+			var source: int = x + scroll if middle else x
+			var index: int = 0
+			if source < WIDTH:
+				index = indices[line + source]
+			elif not mon.is_empty():
+				index = _gen1_mon_index(mon, source - Gen1Credits.MON_SOURCE_X, y)
+			out[line + x] = table[index]
+	return Gen2PicImage.canvas_image(out, Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## $7e solid, the loaded sheet as it is, and the font through
+## `ShiftFontColorIndex`, which zeroes the low plane so ink is colour 2.
+func compose_gen1(map: PackedInt32Array, sheet: StringName) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * ROWS * TILE)
+	var cells: Array = _gen1_sheets.get(sheet, [])
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var tile: int = map[row * COLUMNS + column]
+			var at := Vector2i(column * TILE, row * TILE)
+			if tile == Gen1Credits.BLACK_TILE:
+				_fill(indices, at, PokeTiles.INK)
+			elif tile >= Gen1Layout.CREDITS_TILES_FIRST_CODE \
+				and tile - Gen1Layout.CREDITS_TILES_FIRST_CODE < cells.size():
+				_blit(indices, cells[tile - Gen1Layout.CREDITS_TILES_FIRST_CODE], at)
+			elif tile != BLANK_TILE:
+				font.draw_code(tile, indices, WIDTH, at.x, at.y, Gen2Text.FONT_MAIN)
+				_shift_ink(indices, at)
+	return indices
+
+
+func _shift_ink(indices: PackedByteArray, at: Vector2i) -> void:
+	for y: int in TILE:
+		for x: int in TILE:
+			var slot: int = (at.y + y) * WIDTH + at.x + x
+			indices[slot] = indices[slot] & 2
+
+
+## `LoadFrontSpriteByMonIndex` at `hlcoord 8, 6`, bottom-centred in its box.
+func _gen1_mon_cell(data: GameData, species: int) -> Dictionary:
+	if species <= 0 or data == null:
+		return {}
+	var pic: Dictionary = data.species_pic(species)
+	if pic.is_empty():
+		return {}
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices(pic["atlas"]), data.atlas(pic["atlas"]), pic
+	)
+	if cell.is_empty():
+		return {}
+	var box: int = Gen2PicImage.FRONTPIC_TILES * TILE
+	cell["left"] = Gen2PicImage.frontpic_pad_columns(
+		int(cell["width"]) / TILE, false, RomRegistry.GEN1
+	) * TILE
+	cell["top"] = Gen1Credits.MON_ROW * TILE + box - int(cell["height"])
+	cell["bottom"] = Gen1Credits.MON_ROW * TILE + box
+	return cell
+
+
+func _gen1_mon_index(mon: Dictionary, x: int, y: int) -> int:
+	var px: int = x - int(mon["left"])
+	var py: int = y - int(mon["top"])
+	if px < 0 or py < 0 or px >= int(mon["width"]) or y >= int(mon["bottom"]):
+		return 0
+	return (mon["indices"] as PackedByteArray)[py * int(mon["width"]) + px]
+
+
+static func _cells(data: GameData, name: String) -> Array:
+	var indices: PackedByteArray = data.tile_indices(name)
+	var out: Array = []
+	if indices.is_empty():
+		return out
+	var width: int = indices.size() / TILE
+	@warning_ignore("integer_division")
+	for tile: int in width / TILE:
+		var cell := PackedByteArray()
+		cell.resize(TILE * TILE)
+		for y: int in TILE:
+			for x: int in TILE:
+				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
+		out.append(cell)
+	return out

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -116,6 +116,10 @@ func is_usable() -> bool:
 	return _glyph_width > 0 and _glyphs.size() >= _glyph_width * TILE
 
 
+func font_generation() -> int:
+	return _generation
+
+
 func frame_count() -> int:
 	if _frame_stride <= 0:
 		return 1 if _frame_tiles > 0 else 0

--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2HallOfFamePage
 extends RefCounted
 
-## One Hall of Fame induction panel, on the tile grid the hardware uses.
-## Positions are `engine/events/halloffame.asm`'s own: `DisplayHOFMon`'s two text
-## boxes, its frontpic at (6,5) and every field row, plus
-## `HOF_AnimatePlayerPic`'s name box. `LoadFontsBattleExtra` runs first, so the
-## panel prints with the battle-extra strip over $60 to $78. Node-free: the pic
-## has its own palette and is composed over the page by the screen.
+## One Hall of Fame induction panel, on the tile grid the hardware uses, at
+## `engine/events/halloffame.asm`'s own positions. `LoadFontsBattleExtra` runs
+## first, so Crystal's panel prints with the battle-extra strip over $60 to $78.
+## Node-free: the pic is composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -93,6 +91,37 @@ const SAVING_AT: Vector2i = Vector2i(1, 14)
 var frame_style: int = 0
 
 var font: Gen2Font = null
+## `AnimateHallOfFame`'s own layout, drawn through the main font.
+var gen1: bool = false
+
+const GEN1_INFO_BOX: Rect2i = Rect2i(0, 2, 12, 11)
+const GEN1_NICKNAME_AT: Vector2i = Vector2i(1, 4)
+const GEN1_LABELS_AT: Vector2i = Vector2i(2, 6)
+const GEN1_LABELS: Array[String] = ["LEVEL/", "TYPE1/", "TYPE2/"]
+const GEN1_ROW_STEP: int = 2
+## `PrintLevelCommon` with LEFT_ALIGN and the `c` `PlaceString` left: digits
+## alone.
+const GEN1_LEVEL_AT: Vector2i = Vector2i(8, 7)
+const GEN1_TYPES_AT: Vector2i = Vector2i(3, 9)
+const GEN1_FAMED_BOX: Rect2i = Rect2i(2, 13, 16, 5)
+const GEN1_FAMED_AT: Vector2i = Vector2i(4, 15)
+const GEN1_FAMED_TEXT: String = "HALL OF FAME"
+## `LeaguePCShowMon`'s box, with `wHoFTeamNo` in three cells.
+const GEN1_TEAM_BOX: Rect2i = Rect2i(0, 13, 20, 4)
+const GEN1_TEAM_AT: Vector2i = Vector2i(1, 15)
+const GEN1_TEAM_TEXT: String = "HALL OF FAME No"
+const GEN1_TEAM_NUMBER_AT: Vector2i = Vector2i(16, 15)
+const GEN1_TEAM_DIGITS: int = 3
+const GEN1_STATS_BOX: Rect2i = Rect2i(0, 4, 12, 8)
+const GEN1_NAME_BOX: Rect2i = Rect2i(5, 0, 11, 4)
+const GEN1_NAME_AT: Vector2i = Vector2i(7, 2)
+const GEN1_PLAY_TIME_AT: Vector2i = Vector2i(1, 6)
+## `lb bc, 1, 3`, the `ld [hl], $6d` behind it and two minute digits.
+const GEN1_HOURS_AT: Vector2i = Vector2i(5, 7)
+const GEN1_HOUR_DIGITS: int = 3
+const GEN1_MONEY_LABEL: String = "MONEY"
+const GEN1_MONEY_LABEL_AT: Vector2i = Vector2i(1, 9)
+const GEN1_MONEY_AT: Vector2i = Vector2i(4, 10)
 
 
 static func from_data(data: GameData) -> Gen2HallOfFamePage:
@@ -102,6 +131,7 @@ static func from_data(data: GameData) -> Gen2HallOfFamePage:
 	var out := Gen2HallOfFamePage.new()
 	out.font = glyphs
 	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out.gen1 = Gen2HallOfFame.is_gen1(data)
 	return out
 
 
@@ -113,7 +143,9 @@ func draw(page: Dictionary) -> PackedByteArray:
 	if font == null:
 		return indices
 	var kind: StringName = StringName(page.get("kind", &""))
-	if kind == Gen2HallOfFame.PAGE_SAVING:
+	if gen1:
+		_draw_gen1(page, indices)
+	elif kind == Gen2HallOfFame.PAGE_SAVING:
 		_draw_saving(page, indices)
 	elif kind == Gen2HallOfFame.PAGE_PLAYER:
 		_draw_player(page, indices)
@@ -131,9 +163,84 @@ static func pic_size() -> int:
 	return PIC_TILES * TILE
 
 
-## Where the screen puts the player's own front pic, in pixels.
+## Where the screen puts the player's own front pic, in pixels; Generation 1
+## draws every pic there.
 static func player_pic_position() -> Vector2i:
 	return PLAYER_PIC_AT * TILE
+
+
+func pic_at() -> Vector2i:
+	return player_pic_position() if gen1 else pic_position()
+
+
+## `HoFShowMonOrPlayer` clears the screen for the slide.
+func _draw_gen1(page: Dictionary, indices: PackedByteArray) -> void:
+	if bool(page.get("slide", false)):
+		return
+	var kind: StringName = StringName(page.get("kind", &""))
+	if kind == Gen2HallOfFame.PAGE_MON:
+		_draw_gen1_mon(page, indices)
+	elif kind == Gen2HallOfFame.PAGE_PLAYER:
+		_draw_gen1_player(page, indices)
+
+
+func _draw_gen1_mon(page: Dictionary, indices: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_gen1_box(indices, width, GEN1_INFO_BOX)
+	_gen1_text(indices, width, String(page.get("nickname", "")), GEN1_NICKNAME_AT)
+	var types: Array = page.get("types", [])
+	## `EraseType2Text` blanks the second label outright when both types match.
+	for index: int in mini(GEN1_LABELS.size(), types.size() + 1):
+		_gen1_text(
+			indices, width, GEN1_LABELS[index], GEN1_LABELS_AT + Vector2i(0, index * GEN1_ROW_STEP)
+		)
+	_gen1_text(indices, width, str(int(page.get("level", 0))), GEN1_LEVEL_AT)
+	for index: int in types.size():
+		_gen1_text(
+			indices, width, String(types[index]), GEN1_TYPES_AT + Vector2i(0, index * GEN1_ROW_STEP)
+		)
+	if page.has("team_number"):
+		_gen1_box(indices, width, GEN1_TEAM_BOX)
+		_gen1_text(indices, width, GEN1_TEAM_TEXT, GEN1_TEAM_AT)
+		_gen1_text(
+			indices, width, "%*d" % [GEN1_TEAM_DIGITS, int(page["team_number"])],
+			GEN1_TEAM_NUMBER_AT
+		)
+	elif bool(page.get("famed", false)):
+		_gen1_box(indices, width, GEN1_FAMED_BOX)
+		_gen1_text(indices, width, GEN1_FAMED_TEXT, GEN1_FAMED_AT)
+
+
+func _draw_gen1_player(page: Dictionary, indices: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_gen1_box(indices, width, GEN1_STATS_BOX)
+	_gen1_box(indices, width, GEN1_NAME_BOX)
+	_gen1_text(indices, width, String(page.get("player_name", "")), GEN1_NAME_AT)
+	_gen1_text(indices, width, PLAY_TIME_TEXT, GEN1_PLAY_TIME_AT)
+	_gen1_text(indices, width, "%*d" % [GEN1_HOUR_DIGITS, int(page.get("hours", 0))], GEN1_HOURS_AT)
+	var colon_at: Vector2i = GEN1_HOURS_AT + Vector2i(GEN1_HOUR_DIGITS, 0)
+	font.draw_code(CODE_COLON, indices, width, colon_at.x * TILE, colon_at.y * TILE)
+	_gen1_text(indices, width, String(page.get("minutes", "")), colon_at + Vector2i(1, 0))
+	_gen1_text(indices, width, GEN1_MONEY_LABEL, GEN1_MONEY_LABEL_AT)
+	_gen1_text(indices, width, Gen2MartPage.money_string(int(page.get("money", 0))), GEN1_MONEY_AT)
+	if not page.has("lines"):
+		return
+	_gen1_box(indices, width, MON_BOTTOM_BOX)
+	var lines: Array = page.get("lines", [])
+	for index: int in lines.size():
+		_gen1_text(
+			indices, width, String(lines[index]), TEXT_AT + Vector2i(0, index * TEXT_LINE_SPACING)
+		)
+
+
+func _gen1_box(indices: PackedByteArray, width: int, box: Rect2i) -> void:
+	font.draw_box(
+		0, indices, width, box.position.x * TILE, box.position.y * TILE, box.size.x, box.size.y
+	)
+
+
+func _gen1_text(indices: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
+	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE)
 
 
 func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -185,7 +185,10 @@ func place_at_bottom() -> void:
 ## ending in `done`, which is why `SendOutMonText` runs on, and a caller that
 ## waits with `JoyWaitAorB`, which is every page of `ProfOaksPCBoot`.
 func show_text(text: String, blink_cursor: bool = true) -> void:
-	_pages = Gen2TextLayout.lay_out_pages(text, text_columns(), text_rows())
+	_pages = Gen2TextLayout.lay_out_pages(
+		text, text_columns(), text_rows(),
+		font.font_generation() if font != null else RomRegistry.GEN2
+	)
 	_blink_cursor = blink_cursor
 	_page = 0
 	_scroll_page = -1

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -18,7 +18,9 @@ const TEXTBOX_ROWS: int = 2
 ##
 ## Explicit newlines are kept: a caller that has already decided where a line
 ## ends is obeyed, and only the runs between them are wrapped.
-static func wrap_lines(text: String, columns: int) -> PackedStringArray:
+static func wrap_lines(
+	text: String, columns: int, generation: int = RomRegistry.GEN2
+) -> PackedStringArray:
 	var out: PackedStringArray = PackedStringArray()
 	if columns <= 0:
 		return out
@@ -27,7 +29,7 @@ static func wrap_lines(text: String, columns: int) -> PackedStringArray:
 		var line: String = ""
 		for word: String in _spaced_words(paragraph):
 			var candidate: String = line + word
-			if Gen2Text.encoded_length(candidate) <= columns:
+			if _tiles(candidate, generation) <= columns:
 				line = candidate
 				continue
 
@@ -35,15 +37,15 @@ static func wrap_lines(text: String, columns: int) -> PackedStringArray:
 				out.append(line)
 				line = ""
 				word = word.lstrip(" ")
-				if Gen2Text.encoded_length(word) <= columns:
+				if _tiles(word, generation) <= columns:
 					line = word
 					continue
 
 			# A word too long for a line of its own is cut rather than allowed to
 			# run off the edge. Nothing in these games is that long, but a mod's
 			# text is not the cartridge's.
-			while Gen2Text.encoded_length(word) > columns:
-				var head: String = _take(word, columns)
+			while _tiles(word, generation) > columns:
+				var head: String = _take(word, columns, generation)
 				out.append(head)
 				word = word.substr(head.length())
 			line = word
@@ -70,9 +72,11 @@ static func _spaced_words(paragraph: String) -> PackedStringArray:
 
 
 ## [method lay_out_pages] with each page's lines alone.
-static func lay_out(text: String, columns: int, rows: int) -> Array:
+static func lay_out(
+	text: String, columns: int, rows: int, generation: int = RomRegistry.GEN2
+) -> Array:
 	var out: Array = []
-	for page: Dictionary in lay_out_pages(text, columns, rows):
+	for page: Dictionary in lay_out_pages(text, columns, rows, generation):
 		out.append(page["lines"])
 	return out
 
@@ -85,7 +89,9 @@ static func lay_out(text: String, columns: int, rows: int) -> Array:
 ## page is `start`. `carried` is how many of the page's first lines the scroll
 ## moved up rather than printed, since `TextScroll` copies tiles and a carried
 ## line is already on screen.
-static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
+static func lay_out_pages(
+	text: String, columns: int, rows: int, generation: int = RomRegistry.GEN2
+) -> Array:
 	var out: Array = []
 	if rows <= 0 or columns <= 0:
 		return out
@@ -102,7 +108,7 @@ static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
 			if candidate >= 0 and (stop < 0 or candidate < stop):
 				stop = candidate
 		var segment: String = text.substr(at, -1) if stop < 0 else text.substr(at, stop - at)
-		for line: String in wrap_lines(segment, columns):
+		for line: String in wrap_lines(segment, columns, generation):
 			page.append(line)
 			if page.size() == rows:
 				out.append({"lines": page, "enter": enter, "carried": carried})
@@ -142,10 +148,18 @@ static func standing_page(
 
 
 ## The longest prefix of [param word] that fits in [param columns] tiles.
-static func _take(word: String, columns: int) -> String:
+static func _take(word: String, columns: int, generation: int) -> String:
 	var length: int = 0
 	while length < word.length():
-		if Gen2Text.encoded_length(word.substr(0, length + 1)) > columns:
+		if _tiles(word.substr(0, length + 1), generation) > columns:
 			break
 		length += 1
 	return word.substr(0, maxi(length, 1))
+
+
+## A `<COLON>` is one tile to Generation 1's codec and seven unknowns to
+## Crystal's.
+static func _tiles(text: String, generation: int) -> int:
+	if generation == RomRegistry.GEN1:
+		return Gen1Text.encoded_length(text)
+	return Gen2Text.encoded_length(text)

--- a/game/world/credits.gd
+++ b/game/world/credits.gd
@@ -1,14 +1,12 @@
 class_name Gen2Credits
 extends RefCounted
 
-## The credits (`engine/movie/credits.asm`), as the frame-driven state machine
-## they are. `Credits_Jumptable` runs one entry per frame and loops back after
-## thirteen, so a `CREDITS_WAIT` tick is thirteen frames and not one. The rest of
-## the cycle is what moves: the banner's frame, the two border bands walking
-## sideways two pixels, and the three `Credits_Next` entries `UpdateBGMap` spends
-## copying the tilemap a third at a time. That copy is why this owns two maps: a
-## batch ending on `CREDITS_WAIT2` or `CREDITS_END` is written and never shown,
-## which is why The End stays on screen. Nothing here draws.
+## The credits (`engine/movie/credits.asm`) as the state machine they are.
+## `Credits_Jumptable` runs one entry per frame and loops after thirteen, so a
+## `CREDITS_WAIT` tick is thirteen frames; the cycle moves the banner, walks the
+## border bands two pixels and spends three entries copying the tilemap a third
+## at a time. That copy is why this owns two maps: a batch ending on
+## `CREDITS_WAIT2` or `CREDITS_END` is written and never shown. Nothing here draws.
 
 ## `MUSIC_CREDITS` and the `MUSIC_POST_CREDITS` `.end` fades into, both the same
 ## number on all three cartridges.
@@ -204,6 +202,11 @@ func skippable() -> bool:
 	return _skippable
 
 
+## `.end` fades the music into MUSIC_POST_CREDITS before the screen closes.
+func music_outlasts() -> bool:
+	return false
+
+
 func frame_state() -> Dictionary:
 	return {
 		"map": bg_map(),
@@ -216,11 +219,8 @@ func frame_state() -> Dictionary:
 
 
 ## One frame of `.execution_loop`: the B skip, the jumptable entry, then the
-## VBlank behind `DelayFrame`.
-##
-## [param held] is `hJoypadDown`, since both of the loop's buttons are held
-## states rather than presses. Returns the events the frame asked for, which is
-## the two `PlayMusic` calls and nothing else.
+## VBlank behind `DelayFrame`. [param held] is `hJoypadDown`. Returns the two
+## `PlayMusic` events and nothing else.
 func advance_frame(held: Array = []) -> Array:
 	var events: Array = []
 	if PokeButton.B in held:

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -2,17 +2,18 @@ class_name Gen2CreditsScreen
 extends Control
 
 ## The credits, embedded in the overworld the way the Hall of Fame is.
-## [Gen2Credits] owns `Credits`' whole loop and [Gen2CreditsPage] draws it; this
-## spends the frames and reads the two buttons `.execution_loop` reads. Both are
-## held states rather than presses, so the host says when each is let go: A only
-## leaves once the script has run out, and B burns a tick of the current wait per
-## frame and only on a replay. The two `PlayMusic` calls are the overworld's.
+## [Gen2Credits] owns `Credits`' whole loop, [Gen1Credits] Generation 1's, and
+## [Gen2CreditsPage] draws either; this spends the frames and reads the two
+## buttons `.execution_loop` reads, both held states, so the host says when each
+## is let go. The `PlayMusic` calls are the overworld's.
 
 signal closed()
 signal music_requested(music: int)
 ## `.end`'s `wMusicFade`, which fades whatever is playing into MUSIC_POST_CREDITS
 ## over its own frame count.
 signal music_fade_requested(music: int, frames: int)
+
+var music_outlasts: bool = false
 
 var _data: GameData = null
 var _credits: Gen2Credits = null
@@ -30,12 +31,15 @@ var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 func set_context(data: GameData, skippable: bool = false) -> bool:
 	_data = data
 	_page = Gen2CreditsPage.from_data(data)
-	_credits = Gen2Credits.create(data, skippable)
+	_credits = Gen1Credits.create_gen1(data) \
+		if data != null and data.generation == RomRegistry.GEN1 \
+		else Gen2Credits.create(data, skippable)
 	if _page == null or not _page.ready() or _credits == null:
 		_page = null
 		_credits = null
 		visible = false
 		return false
+	music_outlasts = _credits.music_outlasts()
 	return true
 
 

--- a/game/world/gen1_credits.gd
+++ b/game/world/gen1_credits.gd
@@ -1,0 +1,326 @@
+class_name Gen1Credits
+extends Gen2Credits
+
+## `HallOfFamePC`'s credits (`engine/movie/credits.asm`), one straight loop: a
+## screen's strings are placed, then its command fades the text in, waits, and
+## slides the next `CreditsMons` entry across as a silhouette. `ShiftFontColorIndex`
+## drops the font's ink to colour 2, so a fade is `HoFGBPalettes` walking `rBGP`;
+## the black bands are tile $7e on colour 3 throughout.
+
+## `ClearScreen` then `ld c, 100` before the bands, `ld c, 128` behind
+## `PlayMusic MUSIC_CREDITS`, and `FadeInCredits`' four palettes at five frames.
+const OPEN_FRAMES: int = 100
+const LEAD_FRAMES: int = 128
+const FADE_STEP_FRAMES: int = 5
+const FADE_PALETTES: Array[int] = [0xC0, 0xD0, 0xE0, 0xF0]
+## The palette every mon leaves behind, the one that makes the mon and the text
+## one silhouette, and `GBFadeOutToWhite`'s last step, which the induction ends on.
+const BGP_HIDDEN: int = 0xC0
+const BGP_SILHOUETTE: int = 0xFC
+const BGP_WHITE: int = 0x00
+## The waits behind each command; Yellow's are twelve longer each.
+const WAITS: Dictionary = {
+	Gen1Layout.CREDITS_TEXT_FADE_MON: 90,
+	Gen1Layout.CREDITS_TEXT_MON: 110,
+	Gen1Layout.CREDITS_TEXT_FADE: 120,
+	Gen1Layout.CREDITS_TEXT: 140,
+}
+const WAIT_EXTRA_YELLOW: int = 12
+## `.showTheEnd`'s `ld c, 16`, 24 on Yellow; `DisplayCreditsMon`'s three
+## `CreditsCopyTileMapToVRAM` before its `.scrollLoop1` and `.scrollLoop2`,
+## 7 and 20 frames, Yellow's 10, 10 and 8.
+const THE_END_FRAMES: int = 16
+const THE_END_FRAMES_YELLOW: int = 24
+const SLIDE_SETUP_FRAMES: int = 9
+const SLIDE_FRAMES: int = 27
+const SLIDE_FRAMES_YELLOW: int = 28
+const SLIDE_STEP: int = 8
+## `HallOfFameResetEventsAndSaveScript`'s five `ld c, 600 / 5` behind the
+## credits, which no press shortens, and `WaitForTextScrollButtonPress` after.
+const END_HOLD_FRAMES: int = 600
+
+const BLACK_TILE: int = 0x7E
+## `FillFourRowsWithBlack` at rows 0 and 14, `FillMiddleOfScreenWithWhite`
+## between them.
+const BAND_ROWS: int = 4
+const BAND_BOTTOM_ROW: int = 14
+const MIDDLE_FIRST_ROW: int = 4
+const MIDDLE_ROWS: int = 10
+## `hlcoord 8, 6`, copied to `vBGMap0 + 12`: the mon's left edge is BG column
+## 20, off the right of the screen until the scroll brings it on.
+const MON_ROW: int = 6
+const MON_SOURCE_X: int = (12 + 8) * Gen2Font.TILE
+## `TheEndTextString`'s two rows at `hlcoord 4, 8`.
+const THE_END_AT_GEN1: Vector2i = Vector2i(4, 8)
+const THE_END_ROWS: Array = [
+	[0x60, 0x7F, 0x62, 0x7F, 0x64, 0x7F, 0x7F, 0x64, 0x7F, 0x66, 0x7F, 0x68],
+	[0x61, 0x7F, 0x63, 0x7F, 0x65, 0x7F, 0x7F, 0x65, 0x7F, 0x67, 0x7F, 0x69],
+]
+const COPYRIGHT_AT_GEN1: Vector2i = Vector2i(2, 7)
+
+const SHEET_NONE: StringName = &""
+const SHEET_COPYRIGHT: StringName = &"copyright"
+const SHEET_THE_END: StringName = &"credits_the_end"
+
+enum Phase { OPEN, LEAD, FADE, WAIT, SLIDE_SETUP, SLIDE, THE_END, DONE }
+
+var _yellow: bool = false
+var _phase: Phase = Phase.OPEN
+var _left: int = 0
+var _slide_at: int = 0
+## `rBGP`, which sheet `vChars2 tile $60` holds, and the command being spent.
+var _bgp: int = BGP_WHITE
+var _sheet: StringName = SHEET_NONE
+var _command: int = 0
+var _mons_shown: int = 0
+var _mon: int = 0
+## `rSCX` inside the middle rows during a slide.
+var _slide_scroll: int = 0
+var _mons: PackedInt32Array = PackedInt32Array()
+var _end_hold: int = 0
+
+
+static func create_gen1(data: GameData) -> Gen1Credits:
+	if data == null or data.credits_script().is_empty():
+		return null
+	var out := Gen1Credits.new()
+	out._data = data
+	out._script = data.credits_script()
+	out._mons = data.credits_mons()
+	out._yellow = data.id == RomRegistry.YELLOW
+	out._tilemap.resize(COLUMNS * ROWS)
+	out._tilemap.fill(BLANK_TILE)
+	out._left = OPEN_FRAMES
+	return out
+
+
+func finished() -> bool:
+	return _phase == Phase.DONE
+
+
+func may_finish(held: Array = []) -> bool:
+	return _phase == Phase.DONE and _end_hold <= 0 \
+		and (PokeButton.A in held or PokeButton.B in held)
+
+
+func skippable() -> bool:
+	return false
+
+
+func music_outlasts() -> bool:
+	return true
+
+
+func bg_map() -> PackedInt32Array:
+	return _tilemap.duplicate()
+
+
+func bgp() -> int:
+	return _bgp
+
+
+func sheet() -> StringName:
+	return _sheet
+
+
+func sliding_mon() -> int:
+	return _mon
+
+
+func slide_scroll() -> int:
+	return _slide_scroll
+
+
+func frame_state() -> Dictionary:
+	return {
+		"gen1": true,
+		"map": bg_map(),
+		"bgp": _bgp,
+		"sheet": _sheet,
+		"mon": _mon,
+		"scroll": _slide_scroll,
+	}
+
+
+## The only event is `PlayMusic MUSIC_CREDITS`, on the frame the bands go up.
+func advance_frame(_held: Array = []) -> Array:
+	var events: Array = []
+	match _phase:
+		Phase.OPEN:
+			if _spend():
+				_open_bands()
+				events.append({"type": &"music_requested", "music": MUSIC_CREDITS})
+		Phase.LEAD:
+			if _spend():
+				_next_screen()
+		Phase.FADE:
+			_fade_step()
+			if _spend():
+				_after_fade()
+		Phase.WAIT:
+			if _spend():
+				_after_wait()
+		Phase.SLIDE_SETUP:
+			if _spend():
+				_start_slide()
+		Phase.SLIDE:
+			_slide_step()
+		Phase.THE_END:
+			if _spend():
+				_show_the_end()
+		Phase.DONE:
+			_end_hold = maxi(_end_hold - 1, 0)
+	return events
+
+
+func _spend() -> bool:
+	_left -= 1
+	return _left <= 0
+
+
+func _open_bands() -> void:
+	for row: int in BAND_ROWS:
+		_fill_row(row, BLACK_TILE)
+		_fill_row(BAND_BOTTOM_ROW + row, BLACK_TILE)
+	_bgp = BGP_HIDDEN
+	_phase = Phase.LEAD
+	_left = LEAD_FRAMES
+
+
+## `.nextCreditsScreen`: the middle cleared, then strings placed until a command.
+func _next_screen() -> void:
+	_clear_middle()
+	var line: int = 0
+	while true:
+		var command: int = _next()
+		if command == Gen1Layout.CREDITS_COPYRIGHT:
+			_place_copyright()
+		elif command == Gen1Layout.CREDITS_THE_END:
+			_phase = Phase.THE_END
+			_left = THE_END_FRAMES_YELLOW if _yellow else THE_END_FRAMES
+			return
+		elif command >= Gen1Layout.CREDITS_TEXT:
+			_command = command
+			_begin_command()
+			return
+		else:
+			_place_string(command, line)
+			line += 1
+
+
+func _begin_command() -> void:
+	if _command == Gen1Layout.CREDITS_TEXT_FADE_MON \
+		or _command == Gen1Layout.CREDITS_TEXT_FADE:
+		_phase = Phase.FADE
+		_left = FADE_PALETTES.size() * FADE_STEP_FRAMES
+		return
+	_start_wait()
+
+
+func _fade_step() -> void:
+	var spent: int = FADE_PALETTES.size() * FADE_STEP_FRAMES - _left
+	@warning_ignore("integer_division")
+	_bgp = FADE_PALETTES[mini(spent / FADE_STEP_FRAMES, FADE_PALETTES.size() - 1)]
+
+
+func _after_fade() -> void:
+	if _command == Gen1Layout.CREDITS_THE_END:
+		_after_the_end_fade()
+		return
+	_start_wait()
+
+
+func _start_wait() -> void:
+	_phase = Phase.WAIT
+	_left = int(WAITS[_command]) + (WAIT_EXTRA_YELLOW if _yellow else 0)
+
+
+func _after_wait() -> void:
+	if _command == Gen1Layout.CREDITS_TEXT_FADE_MON \
+		or _command == Gen1Layout.CREDITS_TEXT_MON:
+		_phase = Phase.SLIDE_SETUP
+		_left = SLIDE_SETUP_FRAMES
+		return
+	_next_screen()
+
+
+## `DisplayCreditsMon`: the first scroll frame shows everything still in place.
+func _start_slide() -> void:
+	_mon = _mons[_mons_shown] if _mons_shown < _mons.size() else 0
+	_mons_shown += 1
+	_bgp = BGP_SILHOUETTE
+	_phase = Phase.SLIDE
+	_slide_at = 0
+	_slide_scroll = 0
+
+
+func _slide_step() -> void:
+	_slide_at += 1
+	if _slide_at >= (SLIDE_FRAMES_YELLOW if _yellow else SLIDE_FRAMES):
+		_mon = 0
+		_slide_scroll = 0
+		_bgp = BGP_HIDDEN
+		_next_screen()
+		return
+	_slide_scroll = _slide_at * SLIDE_STEP
+
+
+func _show_the_end() -> void:
+	_clear_middle()
+	_sheet = SHEET_THE_END
+	for row: int in THE_END_ROWS.size():
+		var codes: Array = THE_END_ROWS[row]
+		for column: int in codes.size():
+			_put(THE_END_AT_GEN1 + Vector2i(column, row), int(codes[column]))
+	_phase = Phase.FADE
+	_left = FADE_PALETTES.size() * FADE_STEP_FRAMES
+	_command = Gen1Layout.CREDITS_THE_END
+
+
+## `.showTheEnd`'s `FadeInCredits` runs into `ret`.
+func _after_the_end_fade() -> void:
+	_phase = Phase.DONE
+	_end_hold = END_HOLD_FRAMES
+
+
+func _next() -> int:
+	if _position >= _script.size():
+		return Gen1Layout.CREDITS_THE_END
+	var byte: int = _script[_position]
+	_position += 1
+	return byte
+
+
+func _place_string(index: int, line: int) -> void:
+	var column: int = _data.credits_string_column(index)
+	var at := Vector2i(column, TEXT_TOP_ROW + line * TEXT_LINE_SPACING)
+	for code: int in _data.credits_string(index):
+		if code == CODE_NEXT_LINE:
+			at = Vector2i(column, at.y + TEXT_LINE_SPACING)
+			continue
+		if code == CODE_POKE:
+			for glyph: int in Gen1Text.encode(POKE_TEXT):
+				_put(at, glyph)
+				at.x += 1
+			continue
+		_put(at, code)
+		at.x += 1
+
+
+func _place_copyright() -> void:
+	_sheet = SHEET_COPYRIGHT
+	var rows: Array = _data.credits_copyright_rows()
+	for row: int in rows.size():
+		var codes: PackedByteArray = rows[row]
+		for column: int in codes.size():
+			_put(COPYRIGHT_AT_GEN1 + Vector2i(column, row * TEXT_LINE_SPACING), codes[column])
+
+
+func _clear_middle() -> void:
+	for row: int in MIDDLE_ROWS:
+		_fill_row(MIDDLE_FIRST_ROW + row, BLANK_TILE)
+
+
+func _fill_row(row: int, tile: int) -> void:
+	for column: int in COLUMNS:
+		_put(Vector2i(column, row), tile)

--- a/game/world/gen1_credits.gd.uid
+++ b/game/world/gen1_credits.gd.uid
@@ -1,0 +1,1 @@
+uid://cf8rhuet61xkn

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -26,6 +26,58 @@ const MAX_NICKNAME: int = 10
 const PANEL_FRAMES_CRYSTAL: int = 60
 const PANEL_FRAMES_GOLD_SILVER: int = 180
 
+## `AnimateHallOfFame`, whose panels hold for their own `DelayFrames` and never
+## read the joypad: `ClearScreen` and `ld c, 100` of white first.
+const PAGE_BLANK: StringName = &"blank"
+const GEN1_OPEN_FRAMES: int = 100
+## `HoFShowMonOrPlayer.ScrollPic`: `hSCX` walks $c0 to $a0 by 4 under the back
+## pic, then $a0 to 0 under the front one.
+const GEN1_SLIDE_STEP: int = 4
+const GEN1_SLIDE_BACK_FRAMES: int = 56
+const GEN1_SLIDE_FRONT_FRAMES: int = 40
+const GEN1_SLIDE_FRAMES: int = GEN1_SLIDE_BACK_FRAMES + GEN1_SLIDE_FRONT_FRAMES
+## `ld c, 80` behind the info box and `ld c, 180` behind `HallOfFameText`.
+const GEN1_INFO_FRAMES: int = 80
+const GEN1_FAMED_FRAMES: int = 180
+## `GBFadeOutToWhite`: `FadePal6` on, eight frames a step.
+const GEN1_FADE_PALETTES: Array[int] = [0x90, 0x40, 0x00]
+const GEN1_FADE_STEP_FRAMES: int = 8
+## `HoFPrintTextAndDelay`'s `ld c, 120` behind each of the three boxes.
+const GEN1_TEXT_FRAMES: int = 120
+## `HOF_TEAM_CAPACITY`, and where `wNumHoFTeams` stops.
+const MAX_RECORDS_GEN1: int = 50
+const MASTER_COUNT_GEN1: int = 255
+
+
+static func is_gen1(data: GameData) -> bool:
+	return data != null and data.generation == RomRegistry.GEN1
+
+
+static func max_records(data: GameData) -> int:
+	return MAX_RECORDS_GEN1 if is_gen1(data) else MAX_RECORDS
+
+
+static func master_count(data: GameData) -> int:
+	return MASTER_COUNT_GEN1 if is_gen1(data) else MASTER_COUNT
+
+
+## White and black on Crystal; `SET_PAL_POKEMON_WHOLE_SCREEN`'s row, PAL_MEWMON
+## for the player, through the fade's `rBGP` on Generation 1.
+static func page_palette(data: GameData, page: Dictionary) -> PackedColorArray:
+	var mono: PackedColorArray = PokePalette.pic_palette(
+		PackedColorArray([Color.WHITE, Color.BLACK])
+	)
+	if not is_gen1(data):
+		return mono
+	var colors: PackedColorArray = data.palette(int(page.get("species", 0))) \
+		if StringName(page.get("kind", &"")) == PAGE_MON \
+		else data.world_palette(Gen1Layout.PAL_MEWMON)
+	if colors.size() < mono.size():
+		colors = mono
+	return Gen2WorldPalette.fade_palette(
+		colors, int(page.get("bgp", Gen2WorldPalette.FADE_IDENTITY))
+	)
+
 
 static func panel_frames(data: GameData) -> int:
 	return PANEL_FRAMES_CRYSTAL if Gen2WorldState.is_crystal_profile(data) \
@@ -33,18 +85,19 @@ static func panel_frames(data: GameData) -> int:
 
 
 ## The pages, in `HallOfFame`'s order: the record box, then every non-egg party
-## member, then the player. An empty or egg-only party still answers the player's
-## page, matching `LoadHOFTeam`'s carry falling through to `HOF_AnimatePlayerPic`.
-##
-## [param state] is what `Rate` counts; without it, or without the rating table,
-## the player's page is the bare panel the source never stops on.
+## member, then the player, whose page an empty party still answers. Without
+## [param state] or the rating table it is the bare panel.
 static func pages(
 	data: GameData, save: Gen2SaveData, state: Gen2WorldState = null
 ) -> Array:
 	var out: Array = []
 	if data == null or save == null:
 		return out
-	out.append({"kind": PAGE_SAVING, "lines": Gen2SavePrompt.SAVING_RECORD_LINES})
+	if is_gen1(data):
+		return _gen1_pages(data, save, state)
+	out.append({
+		"kind": PAGE_SAVING, "lines": Gen2SavePrompt.SAVING_RECORD_LINES, "music": true,
+	})
 	var inducted_mons: int = 0
 	for mon: Gen2SaveMon in save.party:
 		if inducted_mons >= MAX_MONS:
@@ -56,6 +109,99 @@ static func pages(
 		out.append(_mon_page(data, mon))
 		inducted_mons += 1
 	out.append_array(_player_pages(data, save, state))
+	return out
+
+
+## `AnimateHallOfFame`: white, then per member the slide, the info box with its
+## cry, the HALL OF FAME box and the fade, then the player's own.
+static func _gen1_pages(data: GameData, save: Gen2SaveData, state: Gen2WorldState) -> Array:
+	var out: Array = [{"kind": PAGE_BLANK, "hold": GEN1_OPEN_FRAMES, "music": true}]
+	var inducted_mons: int = 0
+	for mon: Gen2SaveMon in save.party:
+		if inducted_mons >= MAX_MONS:
+			break
+		if mon.is_egg:
+			continue
+		var page: Dictionary = _gen1_mon_page(data, mon)
+		out.append(_gen1_with(page, {"slide": true, "hold": GEN1_SLIDE_FRAMES, "cry": false}))
+		out.append(_gen1_with(page, {"hold": GEN1_INFO_FRAMES}))
+		out.append(_gen1_with(page, {"famed": true, "hold": GEN1_FAMED_FRAMES, "cry": false}))
+		out.append_array(_gen1_fade(_gen1_with(page, {"famed": true, "cry": false})))
+		inducted_mons += 1
+	out.append_array(_gen1_player_pages(data, save, state))
+	return out
+
+
+static func _gen1_with(page: Dictionary, extra: Dictionary) -> Dictionary:
+	var out: Dictionary = page.duplicate()
+	out.merge(extra, true)
+	return out
+
+
+static func _gen1_fade(page: Dictionary) -> Array:
+	var out: Array = []
+	for bgp: int in GEN1_FADE_PALETTES:
+		out.append(_gen1_with(page, {"bgp": bgp, "hold": GEN1_FADE_STEP_FRAMES}))
+	return out
+
+
+## `HoFDisplayMonInfo`: the nickname, the level, `PrintMonType`'s one or two.
+static func _gen1_mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
+	var entry: Dictionary = data.species(mon.species)
+	var species_name: String = String(entry.get("name", ""))
+	var types: Array = []
+	for type: Variant in entry.get("types", []) as Array:
+		var name: String = String(data.type_name(int(type)))
+		if types.is_empty() or types[0] != name:
+			types.append(name)
+	return {
+		"kind": PAGE_MON,
+		"species": mon.species,
+		"species_name": species_name,
+		"nickname": mon.nickname if not mon.nickname.is_empty() else species_name,
+		"level": mon.level,
+		"types": types,
+	}
+
+
+## `HoFDisplayPlayerStats`: the slide, the two boxes, then the three
+## `HoFPrintTextAndDelay` texts, a `cont` inside one waiting for its press.
+static func _gen1_player_pages(
+	data: GameData, save: Gen2SaveData, state: Gen2WorldState
+) -> Array:
+	var time: PokeGameTime = save.game_time if save.game_time != null else PokeGameTime.new()
+	var panel: Dictionary = {
+		"kind": PAGE_PLAYER,
+		"player_name": save.player_name,
+		"hours": time.hours,
+		"minutes": time.minutes_text(),
+		"money": state.money() if state != null else 0,
+		"cry": false,
+	}
+	var out: Array = [_gen1_with(panel, {"slide": true, "hold": GEN1_SLIDE_FRAMES})]
+	var rating: Dictionary = Gen2ProfOaksPC.rate(data, state)
+	var texts: Array = [
+		Gen2ProfOaksPC.fill_counts(
+			data.special_text("hall_of_fame", "seen_owned"),
+			int(rating.get("seen", 0)), int(rating.get("caught", 0))
+		),
+		data.special_text("hall_of_fame", "rating"),
+	]
+	if not rating.is_empty():
+		texts.append(String((rating["pages"] as Array)[1]))
+	for text: String in texts:
+		var boxes: Array = Gen2TextLayout.lay_out(
+			text, Gen2HallOfFamePage.TEXT_COLUMNS, Gen2HallOfFamePage.TEXT_ROWS,
+			RomRegistry.GEN1
+		)
+		for index: int in boxes.size():
+			out.append(_gen1_with(panel, {
+				"lines": Array(boxes[index] as PackedStringArray),
+				"hold": GEN1_TEXT_FRAMES if index == boxes.size() - 1 else 0,
+			}))
+	var fades: Array = _gen1_fade(out[out.size() - 1])
+	fades[0]["fade_music"] = true
+	out.append_array(fades)
 	return out
 
 
@@ -125,7 +271,7 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 ## eggs skipped, in front of whatever was already kept, with the thirtieth
 ## falling off the end. The win count is `wHallOfFameCount` after its own
 ## increment, which stops at `HOF_MASTER_COUNT` rather than wrapping.
-static func inducted(records: Array, save: Gen2SaveData) -> Array:
+static func inducted(records: Array, save: Gen2SaveData, data: GameData = null) -> Array:
 	if save == null:
 		return records.duplicate(true)
 	var mons: Array = []
@@ -142,8 +288,8 @@ static func inducted(records: Array, save: Gen2SaveData) -> Array:
 			"nickname": mon.nickname.substr(0, MAX_NICKNAME),
 		})
 	var out: Array = records.duplicate(true)
-	out.push_front({"win_count": mini(win_count(records) + 1, MASTER_COUNT), "mons": mons})
-	out.resize(mini(out.size(), MAX_RECORDS))
+	out.push_front({"win_count": mini(win_count(records) + 1, master_count(data)), "mons": mons})
+	out.resize(mini(out.size(), max_records(data)))
 	return out
 
 
@@ -170,6 +316,9 @@ static func record_pages(data: GameData, record: Dictionary) -> Array:
 			continue
 		var mon: Dictionary = raw
 		var species: int = int(mon.get("species", 0))
+		if is_gen1(data):
+			out.append(_gen1_record_page(data, mon, int(record.get("win_count", 0))))
+			continue
 		var species_name: String = String(data.species(species).get("name", ""))
 		var nickname: String = String(mon.get("nickname", ""))
 		var dvs: int = int(mon.get("dvs", 0))
@@ -192,13 +341,32 @@ static func record_pages(data: GameData, record: Dictionary) -> Array:
 	return out
 
 
+## `LeaguePCShowMon`: the info panel with `wHoFTeamNo`'s box.
+static func _gen1_record_page(data: GameData, mon: Dictionary, team: int) -> Dictionary:
+	var stored := Gen2SaveMon.new()
+	stored.species = int(mon.get("species", 0))
+	stored.level = int(mon.get("level", 0))
+	stored.nickname = String(mon.get("nickname", ""))
+	var page: Dictionary = _gen1_mon_page(data, stored)
+	page["team_number"] = team
+	return page
+
+
+## `_HallOfFamePC.MasterLoop` walks newest first, `PKMNLeaguePC` oldest first.
+static func record_at(data: GameData, records: Array, index: int) -> Dictionary:
+	if index < 0 or index >= records.size():
+		return {}
+	var at: int = records.size() - 1 - index if is_gen1(data) else index
+	return records[at] if records[at] is Dictionary else {}
+
+
 ## The stored shape, checked rather than trusted: a save can carry anything.
 static func parse_records(raw: Variant) -> Array:
 	var out: Array = []
 	if not raw is Array:
 		return out
 	for raw_record: Variant in raw as Array:
-		if not raw_record is Dictionary or out.size() >= MAX_RECORDS:
+		if not raw_record is Dictionary or out.size() >= MAX_RECORDS_GEN1:
 			continue
 		var record: Dictionary = raw_record
 		var mons: Array = []
@@ -216,7 +384,7 @@ static func parse_records(raw: Variant) -> Array:
 					"nickname": String(mon.get("nickname", "")).substr(0, MAX_NICKNAME),
 				})
 		out.append({
-			"win_count": clampi(int(record.get("win_count", 0)), 0, MASTER_COUNT),
+			"win_count": clampi(int(record.get("win_count", 0)), 0, MASTER_COUNT_GEN1),
 			"mons": mons,
 		})
 	return out

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -3,9 +3,10 @@ extends Control
 
 ## The screen behind `halloffame`, embedded in the overworld the way the PC and
 ## the mart overlays are: the record box, then `AnimateHallOfFame`'s walk over
-## the party and the player's own panel. The two pic slides and the palette
-## rotations are not here. An induction reads no joypad over its panels and holds
-## each for [method Gen2HallOfFame.panel_frames]; `_HallOfFamePC` walks the same
+## the party and the player's own panel. Crystal's pic slides and palette
+## rotations are not here; Generation 1's `HoFShowMonOrPlayer` slide is. An
+## induction reads no joypad over its panels and holds each for its own `hold`
+## or [method Gen2HallOfFame.panel_frames]; `_HallOfFamePC` walks the same
 ## panels over a stored record and answers A, B and START.
 
 signal closed()
@@ -16,7 +17,13 @@ signal cry_requested(species: int)
 ## `ProfOaksPCRating`'s `PlayMusic MUSIC_NONE` and `PlaySFX`.
 signal rating_reached(sfx: int)
 
+## `PlayMusic MUSIC_HALL_OF_FAME` and `HoFFadeOutScreenAndMusic`.
+signal music_requested()
+signal music_fade_requested()
+
 const BACKDROP: Color = Color.WHITE
+## `HoFShowMonOrPlayer`'s `hSCY` of $d0, which puts the back pic 48 lines down.
+const BACK_PIC_SCROLL_Y: int = 256 - 0xD0
 
 ## Whether this is `_HallOfFamePC`'s viewer rather than `AnimateHallOfFame`'s
 ## induction: only the viewer answers B and START.
@@ -31,6 +38,9 @@ var _index: int = 0
 var _page_renderer: Gen2HallOfFamePage = null
 var _background: TextureRect = null
 var _pic: TextureRect = null
+## The back pic, on screen only while it crosses, and the front pic's rest.
+var _back_pic: TextureRect = null
+var _pic_rest_x: float = 0.0
 ## How long the page on screen holds before moving on by itself, and its clock.
 var _hold_frames: int = 0
 var _hold_clock := Gen2WorldAnimation.FrameClock.new()
@@ -96,19 +106,23 @@ func advance() -> void:
 	_refresh()
 
 
+## Crystal's pics go under the page, so the box borders stay drawn over them;
+## Generation 1's page is opaque.
 func _build() -> void:
 	add_child(Gen2Screen.Field.create(BACKDROP))
-
-	## Under the page, so the box borders stay drawn over it.
-	_pic = TextureRect.new()
-	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(_pic)
-
 	_background = TextureRect.new()
 	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(_background)
+	_pic = TextureRect.new()
+	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_back_pic = TextureRect.new()
+	_back_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_back_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var layers: Array = [_background, _pic, _back_pic] if _page_renderer.gen1 \
+		else [_pic, _back_pic, _background]
+	for layer: TextureRect in layers:
+		add_child(layer)
 
 
 ## Hardware frames of whichever page is holding. Public so a test owns its own.
@@ -120,6 +134,9 @@ func advance_hold_frames(count: int) -> void:
 		if _hold_frames <= 0:
 			set_process(false)
 			advance()
+			return
+		if bool(current_page().get("slide", false)):
+			_slide_pics(_hold_for(current_page()) - _hold_frames)
 
 
 func _process(delta: float) -> void:
@@ -134,24 +151,30 @@ func _refresh() -> void:
 	if _hold_frames > 0:
 		_hold_clock.reset()
 	set_process(_hold_frames > 0)
-	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_MON:
+	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_MON \
+		and bool(page.get("cry", true)):
 		cry_requested.emit(int(page.get("species", 0)))
 	if page.has("sfx"):
 		rating_reached.emit(int(page["sfx"]))
+	if bool(page.get("music", false)):
+		music_requested.emit()
+	if bool(page.get("fade_music", false)):
+		music_fade_requested.emit()
 	var indices: PackedByteArray = _page_renderer.draw(page)
 	var image: Image = Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
-		PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])),
-		true
+		Gen2HallOfFame.page_palette(_data, page), not _page_renderer.gen1
 	)
 	Gen2PicImage.show(_background, image)
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_refresh_pic(page)
 
 
-## `.SavingRecordText`'s hundred frames, and an induction's own panel count.
-## The viewer's panels answer the joypad, so they hold for nothing.
+## A page's own `hold`, else `.SavingRecordText`'s hundred frames or an
+## induction's panel count. The viewer's panels answer the joypad instead.
 func _hold_for(page: Dictionary) -> int:
+	if page.has("hold"):
+		return 0 if viewer else int(page["hold"])
 	match StringName(page.get("kind", &"")):
 		Gen2HallOfFame.PAGE_SAVING:
 			return Gen2SavePrompt.SAVING_RECORD_FRAMES
@@ -164,50 +187,106 @@ func _refresh_pic(page: Dictionary) -> void:
 	if _pic == null:
 		return
 	_pic.texture = null
+	_pic.visible = true
+	_back_pic.texture = null
+	_back_pic.visible = false
 	if _data == null:
 		return
 	var kind: StringName = StringName(page.get("kind", &""))
 	if kind == Gen2HallOfFame.PAGE_PLAYER:
-		_show_player_pic(bool(page.get("female", false)))
-		return
-	if kind != Gen2HallOfFame.PAGE_MON:
-		return
+		_show_player_pic(page)
+	elif kind == Gen2HallOfFame.PAGE_MON:
+		_show_mon_pic(page)
+	if bool(page.get("slide", false)):
+		_slide_pics(0)
+
+
+func _show_mon_pic(page: Dictionary) -> void:
 	var species: int = int(page.get("species", 0))
 	var unown_form: int = int(page.get("unown_form", 0))
 	var pic: Dictionary = _data.unown_pic(unown_form - 1) if unown_form > 0 \
 		else _data.species_pic(species)
 	if pic.is_empty():
 		return
+	var palette: PackedColorArray = Gen2HallOfFame.page_palette(_data, page) \
+		if _page_renderer.gen1 else _data.palette(species, bool(page.get("shiny", false)))
 	var image: Image = Gen2PicImage.from_atlas(
-		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species, bool(page.get("shiny", false)))
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	## The source centres a seven-tile cell on (6,5); a pic smaller than that
 	## cell is drawn at its bottom, the way _PrepMonFrontpic places it.
 	var cell: int = Gen2HallOfFamePage.pic_size()
-	var at: Vector2i = Gen2HallOfFamePage.pic_position()
+	var at: Vector2i = _page_renderer.pic_at()
 	_pic.position = Vector2(
-		at.x + (cell - image.get_width()) / 2.0,
+		at.x + Gen2PicImage.frontpic_pad_columns(
+			image.get_width() / Gen2Font.TILE, false, _data.generation
+		) * Gen2Font.TILE,
 		at.y + cell - image.get_height()
 	)
+	_pic_rest_x = _pic.position.x
+	if _page_renderer.gen1:
+		_show_back_pic(_data.species_pic(species, true), palette)
 
 
-## `HOF_LoadTrainerFrontpic` and `PlaceGraphic` at (12,5), the intro's picture.
-func _show_player_pic(female: bool) -> void:
+## `ScaleSpriteByTwo` doubling a 32x32 back pic up to the seven-tile box.
+func _show_back_pic(pic: Dictionary, palette: PackedColorArray) -> void:
+	if pic.is_empty():
+		return
+	var side: int = Gen2HallOfFamePage.PIC_TILES
+	var image: Image = Gen2PicImage.from_indices(
+		Gen2BattleRenderer.doubled_pic(_data, pic, side),
+		side * Gen2Font.TILE, side * Gen2Font.TILE, palette
+	)
+	Gen2PicImage.show(_back_pic, image)
+	_back_pic.size = Vector2(image.get_size())
+
+
+## `HoFShowMonOrPlayer.ScrollPic`, [param frame] frames in: the back pic
+## crosses leftward, then the front pic comes in from the left.
+func _slide_pics(frame: int) -> void:
+	var at: Vector2i = _page_renderer.pic_at()
+	var step: int = Gen2HallOfFame.GEN1_SLIDE_STEP
+	var back: int = Gen2HallOfFame.GEN1_SLIDE_BACK_FRAMES
+	if frame < back:
+		_back_pic.visible = true
+		_back_pic.position = Vector2(
+			Gen2Screen.WIDTH - frame * step, (at.y + BACK_PIC_SCROLL_Y) % 256
+		)
+		_pic.visible = false
+		return
+	_back_pic.visible = false
+	_pic.visible = true
+	_pic.position.x = _pic_rest_x \
+		- (Gen2HallOfFame.GEN1_SLIDE_FRONT_FRAMES - (frame - back)) * step
+
+
+## `HOF_LoadTrainerFrontpic` and `PlaceGraphic` at (12,5), the intro's picture;
+## `HoFLoadPlayerPics`' two on Generation 1.
+func _show_player_pic(page: Dictionary) -> void:
+	var female: bool = bool(page.get("female", false))
 	var cell: Dictionary = Gen2OakSpeech.player_cell(_data, female)
+	var palette: PackedColorArray = Gen2OakSpeech.player_palette(_data, female)
+	if _page_renderer.gen1:
+		var pic: Dictionary = _data.player_frontpic(0)
+		cell = {} if pic.is_empty() else Gen2PicImage.atlas_cell(
+			_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic
+		)
+		palette = Gen2HallOfFame.page_palette(_data, page)
+		_show_back_pic(_data.player_backpic(Gen1Layout.PLAYER_BACKPICS[0]), palette)
 	if cell.is_empty():
 		return
 	var image: Image = Gen2PicImage.from_indices(
-		cell["indices"], int(cell["width"]), int(cell["height"]),
-		Gen2OakSpeech.player_palette(_data, female)
+		cell["indices"], int(cell["width"]), int(cell["height"]), palette
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	var at: Vector2i = Gen2HallOfFamePage.player_pic_position()
 	_pic.position = Vector2(
-		at.x + Gen2PicImage.frontpic_pad_columns(int(cell["width"]) / Gen2Font.TILE) \
-			* Gen2Font.TILE,
+		at.x + Gen2PicImage.frontpic_pad_columns(
+			int(cell["width"]) / Gen2Font.TILE, false, _data.generation
+		) * Gen2Font.TILE,
 		at.y + Gen2HallOfFamePage.pic_size() - image.get_height()
 	)
+	_pic_rest_x = _pic.position.x

--- a/game/world/prof_oaks_pc.gd
+++ b/game/world/prof_oaks_pc.gd
@@ -64,7 +64,11 @@ static func rating_for(data: GameData, caught: int) -> Dictionary:
 ## `PrintNumber` right-aligns them in [constant COUNT_DIGITS] cells where
 ## `PRINTNUM_LEFTALIGN` does not.
 static func counts_text(data: GameData, seen: int, caught: int) -> String:
-	var text: String = data.oak_pc_text("counts")
+	return fill_counts(data.oak_pc_text("counts"), seen, caught)
+
+
+## The same two numbers into `_DexSeenOwnedText`'s slots as well.
+static func fill_counts(text: String, seen: int, caught: int) -> String:
 	for value: int in [seen, caught]:
 		var digits: String = String.num_int64(value)
 		var number: int = text.find(Gen2TextStream.NUMBER_MARKER)

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -156,7 +156,8 @@ static func fade_palette(palette: PackedColorArray, order: int) -> PackedColorAr
 	var out := PackedColorArray()
 	out.resize(palette.size())
 	for index: int in palette.size():
-		out[index] = palette[(order >> (2 * mini(index, 3))) & 3] if index < 4 			else palette[index]
+		out[index] = palette[(order >> (2 * mini(index, 3))) & 3] if index < 4 \
+			else palette[index]
 	return out
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -102,6 +102,8 @@ const SFX_POISON: int = 0x0B
 ## constants/music_constants.asm, which AnimateHallOfFame plays over the whole
 ## induction.
 const MUSIC_HALL_OF_FAME: int = 20
+## `HoFFadeOutScreenAndMusic`'s `wAudioFadeOutCounterReloadValue`.
+const HALL_OF_FAME_MUSIC_FADE_FRAMES: int = 10
 
 ## `GetWarpSFX`: the door, the warp panel, and everything else, which is a step
 ## out of a building. Read off the tile the step landed on, the way
@@ -777,13 +779,11 @@ func _render_time_of_day() -> int:
 	return _world.map_time_of_day()
 
 
-## SCREEN FILL: the overworld has more to show than the hardware framed, so it
-## fills the window with map where every other screen fills it with its own field.
-## Every menu, box and cursor over it stays inside the 160x144 rectangle
-## [Gen2Screen] centres in the buffer. The setting itself is the screen's and is
-## taken again here rather than trusted from the frame the screen was born on: a
-## tool that stages a framed shot sets the option around building this scene, and
-## either order has to mean the same thing. The zoom is the map's alone.
+## SCREEN FILL: the overworld fills the window with map where every other
+## screen fills it with its own field; every box over it stays inside the
+## 160x144 rectangle [Gen2Screen] centres. The setting is read again here rather
+## than from the frame the screen was born on, since a tool may set it around
+## building this scene. The zoom is the map's alone.
 func _apply_screen_fill() -> void:
 	var options: Gen2Options = Gen2OptionsStore.current()
 	_screen.apply_screen_fill()
@@ -794,13 +794,10 @@ func _apply_screen_fill() -> void:
 
 
 ## A screen that hides the map takes the whole picture with it: it is laid out in
-## 160x144 and has nothing to put in a wider buffer, so the surround becomes that
-## screen's own field. The start menu is not one of these, being a box the map is
-## still visible around, and neither is a map fade. `DoBattleTransition` is: it
-## writes twenty by eighteen cells and nothing wider. The mask is drawn inside the
-## hardware viewport, so raising it would crop a renderer that already filled the
-## whole surface; such a renderer is told instead and closes its own surround,
-## which is the only way a wedge reaches the edge of a filled window.
+## 160x144, so the surround becomes that screen's own field. The start menu is
+## not one, being a box the map stays visible around; `DoBattleTransition` is.
+## The mask is drawn inside the hardware viewport, so a renderer that already
+## filled the whole surface is told instead and closes its own surround.
 func _apply_interface_mask() -> void:
 	var owned: bool = _battle_transition != null or _any_host_open(FULLSCREEN_HOSTS)
 	_screen.interface_masked = _screen.expanded and owned \
@@ -2259,13 +2256,11 @@ func _on_hatch_named(party_index: int, nickname: String) -> void:
 	_script_prompt = "%s hatched" % nickname
 
 
-## `GivePoke`'s own prompt, for the `givepoke` sites that name no OT: thirteen
-## of the fourteen, every starter among them. `GiveANickname_YesNo` stands
-## between `TryAddMonToParty` and the row being named, so the request is left
-## pending while the screen is up and the party host applies it with the answer.
-## False when the routine reaches no prompt and the request may be settled where
-## it was staged: an egg, a gift that names an OT, and the storage that has room
-## for neither, which is `.FailedToGiveMon`.
+## `GivePoke`'s own prompt, for the thirteen `givepoke` sites that name no OT.
+## `GiveANickname_YesNo` stands between `TryAddMonToParty` and the row being
+## named, so the request is left pending while the screen is up. False when the
+## routine reaches no prompt: an egg, a gift that names an OT, and
+## `.FailedToGiveMon`.
 func _open_gift_nickname(request: Dictionary) -> bool:
 	if _nickname_host != null or _world == null or _data == null:
 		return false
@@ -2436,13 +2431,10 @@ func _on_name_rater_closed() -> void:
 	_refresh_labels()
 
 
-## The Day-Care's five specials, hosted exactly as `special NameRater` is. The
-## routine writes the party, the two slots and the money itself, so nothing is
-## staged: the cartridge writes WRAM straight and the save is committed when the
-## player saves. Below, `special UnownPuzzle`, whose `FadeToMenu` and
-## `ExitAllMenus` are what the host's overlay already is; and `_Diploma`'s page,
-## or `_PrintDiploma`'s with the printer's status box over it, where the screen
-## owns both loops and this hands it only what the cache does not carry.
+## The Day-Care's five specials, hosted exactly as `special NameRater` is: the
+## routine writes the party, the two slots and the money itself, as the
+## cartridge writes WRAM straight. Below, `special UnownPuzzle` and `_Diploma`'s
+## page, or `_PrintDiploma`'s with the printer's status box over it.
 func _open_diploma(request: Dictionary) -> bool:
 	if _diploma_host != null or _world == null or _data == null:
 		return false
@@ -3966,19 +3958,16 @@ func preview_bills_pc() -> void:
 	_open_bills_pc()
 
 
-## Public screenshot drivers for the two PCs, whose cells no preview map has:
-## the Pokemon Center's machine and the bedroom's own item PC, which is the one
-## that carries DECORATION.
-## The machine's own list grows with the story, and its last row is postgame:
-## `.ChooseWhichPCListToUse` asks for the Pokedex and then the induction. Neither
-## has happened on a preview save, so this drives `halloffame`'s own two writes
-## first rather than photographing a list that is missing two of its rows.
+## Public screenshot drivers for the two PCs, whose cells no preview map has.
+## The machine's list grows with the story: `.ChooseWhichPCListToUse` asks for
+## the Pokedex and then the induction, so this drives `halloffame`'s own two
+## writes first rather than photographing a list missing two of its rows.
 func preview_pokemon_center_pc() -> void:
 	var save: Gen2SaveData = _embedded_party_save()
 	if _world != null and save != null and save.hall_of_fame.is_empty():
 		_world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
 		_world.state.set_hall_of_fame(true)
-		save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save)
+		save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save, _data)
 	## `_embedded_party_save` builds a development save when nothing is injected,
 	## so the seeded one has to be the save the host is then handed.
 	_injected_save = save
@@ -4102,11 +4091,9 @@ const SLOT_MACHINE_MENU_FRAME_CAP: int = 16
 
 
 ## Public screenshot driver and scene-test entry for `special SlotMachine`,
-## which only the two Game Corners reach and no fixture cell does.
-## [param coins] is the balance the machine opens with, [param lucky] the
-## `wScriptVar` the map's own `setval` leaves, and [param frames] how far into
-## the game to drive: the machine is pressed past its bet menu and then handed
-## A three times, which is how a spin is photographed at all.
+## which no fixture cell reaches. [param coins] is the opening balance,
+## [param lucky] the `wScriptVar` the map's `setval` leaves, and [param frames]
+## how far to drive: past the bet menu, then A three times for a spin.
 func preview_slot_machine(
 	coins: int = 100, lucky: bool = false, bet: int = 1, frames: int = 0
 ) -> void:
@@ -4151,11 +4138,9 @@ const CARD_FLIP_PROMPT_FRAME_CAP: int = 240
 
 
 ## Public screenshot driver and scene-test entry for `special CardFlip`, which
-## only the two Game Corners reach and no fixture cell does.
-## [param coins] is the balance the table opens with and [param frames] how far
-## into the game to drive: every `YesNoBox` is answered YES and every
-## `WaitPressAorB` pressed, so the table deals, toggles and pays without the
-## driver knowing which state it is in.
+## no fixture cell reaches. [param coins] is the opening balance and
+## [param frames] how far to drive: every `YesNoBox` is answered YES and every
+## `WaitPressAorB` pressed.
 func preview_card_flip(coins: int = 100, frames: int = 0) -> void:
 	if _world == null or _data == null or _card_flip_host != null:
 		return
@@ -4410,12 +4395,10 @@ func _first_stone_evolution() -> Dictionary:
 
 
 ## Public screenshot driver and scene-test entry for `EvolveAfterBattle`'s own
-## presentation: it stands the first party member on the first LEVEL evolution
-## the cache holds and opens the screen on it, which is the one path a stone
-## cannot reach, since `.pressed_b` lets B cancel this one and not that one.
-## The party row is left alone. [method _on_evolution_resolved] applies it, the
-## same way the after-battle pass does, so the preview is that pass rather than
-## a picture of it.
+## presentation: the first party member on the first LEVEL evolution the cache
+## holds, the one path a stone cannot reach since `.pressed_b` lets B cancel
+## it. [method _on_evolution_resolved] applies it the way the after-battle pass
+## does.
 func preview_level_evolution() -> void:
 	if _world == null or _data == null:
 		return
@@ -4764,10 +4747,8 @@ func preview_pack_toss() -> void:
 ## Public screenshot driver for ForgetMove. It fills the first party member's
 ## four move slots and grants a TM or HM that member can learn, on an injected
 ## save so nothing persists, then advances one menu step per call: Pack, the
-## TM/HM, USE, YES, the party member, ForgetMove's ask, and the move list.
-## The granted item is whichever TM or HM this species can actually learn, since
-## a development save's first member is whatever the cache holds; a species that
-## can learn none reports that rather than opening a menu it cannot fill.
+## TM/HM, USE, YES, the party member, ForgetMove's ask, and the move list. A
+## species that can learn none reports that rather than opening the menu.
 func preview_move_forget() -> void:
 	if _world == null or _data == null:
 		return
@@ -4859,9 +4840,8 @@ func preview_meet_visible_encounter(cell: Vector2i) -> bool:
 	return true
 
 
-## Public screenshot driver for the real wild capture bridge. It adds one
-## development Master Ball, starts an imported wild encounter, and leaves the
-## production battle overlay on its throw message.
+## Public screenshot driver for the wild capture bridge: one development Master
+## Ball, an imported wild encounter, the battle overlay on its throw message.
 ## `CatchTutorial`: the Dude's own fight, which answers itself. `Route29Tutorial1`
 ## loads the same `loadwildmon RATTATA, 5` in front of it. A Generation 1 cache
 ## throws the old man's, or Prof. Oak's for [param pikachu].
@@ -6087,7 +6067,7 @@ func open_hall_of_fame() -> void:
 	## `AddHallOfFameEntry` runs behind `SaveGameData` and in front of the
 	## animation, so the team is stored whether or not the player watches it;
 	## the snapshot itself is written when the sequence ends.
-	save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save)
+	save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save, _data)
 	## No anchor preset: this is a child of the 160x144 Gen2Screen and sizes
 	## itself in native pixels, the way the story picture does.
 	var host := Gen2HallOfFameScreen.new()
@@ -6095,13 +6075,14 @@ func open_hall_of_fame() -> void:
 	host.closed.connect(_on_hall_of_fame_closed)
 	host.cry_requested.connect(_play_species_cry)
 	host.rating_reached.connect(_on_hall_of_fame_rating)
+	host.music_requested.connect(_play_hall_of_fame_music)
+	host.music_fade_requested.connect(_fade_hall_of_fame_music)
 	_hall_of_fame_host = host
 	_screen.display(host)
 	if _hall_of_fame_host == null:
 		## set_context() with nothing to show closes on _ready(), which runs as
 		## soon as the node enters the tree.
 		return
-	_play_hall_of_fame_music()
 	_script_prompt = "Hall of Fame"
 	_refresh_labels()
 
@@ -6232,14 +6213,22 @@ func _on_hall_of_fame_closed() -> void:
 	var written: Dictionary = persist_world_snapshot()
 	_script_prompt = "Hall of Fame recorded" if bool(written.get("ok", false)) \
 		else "Hall of Fame not saved: %s" % String(written.get("reason", "unknown"))
-	_play_current_map_music()
 	if _renderer != null:
 		_renderer.refresh()
 	_refresh_labels()
 	## `AnimateHallOfFame` is followed by `farcall Credits` with the `wStatusFlags`
 	## byte pushed before the Hall of Fame bit went into it, so this pair is never
 	## skippable however many times it has been seen.
-	open_credits(false)
+	if open_credits(false):
+		return
+	_play_current_map_music()
+	_complete_hall_of_fame_request()
+
+
+func _complete_hall_of_fame_request() -> void:
+	if _world != null and StringName(_world.pending_runtime_request().get("kind", &"")) \
+		== &"hall_of_fame_requested":
+		_show_script_results(_world.complete_runtime_request({"ok": true}))
 
 
 ## `ProfOaksPCRating`'s tail: `PlayMusic MUSIC_NONE` stops the induction music
@@ -6256,15 +6245,15 @@ func _on_hall_of_fame_rating(sfx: int) -> void:
 ## passes the live one, which by Red has the Hall of Fame bit in it, while
 ## `HallOfFame` pushes the byte before setting that bit, so the induction's own
 ## credits cannot be skipped even on a second run.
-func open_credits(skippable: bool = true) -> void:
+func open_credits(skippable: bool = true) -> bool:
 	if _credits_host != null or _world == null or _data == null:
-		return
+		return false
 	var host := Gen2CreditsScreen.new()
 	if not host.set_context(_data, skippable):
 		host.free()
 		_script_prompt = "The credits are not in this cache"
 		_refresh_labels()
-		return
+		return false
 	host.closed.connect(_on_credits_closed)
 	host.music_requested.connect(_play_credits_music)
 	host.music_fade_requested.connect(_fade_credits_music)
@@ -6272,21 +6261,23 @@ func open_credits(skippable: bool = true) -> void:
 	_screen.display(host)
 	_script_prompt = "Credits"
 	_refresh_labels()
+	return true
 
 
+## Generation 1's `Credits` returns with its music still playing.
 func _on_credits_closed() -> void:
 	var host: Gen2CreditsScreen = _credits_host
 	_credits_host = null
+	var music_outlasts: bool = host != null and host.music_outlasts
 	if host != null:
 		Gen2Screen.drop(host)
-	_play_current_map_music()
+	if not music_outlasts:
+		_play_current_map_music()
 	if _renderer != null:
 		_renderer.refresh()
 	_script_prompt = ""
 	_refresh_labels()
-	if _world != null and StringName(_world.pending_runtime_request().get("kind", &"")) \
-		== &"hall_of_fame_requested":
-		_show_script_results(_world.complete_runtime_request({"ok": true}))
+	_complete_hall_of_fame_request()
 
 
 ## `.music`, whose `PlayMusic MUSIC_NONE` and `DelayFrame` in front of the real
@@ -6315,6 +6306,11 @@ func _play_hall_of_fame_music() -> void:
 	if record.is_empty():
 		return
 	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
+func _fade_hall_of_fame_music() -> void:
+	if _audio_player != null:
+		_audio_player.fade_out(HALL_OF_FAME_MUSIC_FADE_FRAMES)
 
 
 ## Public driver for screenshot tooling and scene tests, mirroring

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -3280,13 +3280,13 @@ func _on_boxes_cry(species: int) -> void:
 ## `Gen2BoxScreen.closed` carries the result its own host would have resumed a
 ## script with; nothing is waiting here, because the PC's request is still open.
 ## `_HallOfFamePC.MasterLoop`: one stored team at a time, newest first, until
-## `LoadHOFTeam` runs out of records or B leaves. The panels are the induction's
-## own, which is why this opens the same screen the sequence does.
+## `LoadHOFTeam` runs out of records or B leaves; `PKMNLeaguePC` walks them
+## oldest first. The panels are the induction's own.
 func _open_hall_of_fame(index: int) -> void:
 	var records: Array = _save.hall_of_fame if _save != null else []
 	var pages: Array = Gen2HallOfFame.record_pages(
-		_data, records[index]
-	) if index >= 0 and index < records.size() else []
+		_data, Gen2HallOfFame.record_at(_data, records, index)
+	)
 	if pages.is_empty():
 		## `.absent` and `.invalid` both answer carry, which `.MasterLoop` takes
 		## straight back to the machine's own menu.

--- a/tests/integration/test_credits.gd
+++ b/tests/integration/test_credits.gd
@@ -329,3 +329,109 @@ func test_only_the_border_rows_are_scrolled() -> void:
 		Gen2Credits.create(_gold()).scroll_rows(),
 		[Gen2Credits.BORDER_TOP_ROW, Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER]
 	)
+
+
+const PokedexFixture := preload("res://tests/unit/pokedex_fixture.gd")
+
+
+func _gen1() -> Gen1Credits:
+	return Gen1Credits.create_gen1(PokedexFixture.build_gen1())
+
+
+## `HallOfFamePC`: `ClearScreen` and `ld c, 100` of white, then the two black
+## bands and `PlayMusic MUSIC_CREDITS`, then `ld c, 128` before the first
+## screen.
+func test_generation_1_opens_white_then_raises_the_bands_with_the_music() -> void:
+	var credits: Gen1Credits = _gen1()
+	assert_eq(credits.bgp(), Gen1Credits.BGP_WHITE)
+	assert_eq(_spend(credits, Gen1Credits.OPEN_FRAMES - 1).size(), 0)
+	assert_eq(_cell(credits.bg_map(), 0, 0), Gen2Credits.BLANK_TILE, "no bands yet")
+	var events: Array = credits.advance_frame()
+	assert_eq(events.size(), 1)
+	assert_eq(int(events[0]["music"]), Gen2Credits.MUSIC_CREDITS)
+	var map: PackedInt32Array = credits.bg_map()
+	for row: int in Gen1Credits.BAND_ROWS:
+		assert_eq(_cell(map, 5, row), Gen1Credits.BLACK_TILE)
+		assert_eq(_cell(map, 5, Gen1Credits.BAND_BOTTOM_ROW + row), Gen1Credits.BLACK_TILE)
+	assert_eq(_cell(map, 5, Gen1Credits.MIDDLE_FIRST_ROW), Gen2Credits.BLANK_TILE)
+	assert_eq(credits.bgp(), Gen1Credits.BGP_HIDDEN)
+	assert_eq(credits.position(), 0, "nothing parsed until the lead is spent")
+	_spend(credits, Gen1Credits.LEAD_FRAMES)
+	assert_eq(credits.position(), 2, "the first string and its command")
+	RomCache.clear(PokedexFixture.gen1_directory())
+
+
+## `.fadeInTextAndShowMon`: `FadeInCredits` walks `HoFGBPalettes` five frames a
+## step, the wait follows, and `DisplayCreditsMon` slides the next mon across
+## with everything black, then leaves colour 2 white for the next screen.
+func test_generation_1_fades_waits_and_slides_the_mon() -> void:
+	var credits: Gen1Credits = _gen1()
+	_spend(credits, Gen1Credits.OPEN_FRAMES + Gen1Credits.LEAD_FRAMES)
+	var map: PackedInt32Array = credits.bg_map()
+	assert_eq(_cell(map, 7, Gen2Credits.TEXT_TOP_ROW), 0x92, "STAFF at its own column")
+	for step: int in Gen1Credits.FADE_PALETTES.size():
+		_spend(credits, 1)
+		assert_eq(credits.bgp(), Gen1Credits.FADE_PALETTES[step], "step %d" % step)
+		_spend(credits, Gen1Credits.FADE_STEP_FRAMES - 1)
+	_spend(credits, int(Gen1Credits.WAITS[Gen1Layout.CREDITS_TEXT_FADE_MON]))
+	assert_eq(credits.sliding_mon(), 0, "the copies to VRAM come first")
+	_spend(credits, Gen1Credits.SLIDE_SETUP_FRAMES)
+	assert_eq(credits.sliding_mon(), 1)
+	assert_eq(credits.bgp(), Gen1Credits.BGP_SILHOUETTE)
+	assert_eq(credits.slide_scroll(), 0, "the first scroll frame shows SCX 0")
+	_spend(credits, 1)
+	assert_eq(credits.slide_scroll(), Gen1Credits.SLIDE_STEP)
+	_spend(credits, Gen1Credits.SLIDE_FRAMES - 2)
+	assert_eq(credits.slide_scroll(), (Gen1Credits.SLIDE_FRAMES - 1) * Gen1Credits.SLIDE_STEP)
+	_spend(credits, 1)
+	assert_eq(credits.sliding_mon(), 0)
+	assert_eq(credits.bgp(), Gen1Credits.BGP_HIDDEN)
+	assert_eq(_cell(credits.bg_map(), 7, Gen2Credits.TEXT_TOP_ROW), 0x8D, "NAME is up")
+	RomCache.clear(PokedexFixture.gen1_directory())
+
+
+## `CRED_COPYRIGHT` loads its tiles at $60 and prints the three rows at
+## `hlcoord 2, 7` on the same screen; `CRED_THE_END` clears the middle, swaps
+## the sheet, fades in and returns, which is the credits' end. The script's own
+## delay then holds The End until A or B.
+func test_generation_1_copyright_then_the_end_holds_for_a_press() -> void:
+	var credits: Gen1Credits = _gen1()
+	var frames: int = 0
+	while not credits.finished() and frames < 5000:
+		credits.advance_frame()
+		frames += 1
+		if credits.sheet() == Gen1Credits.SHEET_COPYRIGHT and credits.bgp() == Gen1Credits.BGP_HIDDEN \
+			and credits.sliding_mon() == 0:
+			break
+	assert_eq(_cell(credits.bg_map(), 2, 7), 0x60)
+	assert_eq(_cell(credits.bg_map(), 2, 11), 0x63, "a next drops two rows")
+	while not credits.finished() and frames < 5000:
+		credits.advance_frame()
+		frames += 1
+	assert_true(credits.finished())
+	assert_eq(credits.sheet(), Gen1Credits.SHEET_THE_END)
+	assert_eq(_cell(credits.bg_map(), Gen1Credits.THE_END_AT_GEN1.x, Gen1Credits.THE_END_AT_GEN1.y), 0x60)
+	assert_eq(credits.bgp(), Gen1Credits.FADE_PALETTES[Gen1Credits.FADE_PALETTES.size() - 1])
+	assert_false(credits.may_finish([PokeButton.A]), "the delay reads no joypad")
+	_spend(credits, Gen1Credits.END_HOLD_FRAMES)
+	assert_false(credits.may_finish([]))
+	assert_true(credits.may_finish([PokeButton.A]))
+	assert_true(credits.music_outlasts(), "nothing before jp Init stops it")
+	RomCache.clear(PokedexFixture.gen1_directory())
+
+
+## `ShiftFontColorIndex` zeroes the low plane, so the page's ink is colour 2,
+## the black tile stays colour 3 and the sheet at $60 is drawn as it is.
+func test_generation_1_page_composes_ink_on_colour_two() -> void:
+	var data: GameData = PokedexFixture.build_gen1()
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(data)
+	assert_true(page.ready())
+	var credits: Gen1Credits = Gen1Credits.create_gen1(data)
+	_spend(credits, Gen1Credits.OPEN_FRAMES + Gen1Credits.LEAD_FRAMES)
+	var indices: PackedByteArray = page.compose_gen1(credits.bg_map(), Gen1Credits.SHEET_NONE)
+	var width: int = Gen2Screen.WIDTH
+	assert_eq(indices[0], PokeTiles.INK, "the band")
+	assert_eq(indices[Gen2Credits.TEXT_TOP_ROW * Gen2Font.TILE * width + 7 * Gen2Font.TILE], 2, "the font, shifted")
+	var image: Image = page.image(data, credits.frame_state())
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+	RomCache.clear(PokedexFixture.gen1_directory())

--- a/tests/integration/test_world_credits_screen.gd
+++ b/tests/integration/test_world_credits_screen.gd
@@ -183,3 +183,24 @@ func test_the_hall_of_fame_runs_into_unskippable_credits() -> void:
 	await get_tree().process_frame
 	assert_not_null(_host())
 	assert_false(_host().credits().skippable())
+
+
+## A cache with no credits still ends the induction cleanly: nothing opens
+## behind it and the screen is back on the map.
+func test_the_hall_of_fame_ends_on_the_map_when_the_cache_has_no_credits() -> void:
+	var directory: String = Fixture.directory()
+	var manifest: Dictionary = RomCache.read_json(RomCache.manifest_path(directory))
+	manifest.erase("credits")
+	RomCache.write_json(RomCache.manifest_path(directory), manifest)
+	_data = GameData.open_directory(directory)
+	assert_true(_data.credits_script().is_empty())
+	await _open_world()
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	while _world_screen._hall_of_fame_host != null:
+		var host: Gen2HallOfFameScreen = _world_screen._hall_of_fame_host
+		if host.handle_button(PokeButton.A):
+			host.advance_hold_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)
+	await get_tree().process_frame
+	assert_null(_host())
+	assert_eq(_world_screen._script_prompt, "The credits are not in this cache")

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -143,8 +143,32 @@ static func gen1_directory() -> String:
 	return RomCache.directory_for(GEN1_GAME_ID, SHA1)
 
 
+## `CreditsOrder` as a fixture: one string and a mon, one string faded, the
+## same string with a mon, the copyright with a mon, and The End.
+const GEN1_CREDITS: Dictionary = {
+	"script": [0, 0xFF, 1, 0xFD, 1, 0xFE, 0xFB, 0xFF, 0xFA],
+	"strings": [[0x92, 0x93, 0x80, 0x85, 0x85], [0x8D, 0x80, 0x8C, 0x84]],
+	"columns": [7, 7],
+	"mons": [1, 2, 3],
+	"copyright_rows": [[0x60, 0x61], [0x62], [0x63]],
+}
+const GEN1_DEX_RATINGS: Dictionary = {
+	"counts": "POKéDEX comp-\nletion is:\n<NUM_CC5B> POKéMON seen\n<NUM_CC5C> POKéMON owned",
+	"ratings": [{
+		"threshold": 10,
+		"text": "You still have\nlots to do." + Gen2TextStream.SCROLL_BREAK
+			+ "Look for POKéMON\nin grassy areas!",
+	}],
+}
+const GEN1_HALL_OF_FAME_TEXT: Dictionary = {
+	"seen_owned": "POKéDEX   Seen:<NUM_CC5B>\n         Owned:<NUM_CC5C>",
+	"rating": "POKéDEX Rating<COLON>",
+}
+
+
 ## The same cache shaped the way `Gen1Importer` writes one: 151 species, no order
-## tables, and the four sheets `LoadPokedexTilePatterns` assembles its page from.
+## tables, the four sheets `LoadPokedexTilePatterns` assembles its page from, and
+## what the Hall of Fame and the credits read.
 static func build_gen1() -> GameData:
 	var path: String = gen1_directory()
 	RomCache.clear(path)
@@ -161,6 +185,9 @@ static func build_gen1() -> GameData:
 		"complete": true,
 		"generation": RomRegistry.GEN1,
 		"tiles": _gen1_tiles(path),
+		"credits": GEN1_CREDITS,
+		"oak_ratings": GEN1_DEX_RATINGS,
+		"special_text": {"hall_of_fame": GEN1_HALL_OF_FAME_TEXT},
 	})
 	return GameData.open_directory(path)
 
@@ -195,6 +222,11 @@ static func _gen1_tiles(path: String) -> Dictionary:
 		],
 		["battle_balls", Gen1Layout.BALL_TILES, 1, 0],
 		["pokedex_tiles", Gen1Layout.POKEDEX_TILES, 2, Gen1Layout.POKEDEX_FIRST_CODE],
+		["copyright", 4, 2, Gen1Layout.CREDITS_TILES_FIRST_CODE],
+		[
+			"credits_the_end", Gen1Layout.CREDITS_THE_END_TILES, 3,
+			Gen1Layout.CREDITS_TILES_FIRST_CODE,
+		],
 	]:
 		var name: String = String(entry[0])
 		var count: int = int(entry[1])

--- a/tests/unit/test_gen1_text.gd
+++ b/tests/unit/test_gen1_text.gd
@@ -98,11 +98,13 @@ func test_the_text_box_sheet_is_characters_as_well_as_a_border() -> void:
 	assert_eq(Gen1Text.encode("\u2026"), _bytes([Gen1Text.ELLIPSIS_CODE]))
 
 
-## A name too long to be one tile stays decode-only, the way `<PLAYER>` does:
-## [method encode] matches two characters at a time.
-func test_an_unused_bold_letter_does_not_encode() -> void:
+## A bracketed name in the $60 run writes its tile back, so `_DexRatingText`'s
+## `<COLON>` prints as one; a control code like `<PLAYER>` stays decode-only.
+func test_a_font_extra_name_encodes_to_its_tile() -> void:
 	assert_eq(Gen1Text.character(0x60), "<BOLD_A>")
-	assert_eq(Gen1Text.encode("<BOLD_A>").size(), 8, "eight characters, not one tile")
+	assert_eq(Gen1Text.encode("<BOLD_A>"), _bytes([0x60]))
+	assert_eq(Gen1Text.encode("Rating<COLON>").size(), 7, "one tile, not seven unknowns")
+	assert_eq(Gen1Text.encode("<PLAYER>").size(), 8, "eight unknowns")
 
 
 ## `PlacePKMN`'s text is `db "<PK><MN>@"`: two narrow tiles, never six letters.

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -248,3 +248,87 @@ func test_the_dex_row_draws_two_label_tiles_and_leaves_column_six_blank() -> voi
 func _index_at(indices: PackedByteArray, tile: Vector2i) -> int:
 	var at: int = tile.y * TILE * Gen2Screen.WIDTH + tile.x * TILE
 	return indices[at] if at < indices.size() else -1
+
+
+const PokedexFixture := preload("res://tests/unit/pokedex_fixture.gd")
+
+## `AnimateHallOfFame`'s own pages on a Generation 1 cache: `ld c, 100` of
+## white, then per member the slide, the info box with its cry, HallOfFameText's
+## box and `GBFadeOutToWhite`'s three palettes, then the player's slide and the
+## three `HoFPrintTextAndDelay` boxes, a `cont` inside the rating waiting for
+## its press.
+func test_generation_1_pages_follow_animate_hall_of_fame() -> void:
+	var data: GameData = PokedexFixture.build_gen1()
+	var pages: Array = Gen2HallOfFame.pages(data, _save([1, 4]))
+	assert_eq(pages.size(), 1 + 2 * 6 + 1 + 2 + 3 + 3)
+	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_BLANK)
+	assert_eq(int(pages[0]["hold"]), Gen2HallOfFame.GEN1_OPEN_FRAMES)
+	assert_true(bool(pages[0]["music"]), "PlayMusic MUSIC_HALL_OF_FAME after the white")
+	assert_true(bool(pages[1]["slide"]))
+	assert_eq(int(pages[1]["hold"]), Gen2HallOfFame.GEN1_SLIDE_FRAMES)
+	assert_false(bool(pages[1]["cry"]), "the slide is silent")
+	assert_eq(int(pages[2]["hold"]), Gen2HallOfFame.GEN1_INFO_FRAMES)
+	assert_true(bool(pages[2].get("cry", true)), "HoFDisplayMonInfo ends on PlayCry")
+	assert_eq(pages[2]["types"], [String(data.type_name(1)), String(data.type_name(2))] \
+		if data.type_name(1) != data.type_name(2) else [String(data.type_name(1))])
+	assert_true(bool(pages[3]["famed"]))
+	assert_eq(int(pages[3]["hold"]), Gen2HallOfFame.GEN1_FAMED_FRAMES)
+	for step: int in 3:
+		assert_eq(int(pages[4 + step]["bgp"]), Gen2HallOfFame.GEN1_FADE_PALETTES[step])
+		assert_eq(int(pages[4 + step]["hold"]), Gen2HallOfFame.GEN1_FADE_STEP_FRAMES)
+	var player: int = 1 + 2 * 6
+	assert_eq(StringName(pages[player]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_true(bool(pages[player]["slide"]))
+	assert_eq(pages[player + 1]["lines"], ["POKéDEX   Seen:  0", "         Owned:  0"])
+	assert_eq(int(pages[player + 1]["hold"]), Gen2HallOfFame.GEN1_TEXT_FRAMES)
+	assert_eq(pages[player + 2]["lines"], ["POKéDEX Rating<COLON>"], "one tile, one line")
+	assert_eq(int(pages[player + 3]["hold"]), 0, "cont waits for the press")
+	assert_eq(int(pages[player + 4]["hold"]), 0, "and the carried line's page does too")
+	assert_eq(int(pages[player + 5]["hold"]), Gen2HallOfFame.GEN1_TEXT_FRAMES)
+	assert_true(bool(pages[player + 6]["fade_music"]), "HoFFadeOutScreenAndMusic")
+	RomCache.clear(PokedexFixture.gen1_directory())
+
+
+## `sHallOfFame` keeps fifty teams and `wNumHoFTeams` stops at 255, and
+## `PKMNLeaguePC` walks them oldest first with `wHoFTeamNo` on each panel.
+func test_generation_1_records_keep_fifty_and_walk_oldest_first() -> void:
+	var data: GameData = PokedexFixture.build_gen1()
+	var records: Array = []
+	for _win: int in Gen2HallOfFame.MAX_RECORDS_GEN1 + 1:
+		records = Gen2HallOfFame.inducted(records, _save([1]), data)
+	assert_eq(records.size(), Gen2HallOfFame.MAX_RECORDS_GEN1)
+	assert_eq(Gen2HallOfFame.win_count(records), Gen2HallOfFame.MAX_RECORDS_GEN1 + 1)
+	assert_eq(int(Gen2HallOfFame.record_at(data, records, 0)["win_count"]), 2, "the oldest kept")
+	assert_eq(int(Gen2HallOfFame.record_at(_data, records, 0)["win_count"]), 51, "Crystal's newest")
+	var page: Dictionary = Gen2HallOfFame.record_pages(
+		data, Gen2HallOfFame.record_at(data, records, 0)
+	)[0]
+	assert_eq(int(page["team_number"]), 2)
+	var indices: PackedByteArray = Gen2HallOfFamePage.from_data(data).draw(page)
+	assert_true(_has_ink(indices, Gen2HallOfFamePage.GEN1_TEAM_BOX))
+	assert_true(_has_ink(indices, Gen2HallOfFamePage.GEN1_INFO_BOX))
+	RomCache.clear(PokedexFixture.gen1_directory())
+
+
+## The Generation 1 panels: the slide draws nothing, the info box stands alone
+## until HallOfFameText's box joins it, and the player's panel is its two boxes
+## with `PrintText`'s under them.
+func test_generation_1_panels_draw_their_own_boxes() -> void:
+	var data: GameData = PokedexFixture.build_gen1()
+	var renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(data)
+	var pages: Array = Gen2HallOfFame.pages(data, _save([1]))
+	assert_eq(renderer.draw(pages[1]).count(0), Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	var info: PackedByteArray = renderer.draw(pages[2])
+	assert_true(_has_ink(info, Gen2HallOfFamePage.GEN1_INFO_BOX))
+	assert_false(_has_ink(info, Gen2HallOfFamePage.GEN1_FAMED_BOX))
+	assert_true(_has_ink(renderer.draw(pages[3]), Gen2HallOfFamePage.GEN1_FAMED_BOX))
+	var player: PackedByteArray = renderer.draw(pages[9])
+	assert_true(_has_ink(player, Gen2HallOfFamePage.GEN1_NAME_BOX))
+	assert_true(_has_ink(player, Gen2HallOfFamePage.GEN1_STATS_BOX))
+	assert_true(_has_ink(player, Gen2HallOfFamePage.MON_BOTTOM_BOX))
+	assert_eq(renderer.pic_at(), Gen2HallOfFamePage.player_pic_position(), "hlcoord 12, 5")
+	## `SET_PAL_POKEMON_WHOLE_SCREEN`, then `FadePal6`: colour 3 falls to the
+	## row's colour 2 on the first step.
+	var colors: PackedColorArray = Gen2HallOfFame.page_palette(data, pages[4])
+	assert_eq(colors[3], data.palette(1)[2])
+	RomCache.clear(PokedexFixture.gen1_directory())

--- a/tools/checks/credits.gd
+++ b/tools/checks/credits.gd
@@ -2,12 +2,11 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the credits against freshly imported real caches, for both command
-## profiles. The whole script is run to `CREDITS_END` rather than sampled: every
-## command it carries, every string it names and every scene it selects is exercised
-## once, which is the sweep tests/integration/test_credits.gd's four-string fixture
-## cannot be. Expected values come from pokecrystal and pokegold's
-## engine/movie/credits.asm and the two data files behind it.
+## Verifies the credits against freshly imported real caches, both command
+## profiles and the three Generation 1 cartridges. The whole script is run to its
+## end rather than sampled, which the fixtures of
+## tests/integration/test_credits.gd cannot be. Expected values come from each
+## pinned engine/movie/credits.asm and the data files behind it.
 
 
 ## Long enough for either script, whose own totals are pinned below.
@@ -30,6 +29,16 @@ const SPACE_CODE: int = 0x7F
 const FIRST_LETTER: int = 0x80
 
 
+## Generation 1's `HallOfFamePC` credits: [frames to the return, mons slid].
+## Red's order is 7 `_FADE_MON`, 8 `_MON`, 15 `_FADE` and 5 `_TEXT` behind 228
+## frames of white and lead; Yellow's 11, 5, 12 and 4 with longer waits.
+const EXPECTED_GEN1: Dictionary = {
+	&"red": [5254, 15],
+	&"blue": [5254, 15],
+	&"yellow": [5248, 16],
+}
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in _r.GAME_IDS:
@@ -40,6 +49,92 @@ func run(r: RefCounted) -> void:
 		_verify_strings(game_id, data)
 		_verify_palettes_and_frames(game_id, data)
 		_run(game_id, data)
+	_r.each_game_of(RomRegistry.GEN1, _run_gen1)
+
+
+## A Generation 1 order frame by frame: every string fits from its own column,
+## every `_MON` finds a species, and The End is up when `Credits` returns.
+func _run_gen1() -> void:
+	var data: GameData = _r.data
+	var game_id: StringName = _r.game_id
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(data)
+	if page == null or not page.ready():
+		_r.fail("%s: the cache carries no credits graphics." % game_id)
+		return
+	var credits: Gen1Credits = Gen1Credits.create_gen1(data)
+	if credits == null:
+		_r.fail("%s: the cache carries no credits script." % game_id)
+		return
+	var count: int = Gen1Layout.credits_string_count(game_id)
+	for index: int in count:
+		var column: int = data.credits_string_column(index)
+		var tiles: int = 0
+		for code: int in data.credits_string(index):
+			if code == Gen2Credits.CODE_NEXT_LINE:
+				tiles = 0
+				continue
+			tiles += Gen2Credits.POKE_TEXT.length() if code == Gen2Credits.CODE_POKE else 1
+			_r.check(
+				column >= 0 and column + tiles <= Gen2Credits.COLUMNS,
+				"%s: credits string %d runs off the screen from column %d." % [
+					game_id, index, column,
+				]
+			)
+	_r.check(
+		data.credits_string(count).is_empty(),
+		"%s: the credits table holds more than %d strings." % [game_id, count]
+	)
+	var mons: int = 0
+	var frames: int = 0
+	var last_mon: int = 0
+	while frames < FRAME_CAP and not credits.finished():
+		credits.advance_frame()
+		frames += 1
+		var mon: int = credits.sliding_mon()
+		if mon != last_mon:
+			last_mon = mon
+			if mon > 0:
+				mons += 1
+				_r.check(
+					not data.species_pic(mon).is_empty(),
+					"%s: credits mon %d has no front pic." % [game_id, mon]
+				)
+		if credits.sliding_mon() == 0 and credits.slide_scroll() == 0 \
+			and credits.bgp() == Gen1Credits.BGP_HIDDEN:
+			_verify_gen1_bands(game_id, credits.bg_map())
+	var expected: Array = EXPECTED_GEN1[game_id]
+	_r.check(
+		frames == int(expected[0]),
+		"%s: the credits ran %d frames, not the pinned %d." % [game_id, frames, int(expected[0])]
+	)
+	_r.check(
+		mons == int(expected[1]),
+		"%s: %d mons slid across, not the pinned %d." % [game_id, mons, int(expected[1])]
+	)
+	var the_end: Vector2i = Gen1Credits.THE_END_AT_GEN1
+	_r.check(
+		credits.bg_map()[the_end.y * Gen2Credits.COLUMNS + the_end.x] \
+			== Gen1Layout.CREDITS_TILES_FIRST_CODE
+			and credits.sheet() == Gen1Credits.SHEET_THE_END,
+		"%s: The End is not on screen when Credits returns." % game_id
+	)
+	var image: Image = page.image(data, credits.frame_state())
+	_r.check(
+		image.get_width() == Gen2Screen.WIDTH and image.get_height() == Gen2Screen.HEIGHT,
+		"%s: the credits page did not draw a hardware screen." % game_id
+	)
+
+
+## `FillFourRowsWithBlack`'s two bands, which no string may reach.
+func _verify_gen1_bands(game_id: StringName, map: PackedInt32Array) -> void:
+	for column: int in Gen2Credits.COLUMNS:
+		for row: int in Gen1Credits.BAND_ROWS:
+			_r.check(
+				map[row * Gen2Credits.COLUMNS + column] == Gen1Credits.BLACK_TILE
+					and map[(Gen1Credits.BAND_BOTTOM_ROW + row) * Gen2Credits.COLUMNS + column] \
+						== Gen1Credits.BLACK_TILE,
+				"%s: the credits text reached a black band." % game_id
+			)
 
 
 ## Every string in the table, whose codes have to be ones the screen can draw:

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -68,6 +68,14 @@ const INTRO_SPECIES: Dictionary = {
 	&"red": [33, 30], &"blue": [33, 30], &"yellow": [25, 25],
 }
 const NEW_GAME_WARP: Dictionary = {"map": 38, "x": 3, "y": 6, "tileset": 4}
+## `_DexSeenOwnedText` with 12 and 3 in its slots, `_DexRatingText` whose
+## `<COLON>` is one tile, and `AnimateHallOfFame`'s six pages per member.
+const HOF_SEEN_OWNED: String = "POKéDEX   Seen: 12\n         Owned:  3"
+const HOF_RATING: String = "POKéDEX Rating<COLON>"
+const HOF_RATING_TILES: int = 15
+const HOF_PAGES_PER_MON: int = 6
+const HOF_FADE_PAGES: int = 3
+const HOF_TEAM_CAPACITY: int = 50
 
 ## `data/moves/moves.asm`, first and last: effect, power, type, accuracy, pp.
 const PINNED_MOVES: Dictionary = {
@@ -178,6 +186,7 @@ func _one_game() -> void:
 	_trainers()
 	_trades()
 	_intro()
+	_hall_of_fame()
 
 
 func _intro() -> void:
@@ -208,6 +217,37 @@ func _intro() -> void:
 			Gen2OakSpeech.intro_species(data), Gen2OakSpeech.intro_cry(data)
 		])
 	_new_game_warp()
+
+
+## `HoFDisplayPlayerStats`' two stubs and the pages over the development save.
+func _hall_of_fame() -> void:
+	var data: GameData = _r.data
+	var seen_owned: String = Gen2ProfOaksPC.fill_counts(
+		data.special_text("hall_of_fame", "seen_owned"), 12, 3
+	)
+	_r.check(seen_owned == HOF_SEEN_OWNED, "DexSeenOwnedText fills to %s." % [seen_owned])
+	var rating: String = data.special_text("hall_of_fame", "rating")
+	_r.check(rating == HOF_RATING and Gen1Text.encode(rating).size() == HOF_RATING_TILES,
+		"DexRatingText reads %s in %d tiles." % [rating, Gen1Text.encode(rating).size()])
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	var pages: Array = Gen2HallOfFame.pages(data, save, null)
+	var mons: int = 0
+	var text_pages: int = 0
+	for page: Dictionary in pages:
+		if bool(page.get("slide", false)) and StringName(page["kind"]) == Gen2HallOfFame.PAGE_MON:
+			mons += 1
+		if page.has("lines") and not page.has("bgp"):
+			text_pages += 1
+	_r.check(mons == save.party.size(), "%d of %d party members slide in." % [mons, save.party.size()])
+	_r.check(
+		pages.size() == 1 + mons * HOF_PAGES_PER_MON + 1 + text_pages + HOF_FADE_PAGES,
+		"the induction is %d pages for %d members and %d boxes." % [pages.size(), mons, text_pages]
+	)
+	_r.check(bool(pages[0].get("music", false))
+		and bool(pages[pages.size() - HOF_FADE_PAGES].get("fade_music", false)),
+		"the music starts on the first page and fades with the last panel.")
+	_r.check(Gen2HallOfFame.max_records(data) == HOF_TEAM_CAPACITY,
+		"sHallOfFame keeps %d teams." % Gen2HallOfFame.max_records(data))
 
 
 func _intro_keyboards() -> void:

--- a/tools/preview_credits.gd
+++ b/tools/preview_credits.gd
@@ -46,7 +46,8 @@ func _initialize() -> void:
 		return
 
 	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(data)
-	var credits: Gen2Credits = Gen2Credits.create(data, true)
+	var credits: Gen2Credits = Gen1Credits.create_gen1(data) \
+		if data.generation == RomRegistry.GEN1 else Gen2Credits.create(data, true)
 	if page == null or not page.ready() or credits == null:
 		push_error("The %s cache holds no credits." % args[0])
 		quit(1)
@@ -63,11 +64,21 @@ func _initialize() -> void:
 			path = "%s-%d.%s" % [args[1].get_basename(), wanted, args[1].get_extension()]
 		if not _write(page.image(data, credits.frame_state()), path):
 			return
-		print("frame %d, scene %d, block %d, scroll %d, pos %d, timer %d%s" % [
-			wanted, credits.scene(), credits.banner_block(), credits.scroll(),
-			credits.position(), credits.timer(), ", finished" if credits.finished() else "",
-		])
+		print(_describe(credits, wanted))
 	quit(0)
+
+
+func _describe(credits: Gen2Credits, wanted: int) -> String:
+	var finished: String = ", finished" if credits.finished() else ""
+	if credits is Gen1Credits:
+		var gen1: Gen1Credits = credits
+		return "frame %d, pos %d, bgp $%02X, mon %d, scroll %d%s" % [
+			wanted, gen1.position(), gen1.bgp(), gen1.sliding_mon(), gen1.slide_scroll(), finished,
+		]
+	return "frame %d, scene %d, block %d, scroll %d, pos %d, timer %d%s" % [
+		wanted, credits.scene(), credits.banner_block(), credits.scroll(),
+		credits.position(), credits.timer(), finished,
+	]
 
 
 ## The live path: a real world screen at the new game's own spawn, with

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -5,7 +5,8 @@ extends SceneTree
 ## real font and the real text-box frame.
 ##   Godot --path . -s res://tools/preview_hall_of_fame.gd -- crystal /tmp/hof.png [page]
 ## A fourth argument of `shiny` makes the lead shiny. [page] is how many times to
-## advance, so 0 is the first party member and the last pages are the player's own.
+## advance, so 0 is the first party member and the last pages are the player's own;
+## `page,frames` also spends that many hardware frames on the page.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out and the overlay to draw once.
@@ -14,6 +15,7 @@ const SETTLE_FRAMES: int = 18
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
 var _advance: int = 0
+var _spend: int = 0
 var _shiny: bool = false
 var _frames: int = 0
 
@@ -28,7 +30,9 @@ func _initialize() -> void:
 	if PokeToolPath.refuses(_output_path):
 		quit(2)
 		return
-	_advance = int(args[2]) if args.size() > 2 else 0
+	var page: PackedStringArray = (args[2] if args.size() > 2 else "0").split(",")
+	_advance = int(page[0])
+	_spend = int(page[1]) if page.size() > 1 else 0
 	_shiny = args.size() > 3 and args[3] == "shiny"
 
 	var data: GameData = GameData.open(StringName(args[0]))
@@ -71,6 +75,10 @@ func _process(_delta: float) -> bool:
 		for _step: int in _advance:
 			if _screen._hall_of_fame_host != null:
 				_screen._hall_of_fame_host.advance()
+		if _screen._hall_of_fame_host != null:
+			_screen._hall_of_fame_host.advance_hold_frames(_spend)
+			## The frames the capture settles over must not spend the page.
+			_screen._hall_of_fame_host.set_process(false)
 	if _frames < SETTLE_FRAMES:
 		return false
 	var image: Image = PokeToolPath.capture(root)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -190,13 +190,11 @@ const DRAGON_SHRINE_ANSWERS: Array[int] = [0, 0, 1, 0, 1]
 const OBJECT_STEP_FRAME_BUDGET: int = 64
 
 ## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
-## order. The cave is six floor-crossings, not one: stepping on a warp takes it, so a
-## floor is only crossed between warps its own walk connects, and on Ice Path those
-## regions are disjoint. 1F's Route 44 door reaches the first staircase and nothing
-## else, while the Blackthorn door is reached only from the second staircase, at the
-## far end of the loop through B1F, both B2Fs and B3F. The `stonetable` boulders on
-## B1F are not on this path: their holes are shortcuts into B2F Mahogany side, which
-## the walk already reaches through warp 2.
+## order: six floor-crossings, since stepping on a warp takes it and a floor is
+## crossed only between warps its own walk connects. 1F's Route 44 door reaches
+## the first staircase alone; the Blackthorn door is reached from the second, at
+## the far end of the loop through B1F, both B2Fs and B3F. B1F's `stonetable`
+## boulders are shortcuts into B2F's Mahogany side, which warp 2 already reaches.
 const ICE_PATH_DOORS: Array = [
 	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7), "hm07": true},
 	{"step": "ice_path_1f_to_b1f", "cell": Vector2i(37, 5)},
@@ -246,14 +244,12 @@ const VICTORY_ROAD_LADDERS: Array = [
 	{"step": "victory_road_second_ladder", "cell": Vector2i(13, 31)},
 ]
 
-## The Elite Four, in the order their doors join them. Every map is in the INDIGO
-## group (16); the Pokemon Center's warp 4 at (14,3) is the only way in and each
-## room's exit pair leads to the next. The four rooms share one shape:
-## `<Room>DoorLocksBehindYouScript` walks the player four cells north of the
-## arrival warp and walls the entrance, the boss stands on (5,7) and is faced from
-## (5,8), and beating them opens the exit block over (4,2)/(5,2). Lance's room is
-## taller and is not talked to at all: its coord events on (4,5) and (5,5) run the
-## approach and the champion scene.
+## The Elite Four, in the order their doors join them, all in the INDIGO group
+## (16) behind the Pokemon Center's warp 4 at (14,3). The four rooms share one
+## shape: `<Room>DoorLocksBehindYouScript` walks the player four cells north and
+## walls the entrance, the boss on (5,7) is faced from (5,8), and beating them
+## opens the exit block over (4,2)/(5,2). Lance's taller room is not talked to:
+## its coord events on (4,5) and (5,5) run the approach and the champion scene.
 const ELITE_FOUR_ROOM_ARRIVAL: Vector2i = Vector2i(5, 17)
 const ELITE_FOUR_ROOM_BOSS_FACE: Vector2i = Vector2i(5, 8)
 const ELITE_FOUR_ROOM_EXIT: Vector2i = Vector2i(5, 2)
@@ -2362,14 +2358,12 @@ func _burned_tower_leg(
 		if not bool(eusine_basement.get("ok", false)):
 			return _leg_failed(path, "basement Eusine failed", eusine_basement)
 
-	# (7,15) is the only cell on either profile's basement that `try_warp()` will
-	# fire on, since `CheckWarpCollision` gates a warp on its own tile code and
-	# every other warp_event down here sits on plain floor or on a ledge. Crystal
-	# reaches it because `BurnedTowerB1FLadderCallback` changeblocks the ladder in
-	# at walk-cell (6,14), the block holding (7,15), once the beasts are out. Gold
-	# and Silver ship no such callback and no hole under the player: the way out
-	# of the beasts' region is the ledge run south from (10,8), which the walk's
-	# own hop handling takes on its way to the same ladder.
+	# (7,15) is the only basement cell `try_warp()` fires on, since
+	# `CheckWarpCollision` gates a warp on its tile code and every other warp_event
+	# here sits on floor or a ledge. Crystal's `BurnedTowerB1FLadderCallback`
+	# changeblocks the ladder in at walk-cell (6,14) once the beasts are out; Gold
+	# and Silver ship no callback, and the way out of the beasts' region is the
+	# ledge run south from (10,8) to the same ladder.
 	var out_of_basement: Dictionary = _warp_walk(world, Vector2i(7, 15), save, random, data)
 	if not bool(out_of_basement.get("ok", false)):
 		return _leg_failed(path, "Burned Tower ladder unreachable", out_of_basement)
@@ -3369,14 +3363,12 @@ func _radio_tower_boss(
 	return {"ok": true}
 
 
-## Goldenrod City to the warehouse director's CARD_KEY, and back. Three maps, each
-## cut into regions the others join: the underground's north half ends at the
-## basement door the BASEMENT_KEY unlocks, which warps to the south half, and that
-## half reaches the switch room's top corridor. The puzzle is
-## `..._UpdateDoors`: each switch adds to `wUndergroundSwitchPositions` and opens
-## some doors and closes others, leaving the rest alone, so states accumulate and
-## 3, then 2, then 1 is the one chain to the warehouse. Coming back needs the
-## emergency switch, since the warehouse's own callback clears every door event.
+## Goldenrod City to the warehouse director's CARD_KEY, and back. The
+## underground's north half ends at the door the BASEMENT_KEY unlocks, which warps
+## to the south half and the switch room's top corridor. `..._UpdateDoors` adds
+## each switch to `wUndergroundSwitchPositions`, opening some doors and closing
+## others, so 3, then 2, then 1 is the one chain to the warehouse. Coming back
+## needs the emergency switch, the warehouse's callback clearing every door event.
 func _goldenrod_underground_card_key(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3742,14 +3734,12 @@ func _rising_badge_path(
 	return {"ok": true}
 
 
-## Blackthorn Gym's boulder puzzle and Clair. 1F is four regions and the entrance
-## reaches only one. 2F's three holes are `stonetable` rows, and a boulder that
-## falls through one sets its own event flag, which
-## `BlackthornGym1FBouldersCallback` turns into a `changeblock` on 1F. Two of those
-## are the route: BOULDER1 through the (8,3) hole joins the middle corridor to
-## Clair's room, and BOULDER3 through the (8,7) hole joins it to the pocket 2F's
-## staircase drops into. BOULDER2's hole reaches nothing. BOULDER1 is one push;
-## BOULDER3 goes north until the wall at (6,6) stops it and then east.
+## Blackthorn Gym's boulder puzzle and Clair. 2F's three holes are `stonetable`
+## rows, and a boulder through one sets a flag `BlackthornGym1FBouldersCallback`
+## turns into a `changeblock` on 1F. Two are the route: BOULDER1 through the
+## (8,3) hole joins the middle corridor to Clair's room, BOULDER3 through the
+## (8,7) hole joins it to the pocket 2F's staircase drops into; BOULDER2's hole
+## reaches nothing. BOULDER1 is one push; BOULDER3 goes north to (6,6), then east.
 func _blackthorn_gym_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3833,14 +3823,12 @@ func _blackthorn_gym_leg(
 	return {"ok": true}
 
 
-## Blackthorn City to the Dragon Shrine, and the elder's quiz. Clair's script swaps
-## the gramps standing on (20,2) for one beside it and opens the den door at
-## (20,1). Neither den floor needs a field move: B1F's shrine warp at (19,29) is on
-## the same land region as the ladder from 1F, and the whirlpool at (10,20) guards
-## the water pocket rather than the way through. The quiz is answered correctly:
-## `.WrongAnswer` on the last question checks a flag question 5 has already set, so
-## it asks question 5 again, and a wrong answer there is the one that does not move
-## on.
+## Blackthorn City to the Dragon Shrine, and the elder's quiz. Clair's script
+## swaps the gramps on (20,2) for one beside it and opens the den door at (20,1).
+## Neither den floor needs a field move: B1F's shrine warp at (19,29) shares the
+## ladder's land region, and the whirlpool at (10,20) guards only a pocket. The
+## quiz is answered correctly: `.WrongAnswer` on the last question re-asks
+## question 5, and a wrong answer there is the one that does not move on.
 func _dragon_shrine_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3947,14 +3935,12 @@ func _dragon_shrine_leg(
 	return {"ok": true}
 
 
-## Dragon's Den B1F's DRAGON_FANG ball, which is where Gold and Silver keep the
-## Rising Badge. pokegold ships no DRAGON_SHRINE map: B1F has one warp rather than
-## two and no coord event, and blocks (7..11, 13..15) wall the shrine mouth off.
-## `DragonsDenB1FDragonFangScript` is the errand instead: the ball on (35,16) gives
-## the fang, then Clair walks in, runs `setflag ENGINE_RISINGBADGE` and hands over
-## TM24. The ball's land strip touches no other land, so the lake is the only way
-## onto it and (34,22) is its one shore; the whirlpool on (10,20) is on this route
-## as much as on Crystal's.
+## Dragon's Den B1F's DRAGON_FANG ball, where Gold and Silver keep the Rising
+## Badge: pokegold ships no DRAGON_SHRINE map, and blocks (7..11, 13..15) wall
+## the shrine mouth off. `DragonsDenB1FDragonFangScript` is the errand: the ball
+## on (35,16) gives the fang, then Clair walks in, runs `setflag
+## ENGINE_RISINGBADGE` and hands over TM24. The ball's land strip is reached from
+## the lake alone, at its one shore (34,22), past the whirlpool on (10,20).
 func _dragons_den_dragon_fang(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4012,14 +3998,12 @@ func _dragons_den_dragon_fang(
 	return {"ok": true}
 
 
-## The Dragon Shrine to Indigo Plateau.
-## `VictoryRoadGate`'s coord event at (10,11) is a `readvar VAR_BADGES` against
-## `NUM_JOHTO_BADGES - 1`, so it is the first script on the walked route that reads
-## the badge count back. Route 27 is the reason this leg waited on Waterfall: its
-## Kanto landfall sits in a region that reaches no map edge, the only crossing east
-## of it starts in a pocket reached solely by leaving Tohjo Falls there, and the
-## cave's two lower channels reach the pool feeding them only by climbing
-## `COLL_WATERFALL` cells. `tools/checks/route_27.gd` pins all of it.
+## The Dragon Shrine to Indigo Plateau. `VictoryRoadGate`'s coord event at
+## (10,11) reads `VAR_BADGES` against `NUM_JOHTO_BADGES - 1`, the first script on
+## the route to read the count back. Route 27 waited on Waterfall: its Kanto
+## landfall reaches no map edge, the only crossing east of it starts in a pocket
+## left only through Tohjo Falls, and the cave's lower channels reach their pool
+## only by climbing `COLL_WATERFALL` cells. `tools/checks/route_27.gd` pins it.
 func _kanto_approach_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4046,14 +4030,11 @@ func _kanto_approach_path(
 	return _elite_four_leg(world, save, random, data, path)
 
 
-## The Dragon's Den back to New Bark Town. The way out is the way in reversed.
-## Crystal clears the whirlpool twice: `complete_whirlpool()` is a transient block
-## override, so the warp into the shrine restored (10,20), and the water south of
-## it reaches the shrine's landfall and nothing else. Gold and Silver enter no map
-## in between, so their first clear still holds. Blackthorn's own exit is south
-## rather than west: Route 45 into Route 46 into the Route 29 gate. Route 46 is
-## walked downhill only, its ledges leaving the gate region reaching no map edge
-## at all.
+## The Dragon's Den back to New Bark Town, the way in reversed. Crystal clears
+## the whirlpool twice: `complete_whirlpool()` is a transient block override, so
+## the warp into the shrine restored (10,20). Gold and Silver enter no map in
+## between, so their first clear holds. Blackthorn's exit is south: Route 45 into
+## Route 46 into the Route 29 gate, Route 46 walked downhill only.
 func _blackthorn_departure(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4216,13 +4197,11 @@ func _blackthorn_departure(
 
 
 ## New Bark Town to Route 26, along Route 27 and through Tohjo Falls. New Bark's
-## east column is wall except the four water rows 6 to 9, so leaving town east is a
-## crossing rather than a step, and the far side is still water: one water-only
-## walk comes ashore on ROUTE_27_LANDFALL, one of the two
-## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord cells. From there the way east is
-## the cave, twice over. Row 5 is solid cliff apart from Tohjo Falls' two mouths,
-## both `COLL_CAVE`, whose `.warps` branch forces a step DOWN, so the east mouth
-## drops the player into the pocket whose shore crosses to Route 26.
+## east column is wall except water rows 6 to 9, so one water-only walk comes
+## ashore on ROUTE_27_LANDFALL, a `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord
+## cell. Row 5 is cliff apart from Tohjo Falls' two `COLL_CAVE` mouths, whose
+## `.warps` branch forces a step DOWN, so the east mouth drops the player into the
+## pocket whose shore crosses to Route 26.
 func _kanto_approach(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4516,13 +4495,10 @@ func _victory_road_leg(
 		return _leg_failed(path, "Indigo Plateau unreachable", to_plateau)
 
 	# PlateauRivalBattle1 and 2 open on EVENT_BEAT_RIVAL_IN_MT_MOON, which this
-	# route never reaches, so the coord event runs to PlateauRivalScriptDone and
-	# no second rival battle happens here.
-	#
-	# That branch ends without a `setscene`, so the coord event stays armed and
-	# answers again every time the player stands on it. The cell is stepped onto
-	# once rather than walked to, because a resolving walk would re-dispatch it
-	# until it ran out of attempts.
+	# route never reaches, so the coord event runs to PlateauRivalScriptDone. That
+	# branch ends without a `setscene`, so the event stays armed: the cell is
+	# stepped onto once rather than walked to, or a resolving walk would
+	# re-dispatch it until it ran out of attempts.
 	var approach: Dictionary = _walk_cell_resolving(
 		world, PLATEAU_RIVAL_APPROACH, save, random, data
 	)
@@ -4812,14 +4788,11 @@ func _kanto_crossing_path(
 	return {"ok": true, "world": spawned}
 
 
-## Olivine Port to Vermilion City on the S.S. Aqua. The Hall of Fame is what opens
-## this: `HallOfFameEnterScript` swaps the two port sprite flags, and the sailor
-## those flags swap is the one standing on the port's own coord event at (7,15).
-## Before the Hall of Fame he blocks it. The first crossing is the granddaughter's:
-## `.CanArrive` wants EVENT_FAST_SHIP_FOUND_GIRL or EVENT_FAST_SHIP_FIRST_TIME and
-## neither is set on the way out, so the ship only docks once
-## `SSAquaMetalCoatAndDocking` has run. The bed is not needed; that script sets both
-## flags itself.
+## Olivine Port to Vermilion City on the S.S. Aqua. `HallOfFameEnterScript`
+## swaps the two port sprite flags, moving the sailor off the port's coord event
+## at (7,15). The first crossing is the granddaughter's: `.CanArrive` wants
+## EVENT_FAST_SHIP_FOUND_GIRL or EVENT_FAST_SHIP_FIRST_TIME, so the ship docks
+## only once `SSAquaMetalCoatAndDocking` has run, which sets both flags itself.
 func _ss_aqua_crossing(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5443,13 +5416,11 @@ func _celadon_gym_leg(
 	return {"ok": true}
 
 
-## Celadon Gym to Cerulean City, by way of Saffron and Route 5: two gate buildings
-## and one open connection. Cerulean is as far as this walk goes, because the
-## Cascade Badge is an errand rather than a cell. Misty and her three swimmers all
-## hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, cleared by a scene armed by the
-## gym's own grunt, who is armed by the Power Plant manager. The plant is not walked
-## to either: it sits in a region with no map edge and no walkable neighbour, and
-## the way in is Route 9's river, whose shore the same cut opens.
+## Celadon Gym to Cerulean City, by way of Saffron and Route 5. Cerulean is as
+## far as the walk goes: Misty and her swimmers hide behind
+## EVENT_TRAINERS_IN_CERULEAN_GYM, cleared by a scene the gym's grunt arms, who
+## is armed by the Power Plant manager. The plant sits in a region with no map
+## edge; the way in is Route 9's river, whose shore the same cut opens.
 ## `tools/checks/cerulean.gd` pins all of it.
 func _cerulean_approach_path(
 	world: Gen2WorldAPI,
@@ -5569,14 +5540,11 @@ func _machine_part_errand(
 	return _cerulean_gym_leg(world, save, random, data, path)
 
 
-## Misty, once the errand has put her in her gym. The gym is a pool with the leader
-## on an island, and its trainers are what the walk has to answer: Swimmer Diana
-## watches the one row every route to Misty crosses, and Parker and Briana watch the
-## pool's two alternative columns, so one of the pair is met whichever way round it
-## goes. All three stand on water and walk over it to reach the player, which the
-## cartridge allows because `SeenByTrainerScript`'s steps reach `NormalStep` and
-## check no permission. Misty sets all three of their beaten flags along with her
-## own, so they are reported rather than gated on.
+## Misty, once the errand has put her in her gym. Swimmer Diana watches the one
+## row every route to Misty crosses, and Parker and Briana the pool's two
+## columns, so one of the pair is met either way. All three walk over water to
+## the player, since `SeenByTrainerScript`'s steps reach `NormalStep` and check no
+## permission. Misty sets all three beaten flags with her own.
 func _cerulean_gym_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5620,13 +5588,10 @@ func _cerulean_gym_leg(
 
 
 ## Cerulean Gym back through Saffron to Lavender Town and the Kanto Radio Tower.
-## Two gate buildings and one open connection, the same shape run in reverse and
-## then east. Route 8's five trainers are the only thing between the gate and the
-## crossing, and just one, Super Nerd Tom, cannot be routed around: the three bikers
-## watch the corridor west of the route's eight `$a3` hop-down ledges, and the
-## eastbound walk hops off row 6 onto row 8 east of them. What the leg is for is the
-## EXPN CARD, gated on `EVENT_RETURNED_MACHINE_PART`, which the Cerulean errand
-## already set: the third Kanto opener that sat before its gate.
+## Of Route 8's five trainers only Super Nerd Tom cannot be routed around: the
+## three bikers watch the corridor west of the eight `$a3` hop-down ledges, and
+## the walk hops off row 6 onto row 8 east of them. The leg is for the EXPN CARD,
+## gated on `EVENT_RETURNED_MACHINE_PART`, which the Cerulean errand already set.
 func _lavender_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5702,14 +5667,12 @@ func _lavender_leg(
 	return _fuchsia_leg(world, save, random, data, path)
 
 
-## The lost-doll errand and the Magnet Train, run from Saffron City. An errand
-## rather than a walk, and the one leg whose order the cartridge fixes rather than
-## the geography: the Fan Club's Clefairy guy reads
-## EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before he parts with the doll, and
-## only the Copycat sets it. The ride itself never touches the platform on foot:
-## each station is two regions with row 9 solid between them, the officer is talked
-## to across that row, and his script's `applymovement` walks the player over the
-## wall onto the train door, because a scripted step ignores collision.
+## The lost-doll errand and the Magnet Train, from Saffron City. The Fan Club's
+## Clefairy guy reads EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before parting
+## with the doll, and only the Copycat sets it. Each station is two regions with
+## row 9 solid between them: the officer is talked to across it and his
+## `applymovement` walks the player over the wall, a scripted step ignoring
+## collision.
 func _magnet_train_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5959,14 +5922,11 @@ func _magnet_train_ride(
 	return {"ok": true}
 
 
-## Lavender Town south to Fuchsia City and the Soul Badge. The longest open walk in
-## Kanto and the first leg since Vermilion with no errand in it at all: four plain
-## connections and one door at the end. What it costs is trainers, eighteen of them,
-## and `tools/checks/fuchsia.gd` measures which ones a walk owes: on this profile
-## only Route 13's Pokefan Joshua and Hiker Kenny stand where shutting their sight
-## line seals the way south. The gym is a maze rather than a puzzle with a gate, and
-## its four disguised trainers are `OBJECTTYPE_SCRIPT`, so Janine sets all four
-## beaten flags herself along with the badge.
+## Lavender Town south to Fuchsia City and the Soul Badge: four plain connections
+## and one door, with eighteen trainers on the way. `tools/checks/fuchsia.gd`
+## measures which a walk owes: only Route 13's Pokefan Joshua and Hiker Kenny
+## stand where their sight line seals the way south. The gym's four disguised
+## trainers are `OBJECTTYPE_SCRIPT`, so Janine sets their beaten flags herself.
 func _fuchsia_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6064,13 +6024,11 @@ func _fuchsia_leg(
 
 
 ## Fuchsia Gym back to Vermilion, through Diglett's Cave to Route 2, and up to
-## Pewter Gym for the Boulder Badge. The order is forced: measured against a real
-## Crystal cache, a walk out of Cerulean reaches 91 maps and none of west Kanto, and
-## Fuchsia's own south edge is sealed the other way while
-## EVENT_CINNABAR_ROCKS_CLEARED is clear. Diglett's Cave is the one door into west
-## Kanto and the Snorlax on top of it is the lock. What opens that lock is the
-## radio, which is why the Goldenrod leg takes the Radio Card: `SnorlaxAwake`
-## answers only while the Poke Flute channel is the track in `wMapMusic`.
+## Pewter Gym for the Boulder Badge. A walk out of Cerulean reaches 91 maps and
+## none of west Kanto, and Fuchsia's south edge is sealed while
+## EVENT_CINNABAR_ROCKS_CLEARED is clear, so Diglett's Cave is the one door and
+## the Snorlax on it the lock: `SnorlaxAwake` answers only while the Poke Flute
+## channel is the track in `wMapMusic`, which is why Goldenrod took the Radio Card.
 func _pewter_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6269,12 +6227,10 @@ func _pewter_gym_leg(
 	return _cinnabar_leg(world, save, random, data, path)
 
 
-## Pewter Gym south to Cinnabar Island and east to Seafoam Gym's Volcano Badge. Six
-## plain connections carry the walk down the west coast and then it is water the
-## rest of the way, Pallet's own pond being the last land. Two things make this leg
-## come before Viridian's: Blue stands on Cinnabar until he is talked to, and
+## Pewter Gym south to Cinnabar Island and east to Seafoam Gym's Volcano Badge,
+## water all the way past Pallet's pond. This leg comes before Viridian's because
 ## `CinnabarIslandBlue` is the only `clearevent` for EVENT_VIRIDIAN_GYM_BLUE in
-## either pin; and `Route20ClearRocksCallback` is a MAPCALLBACK_NEWMAP, so simply
+## either pin, and `Route20ClearRocksCallback` is a MAPCALLBACK_NEWMAP, so
 ## arriving on Route 20 sets EVENT_CINNABAR_ROCKS_CLEARED and takes the six `$7a`
 ## wall blocks off Route 19.
 func _cinnabar_leg(
@@ -6577,14 +6533,11 @@ func _viridian_leg(
 	return _mt_silver_leg(world, save, random, data, path)
 
 
-## Viridian Gym to Red, which is Oak's errand and then a walk west. The sixteenth
-## badge opens the leg and Oak is what spends it: `maps/OaksLab.asm` takes
-## `.OpenMtSilver` only on `ifequal NUM_BADGES`, so the walk goes south to Pallet
-## before it goes west. That is not a courtesy call: the Victory Road Gate is three
-## regions joined by two single cells with a black belt in each, so
-## EVENT_OPENED_MT_SILVER is the one thing that joins the corridor to the Route 28
-## arm. Red's own script ends on `credits`, which commits nothing and emits one
-## event, and `disappear` then closes the room behind the walk.
+## Viridian Gym to Red, which is Oak's errand and then a walk west:
+## `maps/OaksLab.asm` takes `.OpenMtSilver` only on `ifequal NUM_BADGES`, and the
+## Victory Road Gate is three regions joined by two single cells with a black belt
+## in each, so EVENT_OPENED_MT_SILVER alone joins the corridor to the Route 28
+## arm. Red's script ends on `credits`, which commits nothing, and `disappear`.
 func _mt_silver_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7198,14 +7151,11 @@ func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) ->
 		world.advance_object_steps_pass(random)
 
 
-## Mahogany Town east to Blackthorn City. Starts
-## in the town, since the Radio Tower leg before it left the gym. Route 44 carries
-## seven trainers and no scripted gate, so the leg is a walk the trainers interrupt.
-## Its one warp is the Ice Path door at (56,7); the east connection to Blackthorn
-## exists but the cartridge's own way through is the cave. Ice Path 1F is the only
-## floor on the way, its second warp being Blackthorn's own, so the `stonetable`
-## puzzle on B1F is beside the route rather than across it. The floor is COLL_ICE,
-## which is LAND_TILE, so the walk crosses it without the source's sliding.
+## Mahogany Town east to Blackthorn City. Route 44 carries seven trainers and no
+## scripted gate; its one warp is the Ice Path door at (56,7). Ice Path 1F is the
+## only floor on the way, its second warp being Blackthorn's own, so B1F's
+## `stonetable` puzzle is beside the route. The floor is COLL_ICE, a LAND_TILE,
+## so the walk crosses it without the source's sliding.
 func _blackthorn_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7436,13 +7386,10 @@ func _olivine_cafe_hm04(
 
 
 ## Cianwood City's gym, whose only corridor is walled by three
-## SPRITEMOVEDATA_STRENGTH_BOULDER objects at (3,7), (4,7) and (5,7). Row 7 is the
-## sole link between the entrance half and Chuck, its ends are walls, and row 5
-## above it opens only at (4,5) and (5,5), the second of which a Black Belt stands
-## on for good. So no single push opens it: the corridor opens by clearing (3,7) and
-## (5,7) north first, then pushing the middle boulder sideways into the cell (3,7)
-## left behind. A state-space search over player cell plus boulder cells finds no
-## shorter answer. Chuck himself needs no Strength.
+## SPRITEMOVEDATA_STRENGTH_BOULDER objects at (3,7), (4,7) and (5,7). Row 5 above
+## opens only at (4,5) and (5,5), a Black Belt standing on the second for good, so
+## the corridor opens by clearing (3,7) and (5,7) north first, then pushing the
+## middle boulder sideways into (3,7). A state-space search finds no shorter answer.
 func _storm_badge_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7613,13 +7560,11 @@ func _buy_balls(
 	return {"ok": true}
 
 
-## Route 32's Pokemon Center for the OLD ROD, and then the shore below it for what
-## the rod is here to catch. This is the route's answer to Surf and Whirlpool, and
-## it has to be a rod rather than a walk: every grass wild in reach before Route
-## 40's south edge that CanLearnTMHMMove accepts for SURF is night only except
-## Slowpoke Well's Slowpoke, and Slowpoke does not take WHIRLPOOL at all. The walked
-## route runs on the new game's own 06:00 clock, so Route 32's Old Rod row is the
-## one time-independent source of a mon that takes both, at Tentacool on the last
+## Route 32's Pokemon Center for the OLD ROD, then the shore below it: every
+## grass wild in reach before Route 40's south edge that CanLearnTMHMMove accepts
+## for SURF is night only except Slowpoke, which does not take WHIRLPOOL, and the
+## route runs on the new game's 06:00 clock. The Old Rod row is the one
+## time-independent source of a mon that takes both, Tentacool on the last
 ## threshold.
 func _route_32_old_rod(
 	world: Gen2WorldAPI,
@@ -7668,14 +7613,12 @@ func _route_32_old_rod(
 	)
 
 
-## Catches something on the current map that can learn [param move], which is how
-## this route gets both of the HMs its own party cannot take. Neither is optional:
-## the starter is still unevolved by Olivine and all three starters learn STRENGTH
-## only after evolving, so Union Cave 1F's Geodude and Onix are the first catch, and
-## none of the party learns WATERFALL at all, so Dragon's Den B1F's Dratini is the
-## second. The walk itself never rolls a wild encounter, so this forces one, checks
-## the species against CanLearnTMHMMove and throws a Poke Ball; both rolls come from
-## the route's seeded generator.
+## Catches something on the current map that can learn [param move]: the starter
+## is unevolved by Olivine and learns STRENGTH only after evolving, so Union Cave
+## 1F's Geodude and Onix are the first catch, and nothing in the party learns
+## WATERFALL, so Dragon's Den B1F's Dratini is the second. The walk never rolls a
+## wild encounter, so this forces one, checks CanLearnTMHMMove and throws a Poke
+## Ball off the route's seeded generator.
 func _catch_field_move_mon(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7749,14 +7692,12 @@ func _catch_field_move_mon(
 	return {"ok": true}
 
 
-## TeachTMHM against the first party member the machine will take, which is what
-## ChooseMonToLearnTMHM leaves the player to pick. Compatibility, a known move and a
-## full moveset are all real refusals, so the walk tries each slot in party order
-## and reports the last reason when none of them can learn it. A full moveset
-## everywhere is the second pass rather than a failure: it is `ForgetMove`'s own
-## prompt, which the walk answers with the first slot that is not an HM, since every
-## HM it has taught is load bearing. A levelled party reaches it, because four
-## level-up moves leave the starter no room for CUT.
+## TeachTMHM against the first party member the machine will take, which
+## ChooseMonToLearnTMHM leaves the player to pick. Compatibility, a known move and
+## a full moveset are real refusals, tried in party order. A full moveset
+## everywhere is `ForgetMove`'s own prompt, answered with the first slot that is
+## not an HM, since every HM taught is load bearing: four level-up moves leave the
+## starter no room for CUT.
 func _teach_tm_hm(world: Gen2WorldAPI, save: Gen2SaveData, item: int) -> Dictionary:
 	var reason: String = "no party member"
 	for index: int in save.party.size():
@@ -8233,14 +8174,11 @@ func _party_species(save: Gen2SaveData) -> Array:
 	return values
 
 
-## The experience a won trainer battle pays, since this walk answers every one of
-## them with a win rather than fighting it.
-## [method Gen2Battle.award_win_experience] is the engine's own split, level up,
-## evolution and move learning; the fought party is written back over the saved one
-## through the adapter that owns that seam, so a leg arrives carrying the levels its
-## fights paid for. What is still not a played route: no party member takes damage,
-## and a move offered into a full moveset is left in the engine's queue, which is
-## the same answer as declining it.
+## The experience a won trainer battle pays, since this walk answers every one
+## with a win. [method Gen2Battle.award_win_experience] is the engine's own split,
+## level up, evolution and move learning, written back through the adapter that
+## owns the seam. No party member takes damage, and a move offered into a full
+## moveset is left in the engine's queue, which is declining it.
 func _award_battle_experience(
 	data: GameData, world: Gen2WorldAPI, save: Gen2SaveData, battle: Gen2Battle,
 	player_party: Gen2Party
@@ -8955,14 +8893,11 @@ func _walk_to_connection(
 	}
 
 
-## The cell [param step] from [param cell] reaches by an ordinary walk or, when that
-## is blocked, a ledge hop, mirroring `_try_ledge_hop`'s order and its surf and
-## map-bounds refusals. Returns (-1, -1) when neither applies, so a BFS frontier can
-## use it as one reachability test. [param water_only] is what a surfing plan needs:
-## `can_walk_to()` lets a surfing player step onto land, and that step is
-## `.ExitWater`, so a plan drawn once and replayed would stop surfing partway and
-## see every later water step refused. Restricting the frontier to WATER_TILE keeps
-## the plan legal in the mode it was drawn in.
+## The cell [param step] from [param cell] reaches by a walk or, when blocked, a
+## ledge hop, in `_try_ledge_hop`'s order; (-1, -1) when neither applies, so a
+## BFS frontier can use it as one reachability test. [param water_only] keeps a
+## surfing plan on WATER_TILE: `can_walk_to()` lets a surfing player step onto
+## land, which is `.ExitWater`, and a replayed plan would then stop surfing.
 func _reachable_step(
 	world: Gen2WorldAPI, cell: Vector2i, step: Vector2i,
 	warp_target: Vector2i = Vector2i(-1, -1),
@@ -9063,10 +8998,10 @@ func _walk_to_story_cell(
 			"target": _cell_value_from_vector(target),
 		}
 	var steps: Array[Vector2i] = plan["steps"]
+	var landings: Array[Vector2i] = plan["landings"]
 	var events: Array = []
-	var arrows: Dictionary = _gen1_arrow_landings(world)
-	for direction: Vector2i in steps:
-		var expected: Vector2i = arrows.get(world.player_cell + direction, world.player_cell + direction)
+	for index: int in steps.size():
+		var direction: Vector2i = steps[index]
 		var moved: Dictionary = world.move_result(direction)
 		if not bool(moved.get("ok", false)):
 			return {
@@ -9076,8 +9011,8 @@ func _walk_to_story_cell(
 				],
 			}
 		events = _dispatch_after_step(world)
-		## A spin tile has already moved the player off the plan.
-		if not events.is_empty() or world.player_cell != expected:
+		## A spin tile has moved the player off the plan; a hop lands on it.
+		if not events.is_empty() or world.player_cell != landings[index]:
 			break
 	return {"ok": true, "steps": steps.size(), "events": events}
 
@@ -9106,12 +9041,14 @@ func _plan_walk(
 			previous[next] = {"cell": cell, "direction": direction}
 			frontier.append(next)
 	var steps: Array[Vector2i] = []
+	var landings: Array[Vector2i] = []
 	var cursor: Vector2i = target
 	while found and cursor != world.player_cell:
 		var link: Dictionary = previous[cursor]
 		steps.push_front(link["direction"])
+		landings.push_front(cursor)
 		cursor = link["cell"]
-	return {"found": found, "steps": steps, "previous": previous}
+	return {"found": found, "steps": steps, "landings": landings, "previous": previous}
 
 
 ## Each spin tile and the cell `DecodeArrowMovementRLE`'s whole ride stops on.


### PR DESCRIPTION
A Generation 1 induction drew Crystal's panels and then stopped on "The credits are not in this cache" with `hall_of_fame_requested` pending, so no playthrough got past the Champion on a real screen.

## Added

- `AnimateHallOfFame`'s own pages: 100 white frames, then per member the `HoFShowMonOrPlayer` slide (the doubled back pic across at `hSCY` $d0, the front pic in from the left), `HoFDisplayMonInfo`'s box with the cry for 80 frames, `HallOfFameText`'s box for 180 and `GBFadeOutToWhite`'s three palettes, then the player's slide, `HoFDisplayPlayerStats`' two boxes and the three `HoFPrintTextAndDelay` texts, a `cont` inside the rating waiting for its press. The whole screen is drawn through `SET_PAL_POKEMON_WHOLE_SCREEN`'s row and each page's `rBGP`.
- `LeaguePCShowMon`: the same panel under `HALL OF FAME No`, walked oldest first; `sHallOfFame` keeps 50 teams and `wNumHoFTeams` stops at 255.
- `Gen1Credits`, `HallOfFamePC`'s loop: the bands and MUSIC_CREDITS at frame 100, strings at their `db -n` columns, `FadeInCredits` on colour 2 (`ShiftFontColorIndex` zeroes the low plane), the four waits (Yellow's twelve longer) and `DisplayCreditsMon` sliding each `CreditsMons` entry across as a silhouette at 8 px a frame. `TheEndGfx` and the copyright tiles share `vChars2 tile $60`, so the page keeps both sheets by name. THE END holds the script's 600 frames and then until A or B. 5254 frames on Red and Blue, 5248 on Yellow.
- `tools/checks/credits.gd` runs all three cartridges' orders to the end; `gen1_tables.gd` pins the two dex texts and the page count; `preview_hall_of_fame.gd` takes `page,frames` and `preview_credits.gd` drives either generation.

## Changed

- Cache format 133. `Gen1Layout` pins `CreditsOrder`, `CreditsTextPointers`, `CreditsMons`, `TheEndGfx`, `NintendoCopyrightLogoGraphics`, `CopyrightTextString` and `DexSeenOwnedText`; Blue's `TheEndGfx` sits one byte on from Red's behind `CredVersion`.
- The Hall of Fame music starts on the page that asks for it and fades on the page that ends it, on both generations.

## Fixed

- `Gen1Text.encode` wrote seven unknowns for a decoded `<COLON>`, and `Gen2TextLayout` measured Generation 1 text with Crystal's codec, so `_DexRatingText` wrapped and could not print.
- An induction on any cache without credits left `hall_of_fame_requested` pending for ever.
- The story walk stopped on every ledge hop: the spin-tile guard compared a hop against a one-cell step. All three Johto profiles walk to Red again (296, 293 and 293 steps) and Red walks to the Hall of Fame (360).
- `GameData.palette` raised on a species record without a palette.
- README lines that still said Play was refused on Generation 1.

| Check | Result |
|---|---|
| GUT, whole tier | 4569/4569 |
| `validate.gd -- gen1 art pc pokecenter_pc elite_four` | all pass |
| `replay_world.gd` | 33 routes, 0 failures |
| Warning scan | 0 warnings in 638 scripts |
| `tools/release.sh --gates` | pass, comments 41932 of 41932 |
