### PR TITLE
Fight Red, Blue and Yellow's trainers as TrainerAI does

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -455,6 +455,11 @@ const FLEE_ODDS_RANGE: int = 256
 ## Priority runs 0 to 3 with most moves at 1, so a move can go below the ordinary
 ## as well as above it. Keyed by effect byte, which the cache carries.
 const BASE_PRIORITY: int = 1
+## `MainInBattleLoop`'s two `cp`s in order: QUICK_ATTACK's user moves first,
+## COUNTER's last, and `50 percent + 1` bounds the tie.
+const GEN1_PRIORITY_MOVES: Array = [[0x62, true], [0x44, false]]
+const GEN1_TIE_BOUND: int = 129
+
 const EFFECT_PRIORITIES: Dictionary = {
 	Gen2MoveEffect.PROTECT: 3,
 	Gen2MoveEffect.ENDURE: 3,
@@ -526,6 +531,13 @@ var landmark: int = LANDMARK_NONE
 ## and each removed as it is spent (`xor a; ld [de], a`). Empty for a wild battle
 ## and for a class carrying `NO_ITEM` twice.
 var enemy_items: Array[int] = []
+
+## `wTrainerClass`, zero for a wild.
+var enemy_trainer_class: int = 0
+## `wAICount` and `wAILayer2Encouragement`, the `ExecuteEnemyMove`s since a
+## faint replacement. Generation 1 alone reads either.
+var gen1_ai_count: int = Gen1TrainerAI.COUNT_UNLOADED
+var gen1_enemy_moves: int = 0
 
 ## `wPlayerUsedMoves`, oldest first: all the switch AI has to go on about what it
 ## is facing. `NewBattleMonStatus` clears it on every send-out, so it describes
@@ -758,6 +770,7 @@ static func use_item(item: int) -> Dictionary:
 ## `ComputeTrainerReward`, and neither win branch pays money either.
 func init_enemy_trainer(trainer_class: int, rewarded: bool = true) -> void:
 	enemy_items = []
+	enemy_trainer_class = maxi(trainer_class, 0)
 	if data == null or trainer_class <= 0:
 		return
 	var attributes: Dictionary = data.trainer_attributes(trainer_class)
@@ -789,7 +802,7 @@ func _compute_trainer_reward(base_reward: int) -> void:
 	if last == null:
 		return
 	var product: int = base_reward * last.level
-	if data != null and data.generation == RomRegistry.GEN1:
+	if is_gen1():
 		battle_reward = mini(product, GEN1_REWARD_CEILING)
 		return
 	battle_reward = product & 0xFFFF
@@ -1421,6 +1434,12 @@ func send_out(
 		return events
 	if side == PLAYER:
 		_apply_player_badges()
+	elif is_gen1():
+		# `EnemySendOutFirstMon`'s `wAICount` reset, and `HandleEnemyMonFainted`'s
+		# `wAILayer2Encouragement` one, which an `AISwitchIfEnoughMons` skips.
+		gen1_ai_count = Gen1TrainerAI.COUNT_UNLOADED
+		if not withdrawing:
+			gen1_enemy_moves = 0
 	_clear_trapping()
 	if not preserve_counter_moves:
 		# NewBattleMonStatus/NewEnemyMonStatus clear both counter-move words.
@@ -1697,6 +1716,38 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	return _run_turn(events)
 
 
+## `TrainerAI` stands in front of `ExecuteEnemyMove` on both orderings, so an
+## item or a switch replaces the move where it would have been, marked
+## `trainer_ai`.
+func _gen1_ai_action(side: int, actions: Dictionary) -> Dictionary:
+	var action: Dictionary = actions[side]
+	if side != ENEMY or not is_gen1() or _is_switch(action) or _is_item(action):
+		return action
+	var chosen: Dictionary = Gen1TrainerAI.trainer_action(self, rng)
+	if chosen.is_empty():
+		return action
+	chosen["trainer_ai"] = true
+	actions[side] = chosen
+	return chosen
+
+
+## `EnemySwitch`: on SHIFT the player is asked whether to change before that
+## Pokémon is out, and the turn stops there. `SwitchEnemyMon` raises
+## `wFirstMonsNotOutYet`, so a Generation 1 class's switch asks nobody.
+func _switch_offered(side: int, action: Dictionary, actions: Dictionary, events: Array) -> bool:
+	_pursuit_before_switch(side, actions, events)
+	if side == ENEMY and not bool(action.get("trainer_ai", false)) and should_offer_switch():
+		_pending_switch_offer = int(action.get("index", -1))
+		events.append({
+			"type": SWITCH_OFFERED, "side": PLAYER,
+			"index": _pending_switch_offer,
+			"species": party(ENEMY).at(_pending_switch_offer).species,
+		})
+		return true
+	events.append_array(send_out(side, int(action.get("index", -1))))
+	return false
+
+
 ## The per-side loop and the end-of-turn tail, from wherever the turn last
 ## stopped. Baton Pass is the one thing that stops it part way: `DoPlayerTurn`
 ## opens a switch menu and waits, so the rest sits in [member _pending_turn].
@@ -1706,34 +1757,23 @@ func _run_turn(events: Array) -> Array:
 
 	while int(_pending_turn["index"]) < acting.size():
 		var side: int = int(acting[int(_pending_turn["index"])])
-		var action: Dictionary = actions[side]
-		var action_event_start: int = events.size()
-		var moving: bool = not (_is_run(action) or _is_switch(action) or _is_item(action))
 		# `HasPlayerFainted`/`HasEnemyFainted` between the halves of the turn,
 		# gating the whole second half rather than its move, which is why it is
-		# asked before the bracket opens. A switching or item-using side is always
-		# [method order]'s first, so this is only ever asked of a move.
-		if moving and (mon(side).is_fainted() or mon(opponent_of(side)).is_fainted()):
+		# asked before the bracket opens.
+		if mon(side).is_fainted() or mon(opponent_of(side)).is_fainted():
 			break
+		var action: Dictionary = _gen1_ai_action(side, actions)
+		var action_event_start: int = events.size()
+		var moving: bool = not (_is_run(action) or _is_switch(action) or _is_item(action))
 		_open_turn_bracket(side, action)
-		if not moving:
+		if not moving and not bool(action.get("trainer_ai", false)):
 			# `.reset_rage` for a switch and `.reset_bide` for an item or a failed
 			# run, both falling into `.locked_in`'s zeroing, and `AI_TryItem` the
 			# same on the enemy's side. -1 is no effect, so both counters go.
 			_reset_action_counters(side, -1)
 		if _is_switch(action):
-			_pursuit_before_switch(side, actions, events)
-			# `EnemySwitch`: on SHIFT the player is told who is coming and asked
-			# whether to change, before that Pokémon is out. The turn stops here.
-			if side == ENEMY and should_offer_switch():
-				_pending_switch_offer = int(action.get("index", -1))
-				events.append({
-					"type": SWITCH_OFFERED, "side": PLAYER,
-					"index": _pending_switch_offer,
-					"species": party(ENEMY).at(_pending_switch_offer).species,
-				})
+			if _switch_offered(side, action, actions, events):
 				return events
-			events.append_array(send_out(side, int(action.get("index", -1))))
 		elif _is_item(action):
 			## `BattleMenu_Pack` spends the player's item before the turn
 			## resolves; only the enemy reaches into its bag inside one.
@@ -1741,6 +1781,8 @@ func _run_turn(events: Array) -> Array:
 				_use_trainer_item(side, int(action.get("item", 0)), events)
 		elif moving and side != _pursuit_spent:
 			var slot: int = effective_slot(side, int(action.get("slot", 0)))
+			if side == ENEMY and is_gen1():
+				gen1_enemy_moves += 1
 			_act(side, slot, move_for(side, slot), events)
 			_report_unannounced_action_faints(events, action_event_start)
 		# The move asked for a Baton Pass target and nothing behind it can happen
@@ -2063,7 +2105,7 @@ func _tick_wrap(events: Array) -> void:
 	## `CheckNumAttacksLeft` at the end of the whole turn is what lets go. So the
 	## turn the counter empties still holds the target, whichever side moves
 	## first on it.
-	if data != null and data.generation == RomRegistry.GEN1:
+	if is_gen1():
 		for side: int in [PLAYER, ENEMY]:
 			if mon(side).trapped_turns <= 0:
 				mon(side).trapping_move = 0
@@ -2493,7 +2535,8 @@ func _use_trainer_item(side: int, item: int, events: Array) -> void:
 		return
 	enemy_items.erase(item)
 	var user: Gen2BattleMon = mon(side)
-	var effect: Dictionary = Gen2AIItems.apply(user, item)
+	var effect: Dictionary = Gen1TrainerAI.apply_item(self, user, item) if is_gen1() \
+		else Gen2AIItems.apply(user, item)
 	events.append({
 		"type": TRAINER_USED_ITEM, "side": side, "item": item,
 		"species": user.species, "effect": effect,
@@ -2585,6 +2628,11 @@ func _wake_up(sleeper: Gen2BattleMon) -> int:
 ## `XItemEffect`, `GuardSpecEffect` and `DireHitEffect`, on whoever is out rather
 ## than a party member, each refusing a capped stage or a set flag with
 ## `WontHaveAnyEffect_NotUsedMessage`.
+## `AIIncreaseStat` reaches the same routine for the enemy.
+func apply_x_item(user: Gen2BattleMon, item: int) -> Dictionary:
+	return _apply_active_item(user, item)
+
+
 func _apply_active_item(user: Gen2BattleMon, item: int) -> Dictionary:
 	if user == null or user.is_fainted():
 		return {"ok": false, "reason": &"item_has_no_effect"}
@@ -2856,11 +2904,15 @@ func move_for(side: int, slot: int) -> int:
 	return int(attacker.moves[chosen_slot]) if attacker.can_use(chosen_slot) else Gen2Damage.STRUGGLE
 
 
+func is_gen1() -> bool:
+	return data != null and data.generation == RomRegistry.GEN1
+
+
 ## `USING_TRAPPING_MOVE` read from the user's side: while the opponent is bound,
 ## Generation 1 repeats the move that bound it and spends no PP on the repeat.
 ## Answers 0 on Generation 2, where a bound target still takes its turn.
 func gen1_trapping_move(side: int) -> int:
-	if data == null or data.generation != RomRegistry.GEN1:
+	if not is_gen1():
 		return 0
 	return mon(1 - side).trapping_move
 
@@ -2882,6 +2934,8 @@ func order(chosen: Dictionary, actions: Dictionary = {}) -> Array:
 		or _is_item(actions.get(ENEMY, {}))
 	if player_switching or enemy_switching:
 		return _sides(player_switching)
+	if is_gen1():
+		return _gen1_order(chosen)
 
 	var player_priority: int = priority_of(data.move(int(chosen[PLAYER])))
 	var enemy_priority: int = priority_of(data.move(int(chosen[ENEMY])))
@@ -2898,6 +2952,22 @@ func order(chosen: Dictionary, actions: Dictionary = {}) -> Array:
 		return _sides(player_speed > enemy_speed)
 
 	return _sides(rng.randi_range(0, 255) < 128)
+
+
+## `MainInBattleLoop` from `.noLinkBattle`: a priority is a move number, both
+## effect bytes being NO_ADDITIONAL_EFFECT, then speed, then one byte.
+func _gen1_order(chosen: Dictionary) -> Array:
+	var player_move: int = int(chosen[PLAYER])
+	var enemy_move: int = int(chosen[ENEMY])
+	for priority: Array in GEN1_PRIORITY_MOVES:
+		var move: int = int(priority[0])
+		if (player_move == move) != (enemy_move == move):
+			return _sides((player_move == move) == bool(priority[1]))
+	var player_speed: int = player.stat("speed")
+	var enemy_speed: int = enemy.stat("speed")
+	if player_speed != enemy_speed:
+		return _sides(player_speed > enemy_speed)
+	return _sides(rng.randi_range(0, 255) < GEN1_TIE_BOUND)
 
 
 ## `DetermineMoveOrder`'s `.equal_priority` block: true for the player first,

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3758,6 +3758,8 @@ func _random_slot(side: int) -> int:
 ## pairing, which is not one of the cartridge's own trainers and so has no AI
 ## flags to read.
 func _enemy_slot() -> int:
+	if _generation() == RomRegistry.GEN1:
+		return Gen1TrainerAI.select_slot(_battle, _rng)
 	if _enemy_trainer_class == 0:
 		return _random_slot(Gen2Battle.ENEMY)
 	var policy: Dictionary = Gen2BattleAI.trainer_policy(
@@ -3792,7 +3794,8 @@ func _party_status_mask(side: int) -> int:
 ## cartridge's trainers, so it has no class flags and never uses an item.
 func _enemy_action() -> Dictionary:
 	var slot: int = _enemy_slot()
-	if _enemy_trainer_class == 0:
+	## `TrainerAI` is asked inside the turn, where `MainInBattleLoop` asks it.
+	if _enemy_trainer_class == 0 or _generation() == RomRegistry.GEN1:
 		return Gen2Battle.use_move(slot)
 	var policy: Dictionary = Gen2BattleAI.trainer_policy(
 		_data, _enemy_trainer_class, _battle.in_battle_tower
@@ -5788,9 +5791,6 @@ const LINES: Dictionary = {
 	Gen2Battle.ATTRACT_INFLICTED: ["%s fell in love!", &"name:target"],
 	Gen2Battle.ENCORE_INFLICTED: ["%s got an encore!", &"name:target"],
 	Gen2Battle.ENCORE_ENDED: ["%s's encore ended!", &"name:side"],
-	# `EnemyUsedOnText`, one line for all thirteen: the trainer's own name is not in
-	# the event, so the class is all this can say.
-	Gen2Battle.TRAINER_USED_ITEM: ["Enemy used %s on %s!", &"item:item", &"name:side"],
 	Gen2Battle.HP_RESTORED: ["%s regained health!", &"name:side"],
 	Gen2Battle.HP_ALREADY_FULL: ["%s's HP is full!", &"name:side"],
 	Gen2Battle.WENT_TO_SLEEP: ["%s went to sleep!", &"name:side"],
@@ -5913,6 +5913,7 @@ const LINE_HANDLERS: Dictionary = {
 	Gen2Battle.STAT_CHANGED: &"_stat_changed_text",
 	Gen2Battle.STAT_CHANGE_FAILED: &"_stat_failed_text",
 	Gen2Battle.WITHDREW: &"_withdrew_text",
+	Gen2Battle.TRAINER_USED_ITEM: &"_trainer_used_item_text",
 	Gen2Battle.SENT_OUT: &"_sent_out_text",
 	Gen2Battle.WEATHER_STARTED: &"_weather_text",
 	Gen2Battle.WEATHER_CONTINUES: &"_weather_text",
@@ -6032,8 +6033,31 @@ func _charging_up_text(event: Dictionary) -> String:
 ## is already the one that came in.
 func _withdrew_text(event: Dictionary) -> String:
 	if int(event.get("side", Gen2Battle.PLAYER)) == Gen2Battle.ENEMY:
+		if _generation() == RomRegistry.GEN1:
+			return _gen1_trainer_ai_text("withdraw", [
+				_enemy_battler_label(), _name_of(int(event["species"])),
+			])
 		return "Enemy withdrew %s!" % _name_of(int(event["species"]))
 	return "%s, come back!" % _name_of(int(event["species"]))
+
+
+## `EnemyUsedOnText`, one line for all thirteen, or `AIBattleUseItemText`.
+func _trainer_used_item_text(event: Dictionary) -> String:
+	var item: String = _data.item_name(int(event["item"]))
+	var battler: String = _battler_name(int(event.get("side", Gen2Battle.ENEMY)))
+	if _generation() == RomRegistry.GEN1:
+		return _gen1_trainer_ai_text("use_item", [
+			_enemy_battler_label(), item, _name_of(int(event["species"])),
+		])
+	return "Enemy used %s on %s!" % [item, battler]
+
+
+## One of `trainer_ai.asm`'s two boxes, its `text_ram` markers filled in order.
+func _gen1_trainer_ai_text(key: String, values: Array) -> String:
+	var text: String = _data.special_text("trainer_ai", key)
+	for value: String in values:
+		text = Gen2TextStream.fill_marker(text, Gen2TextStream.RAM_MARKER, value)
+	return text
 
 
 func _sent_out_text(event: Dictionary) -> String:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -1,13 +1,9 @@
 class_name Gen2EffectCommands
 extends RefCounted
 
-## The steps a move is made of. A move is a short program rather than a switch
-## case: the cartridge keeps a command list per effect and runs it in order. An
-## ordinary attack announces, spends the PP, works out damage, rolls the hit,
-## applies it and checks for a faint, and every other move is that list with steps
-## added, removed or replaced. None of it reaches [Gen2Battle], which only runs a
-## list. The names are the cartridge's, so a sequence reads against
-## `data/moves/effects.asm` line for line.
+## The steps a move is made of: the cartridge keeps a command list per effect
+## and runs it in order, and [Gen2Battle] only runs a list. The names are the
+## cartridge's, so a sequence reads against `data/moves/effects.asm` line for line.
 
 ## Announces the move. First, because a move that fails still says it was used.
 const USED_MOVE_TEXT: StringName = &"usedmovetext"
@@ -130,12 +126,9 @@ const CHECK_IMMUNE: StringName = &"checkimmune"
 ## Rolls whether the move connects, and ends it if it does not.
 const CHECK_HIT: StringName = &"checkhit"
 
-## The effects whose list still has work after a miss, and so are not ended by
-## [constant CHECK_HIT]. `BattleCommand_CheckHit` ends nothing on the cartridge:
-## it writes `wAttackMissed` and the list runs to `failuretext`, which this engine
-## has none of, so the hit check ends the move instead. These three carry a
-## command between the two: Selfdestruct faints its user whether or not it
-## connected, `rolloutpower` breaks the chain, and `furycutter` zeroes its count.
+## The effects whose list still has work after a miss. `BattleCommand_CheckHit`
+## only writes `wAttackMissed` and the list runs on to `failuretext`; the hit
+## check ends the move here instead, and these three carry a command between.
 const CONTINUES_AFTER_MISS: Array[int] = [
 	Gen2MoveEffect.SELFDESTRUCT, Gen2MoveEffect.ROLLOUT, Gen2MoveEffect.FURY_CUTTER,
 ]
@@ -775,6 +768,9 @@ static func _do_turn(turn: Gen2Turn) -> void:
 	# check, so Struggle counts even though it spends nothing.
 	turn.attacker().turns_taken = (turn.attacker().turns_taken + 1) & 0xFF
 
+	# `DecrementPP` has no enemy half in Generation 1.
+	if turn.side == Gen2Battle.ENEMY and turn.battle.is_gen1():
+		return
 	if turn.slot >= 0 and turn.move_number != Gen2Damage.STRUGGLE:
 		turn.attacker().spend_pp(turn.slot)
 
@@ -1002,12 +998,8 @@ static func _hidden_power(turn: Gen2Turn) -> void:
 	_damage_stats(turn)
 
 
-## `BattleCommand_Present`: three power rows and a fourth that heals the target a
-## quarter of its maximum. The matchup and the accuracy roll come first and are
-## asked by the command itself, `present` sitting where `damagecalc` would with no
-## `failuretext` in front of `applydamage`. The heal is the target's: the source
-## switches turn, measures, switches back and calls `RestoreHP`, which reads the
-## side opposite whoever is acting.
+## `BattleCommand_Present`: three power rows and a fourth that heals the target
+## a quarter of its maximum, the matchup and the accuracy roll asked first.
 static func _present(turn: Gen2Turn) -> void:
 	var matchup: Dictionary = Gen2Damage.stab_damage(
 		turn.attacker(), turn.defender(), turn.effective_move(), 0
@@ -1102,12 +1094,9 @@ static func _reset_type_matchup(turn: Gen2Turn) -> void:
 	turn.effectiveness = Gen2Layout.MATCHUP_EFFECTIVE
 
 
-## `BattleCommand_HealBell`: every Pokémon in the user's party loses its status,
-## the one on the field included. The source zeroes all six bytes whether or not a
-## slot holds anything, so a shorter party is the same thing. Its trailing
-## `CalcPlayerStats` has no counterpart, a burn and a paralysis being applied when
-## a stat is read ([method Gen2BattleMon.stat]). Its opening `res
-## SUBSTATUS_NIGHTMARE` is the ringer's own, reached through Sleep Talk.
+## `BattleCommand_HealBell`: every party member loses its status. Its trailing
+## `CalcPlayerStats` has no counterpart, a burn being applied when a stat is
+## read, and its opening `res SUBSTATUS_NIGHTMARE` is reached through Sleep Talk.
 static func _heal_bell(turn: Gen2Turn) -> void:
 	for mon: Gen2BattleMon in turn.battle.party(turn.side).mons:
 		if mon == null:
@@ -1524,14 +1513,10 @@ static func _jump_kick_crash(turn: Gen2Turn) -> void:
 	})
 
 
-## Takes the damage off and reports what was taken.
-## `BattleCommand_ApplyDamage` rolls the defender's Focus Band first, and a band
-## that fires calls `BattleCommand_FalseSwipe`, leaving one hit point; the roll
-## happens whether or not the hit was lethal. The band sits in front of the
-## substitute routing, which is the source's order: `FalseSwipe` clamps against
-## the *real* health, so a band can fire, cut the figure, and have the doll spend
-## the cut figure with "hung on" printed anyway. `.update_damage_taken` then
-## returns early against a doll, which stops Counter answering a hit it took.
+## `BattleCommand_ApplyDamage` rolls the defender's Focus Band first, whether
+## or not the hit was lethal, and in front of the substitute routing: a band can
+## fire, cut the figure, and have the doll spend the cut figure with "hung on"
+## printed anyway. `.update_damage_taken` returns early against a doll.
 static func _apply_damage(turn: Gen2Turn) -> void:
 	if turn.missed or turn.damage <= 0:
 		return
@@ -1589,12 +1574,9 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
 
 
-## `DoSubstituteDamage`: the doll spends the hit and the health is never touched.
-## The damage is a sixteen-bit word against a one-byte counter, so anything from
-## 256 up breaks the doll without arithmetic and the subtraction breaks it on
-## exactly zero as well as on a borrow. `xor a / ld [hl], a` over the effect byte
-## then makes the rest of the list an ordinary attack, five effects exempted, and
-## `ResetDamage` closes both branches.
+## `DoSubstituteDamage`: a sixteen-bit word against a one-byte counter, so 256
+## up breaks the doll outright and the subtraction breaks it on zero too. `xor a`
+## over the effect byte makes the rest of the list an ordinary attack.
 static func _substitute_damage(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	turn.emit(Gen2Battle.SUBSTITUTE_TOOK_DAMAGE, {"target": turn.target})
@@ -1712,13 +1694,9 @@ static func _recoil(turn: Gen2Turn) -> void:
 	})
 
 
-## The defender first, then the attacker, the order they can go down in. A
-## defender that went down ends the move, `BattleCommand_CheckFaint` finishing on
-## `jp EndMoveEffect`, so every secondary status and [constant TRAP_TARGET] behind
-## it is skipped; the attacker going down to recoil ends nothing, the cartridge
-## testing only the opponent's HP. The commands behind it keep their own
-## fainted-target check, since a list with no faint step can still reach one
-## through [constant BEAT_UP].
+## A defender that went down ends the move, `BattleCommand_CheckFaint`
+## finishing on `jp EndMoveEffect`; the attacker going down to recoil ends
+## nothing, the cartridge testing only the opponent's HP.
 static func _check_faint(turn: Gen2Turn) -> void:
 	_destiny_bond_takes_user(turn)
 	for side: int in [turn.target, turn.side]:
@@ -1728,13 +1706,9 @@ static func _check_faint(turn: Gen2Turn) -> void:
 		turn.end()
 
 
-## The Destiny Bond half of `BattleCommand_CheckFaint`, the one reader of the
-## flag, and it reads the *target's*. The health is emptied rather than damaged,
-## the source zeroing both bytes of `wBattleMonHP` by hand, so no held item,
-## Endure or Focus Band stands between the bond and the attacker; sitting in front
-## of the loop below reports the target's faint first, the order the source's two
-## `HandleMonFaint` calls take. A user already down is not exempted, since
-## `recoil` runs in front of `checkfaint` in `RecoilHit`.
+## The Destiny Bond half of `BattleCommand_CheckFaint`, reading the target's
+## flag. The source zeroes `wBattleMonHP` by hand, so no item, Endure or Focus
+## Band stands between the bond and the attacker.
 static func _destiny_bond_takes_user(turn: Gen2Turn) -> void:
 	var target: Gen2BattleMon = turn.battle.mon(turn.target)
 	if not target.is_fainted():
@@ -1895,13 +1869,9 @@ static func _effect_chance(turn: Gen2Turn) -> void:
 		turn.failed_chance = true
 
 
-## Puts a status on the defender, or fails. One at a time: a Pokémon already
-## carrying something is refused, as is one whose type makes it immune, and only
-## sleep is rolled for a length.
-## The four `*Target` commands share their order: existing status, weather, type,
-## and only then `wEffectFailed`. Last is not cosmetic, the first step being the
-## one that does something besides refuse: a burn whose roll failed still reaches
-## `Defrost`.
+## The four `*Target` commands share their order: existing status, weather,
+## type, and only then `wEffectFailed`, so a burn whose roll failed still
+## reaches `Defrost`.
 static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.is_fainted():
@@ -1990,13 +1960,9 @@ static func _status_interrupts(turn: Gen2Turn, flag: int) -> void:
 		_cant_move(defender)
 
 
-## Whether the target's type refuses this status, which two of the five ask.
-## Poison asks `CheckIfTargetIsPoisonType`, comparing the target's types against
-## POISON rather than the move's, so a Poison-type is refused whatever poisons it.
-## Burn and freeze ask `CheckMoveTypeMatchesTarget`, comparing the *move's* type,
-## and its `.normal` branch returns non-zero without comparing, so Tri Attack can
-## burn and freeze anything. Sleep and paralysis ask neither, which is why Body
-## Slam paralyses a Ground-type.
+## Poison asks `CheckIfTargetIsPoisonType` against the target's types, burn and
+## freeze `CheckMoveTypeMatchesTarget` against the move's, whose `.normal`
+## branch lets Tri Attack burn anything, and sleep and paralysis ask neither.
 static func _status_type_refuses(turn: Gen2Turn, flag: int) -> bool:
 	var types: Array = turn.defender().types()
 	if flag == Gen2Status.POISON:
@@ -2136,14 +2102,9 @@ static func _drain_target(turn: Gen2Turn) -> void:
 	})
 
 
-## `BattleCommand_ConstantDamage`: the whole hit without the ordinary formula.
-## LEVEL_DAMAGE is the user's level, PSYWAVE a roll of it, SUPER_FANG half the
-## target's HP and STATIC_DAMAGE the power field. None criticals or announces an
-## effectiveness, the number having been multiplied by neither, which is what
-## [constant RESET_TYPE_MATCHUP] behind them says.
-## [constant Gen2MoveEffect.REVERSAL] shares the command and not the shape: it
-## sets a power and runs the formula, its list carrying `stab`, so Flail against a
-## Ghost really is super effective.
+## `BattleCommand_ConstantDamage`: the user's level, a roll of it, half the
+## target's HP or the power field, none of them multiplied or announced.
+## [constant Gen2MoveEffect.REVERSAL] shares the command and runs the formula.
 static func _fixed_damage(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -2219,12 +2180,8 @@ static func _check_charge(turn: Gen2Turn) -> void:
 	turn.skip_to = CHARGE
 
 
-## `BattleCommand_Charge`: the charging turn. It locks the user in, says its own
-## line and ends the move; Skull Bash carries on at [constant END_TURN], which is
-## where its Defense raise sits.
-## A user that is asleep gets `PrintButItFailed` instead, which is Sleep Talk
-## reaching a two-turn move: the source spends `movedelay` and `raisesub` before
-## the line.
+## `BattleCommand_Charge`: the charging turn, which Skull Bash carries on from
+## at [constant END_TURN]. A sleeping user is Sleep Talk's `PrintButItFailed`.
 static func _charge(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	if Gen2Status.is_asleep(mon.status):
@@ -2322,13 +2279,9 @@ static func _rollout_check(turn: Gen2Turn) -> void:
 		turn.skip_to = DO_TURN
 
 
-## `BattleCommand_RolloutPower`, both halves of Rollout: the count and the
-## doubling. It runs after `stab` and the hit check and before `damagevariation`,
-## so the doubling lands on the matched-up damage and the spread comes off the
-## doubled figure; a miss ends the chain, and a fifth hit clears the flag while
-## keeping its count. The count is raised before the doubling and one doubling
-## does nothing (`inc [hl]`, then `dec b / jr z`), so the first hit is worth its
-## own power and the fifth sixteen times it. Defense Curl adds one more.
+## `BattleCommand_RolloutPower`, after `stab` and before `damagevariation`. The
+## count is raised before the doubling and one doubling does nothing, so the
+## first hit is worth its own power and the fifth sixteen times it.
 static func _rollout_power(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	# Sleep Talk can call Rollout while the user remains asleep. The cartridge's
@@ -2451,12 +2404,9 @@ static func _gen1_cure_volatile(battle: Gen2Battle, side: int) -> void:
 	battle.reflect_turns[side] = 0
 
 
-## `TrappingEffect`. The counter goes on the target, where
-## [member Gen2BattleMon.trapped_turns] already lives, and Generation 1 spends it
-## by repeating the move rather than by bleeding: [method Gen2Battle.move_for]
-## forces the move on the user and [method _check_status] holds the target in
-## place. `.MultiturnMoveCheck` jumps past the damage calculation, the accuracy
-## roll and `DecrementPP`, which is the skip here.
+## `TrappingEffect`: Generation 1 spends the counter by repeating the move,
+## [method Gen2Battle.move_for] forcing it on the user and [method _check_status]
+## holding the target. `.MultiturnMoveCheck` skips the calculation and the roll.
 static func _gen1_trap_target(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.trapping_move != 0:
@@ -2571,12 +2521,9 @@ static func _psych_up(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.STAGES_COPIED)
 
 
-## Locks whichever of the target's slots holds
-## [member Gen2BattleMon.last_counter_move], searched for as the cartridge
-## searches, nothing the attacker did carrying the slot. Fails silently against a
-## target that has not moved, a last move of Struggle, an already disabled target,
-## a move no longer in the list (a mid-battle level up, which the cartridge never
-## has to consider), or a slot out of PP.
+## Locks the slot holding [member Gen2BattleMon.last_counter_move]. Silent
+## against a target that has not moved, Struggle, an already disabled target, a
+## move no longer in the list, or a slot out of PP.
 static func _disable(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.disabled_slot >= 0:
@@ -2682,13 +2629,9 @@ static func _focus_energy(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.FOCUS_ENERGY_SET)
 
 
-## Binds the target for three to six turns, of which
-## [method Gen2Battle._tick_wrap] spends the first without damage.
-## `BattleCommand_TrapTarget`'s three refusals in its order: a missed move, which
-## is structural here since [method _check_hit] ends the move first, a target
-## already bound, and a target behind a Substitute. All three are silent, the
-## cartridge printing nothing, and the doll check sits in front of `BattleRandom`,
-## so a bind aimed at one draws no roll.
+## `BattleCommand_TrapTarget`'s three silent refusals in order: a miss, a
+## target already bound, and one behind a Substitute, whose check sits in front
+## of `BattleRandom` so it draws no roll.
 static func _trap_target(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.trapped_turns > 0:
@@ -2872,13 +2815,9 @@ static func _nightmare(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.NIGHTMARE_STARTED, {"target": turn.target})
 
 
-## Two moves sharing a byte, told apart by the *user's* types: a Ghost curses the
-## target for half its own maximum, everybody else trades a stage of Speed for one
-## each of Attack and Defense. Those three are `LowerStat` and
-## `BattleCommand_AttackUp`/`..._DefenseUp` acting on the user's own stages with no
-## Mist, Substitute or `wEffectFailed` check, which is why they are stage moves
-## here rather than [method _stat_change] calls; `ResetMiss` between them stops a
-## Speed that could not fall from swallowing the raises.
+## Told apart by the user's types. The non-Ghost half is `LowerStat` and the two
+## `*Up`s on the user's own stages with no Mist or Substitute check, and
+## `ResetMiss` stops a Speed that could not fall from swallowing the raises.
 static func _curse(turn: Gen2Turn) -> void:
 	var user: Gen2BattleMon = turn.attacker()
 	if user.types().has(Gen2Layout.TYPE_GHOST):
@@ -2965,12 +2904,9 @@ static func _clear_hazards(turn: Gen2Turn) -> void:
 		turn.emit(Gen2Battle.RELEASED_BY, {"target": turn.target})
 
 
-## `ProtectChance`, which Protect, Detect and Endure all are: three gates, then a
-## roll whose odds halve per consecutive use, with the failure already reported
-## when it says no. The two gates in front are easy to get backwards: going second
-## fails outright, which is what makes two Protects a question of speed, and the
-## Substitute refused is the *user's own* (`BATTLE_VARS_SUBSTATUS4`, not `_OPP`),
-## so nothing about the target is asked.
+## `ProtectChance`: three gates, then a roll whose odds halve per consecutive
+## use. Going second fails outright, and the Substitute refused is the user's
+## own (`BATTLE_VARS_SUBSTATUS4`, not `_OPP`).
 static func _protect_chance(turn: Gen2Turn) -> bool:
 	var user: Gen2BattleMon = turn.attacker()
 	if turn.battle.opponent_went_first(turn.side):
@@ -3035,12 +2971,8 @@ static func _destiny_bond(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.DESTINY_BOND_SET)
 
 
-## `BattleCommand_ForceSwitch`: Whirlwind and Roar, with two endings. Against a
-## trainer the target's side switches to a random standing member; against a wild
-## the battle *ends* in either direction, `SetBattleDraw` making both a draw.
-## The source's `.trainer` and `.vs_trainer` are one routine here, every
-## difference between them being which side is read: the user's level against the
-## target's, the user having moved second, and a random member of that party.
+## `BattleCommand_ForceSwitch`: a random standing member against a trainer, a
+## draw against a wild in either direction.
 static func _force_switch(turn: Gen2Turn) -> void:
 	if FORCE_SWITCH_REFUSED_TYPES.has(turn.battle.battle_type) or turn.missed:
 		turn.emit(Gen2Battle.MOVE_FAILED)
@@ -3135,13 +3067,10 @@ static func _force_switch_wild(turn: Gen2Turn) -> void:
 	turn.emit(line, {"target": turn.target})
 
 
-## `BattleCommand_BatonPass`: switch, and hand the arrival everything the position
-## was carrying. The two halves differ in one thing, which is why this is the
-## first effect that cannot be resolved in one go: the enemy's target is picked by
-## the ordinary AI switch and the player's by `ForcePickSwitchMonInBattle`, a menu
-## inside the move that cannot be backed out of, so the turn stops here until
-## [method Gen2Battle.pass_to]. Committing a target before the turn would be
-## wrong: a pass that moves second is picked once the opponent's move has landed.
+## `BattleCommand_BatonPass`. The player's target is `ForcePickSwitchMonInBattle`,
+## a menu inside the move, so the turn stops here until
+## [method Gen2Battle.pass_to]: a pass that moves second is picked once the
+## opponent's move has landed.
 static func _baton_pass(turn: Gen2Turn) -> void:
 	var battle: Gen2Battle = turn.battle
 	var side: int = turn.side
@@ -3166,14 +3095,10 @@ static func _baton_pass(turn: Gen2Turn) -> void:
 	)
 
 
-## `BattleCommand_Teleport`: the user takes itself out of a wild battle, which
-## [method Gen2Battle.force_out] ends as a draw. Four refusals in the source's
-## order: the four scripted `wBattleType` values, Mean Look or Spider Web, a
-## trainer battle, and `BattleCommand_ForceSwitch`'s level comparison. The enemy's
-## half draws that roll and throws it away, `cp b / jr nc, .run_away` falling
-## straight into `.run_away`, so a wild Pokemon always teleports
-## (`docs/bugs_and_glitches.md`). Mirrored rather than fixed, and the roll is still
-## drawn so the generator moves the same way.
+## `BattleCommand_Teleport`: four refusals in order, the scripted `wBattleType`
+## values, Mean Look, a trainer battle, and the level comparison. The enemy's
+## half draws that roll and throws it away (`docs/bugs_and_glitches.md`), so a
+## wild always teleports; the roll is still drawn.
 static func _teleport(turn: Gen2Turn) -> void:
 	if FORCE_SWITCH_REFUSED_TYPES.has(turn.battle.battle_type) \
 		or Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.CANT_RUN) \
@@ -3196,13 +3121,8 @@ static func _teleport(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.FLED_FROM_BATTLE)
 
 
-## `BattleCommand_Foresight`: the flag that drops the target's evasion out of the
-## accuracy sum and opens the two Ghost immunities the matchup table keeps past
-## its `-2` marker. It sits on the target and nothing but a switch clears it. Two
-## refusals: a target that is flying or underground, and one already identified.
-## Only the second is reached through the cartridge's own list, since `checkhit`
-## in front of the command has already turned a hidden target away; the first is
-## kept for a registered list that carries no `checkhit`.
+## `BattleCommand_Foresight`: the flag that drops the target's evasion and
+## opens the two Ghost immunities past the table's `-2` marker.
 static func _foresight(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if _is_hidden(defender.substatus) \
@@ -3230,12 +3150,9 @@ static func _lock_on(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.TOOK_AIM)
 
 
-## `BattleCommand_Spite`: two to five PP off the slot holding the target's last
-## move, or what it has left. The slot is searched for the way [method _disable]
-## searches, and the guard for a move no longer in the list is this project's:
-## `.loop` there has no bound and would run off the end, reachable only through a
-## mid-battle level up. Four refusals, all `PrintDidntAffect2`: a target that has
-## not moved, a last move of Struggle, an empty slot, and that missing one.
+## `BattleCommand_Spite`: two to five PP off the target's last move. The guard
+## for a move no longer in the list is this project's: `.loop` has no bound and
+## would run off the end after a mid-battle level up.
 static func _spite(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	var last_move: int = defender.last_counter_move
@@ -3265,12 +3182,8 @@ static func _roll_spite_pp(rng: RandomNumberGenerator) -> int:
 const SPITE_MIN_PP: int = 2
 
 
-## `BattleCommand_PainSplit`: both Pokémon end on the floored average of the two
-## totals, neither above its own maximum. The health words are written by hand, so
-## no doll takes it, no Focus Band fires and no Endure clamps it, and both being
-## standing means the average is at least one. Two refusals, both
-## `PrintDidntAffect2`: a miss, already an ended move, and a target behind a
-## doll.
+## `BattleCommand_PainSplit`: the floored average, written by hand, so no doll,
+## Focus Band or Endure sees it. Refused against a target behind a doll.
 static func _pain_split(turn: Gen2Turn) -> void:
 	if _substitute_refuses(turn):
 		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
@@ -3290,12 +3203,8 @@ static func _pain_split(turn: Gen2Turn) -> void:
 	})
 
 
-## `BattleCommand_Thief`: the target's held item, onto a thief carrying none. The
-## cartridge writes the battle struct and the party struct, being two copies of
-## one Pokémon; [method Gen2Battle.mon] hands back the party member itself, so one
-## write is both. Four silent refusals in the source's order: the thief holds
-## something, the target holds nothing, the item is mail, and the chance came up
-## short, read last because `effectchance` drew its roll earlier.
+## `BattleCommand_Thief`: four silent refusals in order, the chance read last
+## because `effectchance` drew its roll earlier.
 static func _thief(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -3321,13 +3230,8 @@ static func _pursuit(turn: Gen2Turn) -> void:
 	turn.damage = mini(turn.damage * 2, 0xFFFF)
 
 
-## `BattleCommand_BeatUp`: one pass of the loop, which picks the party member
-## this hit is worked out from and loads the formula's two numbers off its base
-## stats. `damagecalc` never sees `damagestats`, so no item, screen, stage or
-## truncation touches either figure, and there is no `stab`, so the modifier
-## stays `EFFECTIVE` and no effectiveness is announced.
-## A member with no health or any status takes `.beatup_fail`, which skips
-## forward to `buildopponentrage`: the hit is not spent and the loop carries on.
+## `BattleCommand_BeatUp`: one pass, the formula's two numbers off the member's
+## base stats with no item, screen, stage or `stab`.
 static func _beat_up(turn: Gen2Turn) -> void:
 	turn.damage = 0
 	var battle: Gen2Battle = turn.battle
@@ -3406,13 +3310,9 @@ static func _safeguard_refuses(turn: Gen2Turn, side: int) -> bool:
 	return Gen2Screens.has(turn.battle.screens[side], Gen2Screens.SAFEGUARD)
 
 
-## `BattleCommand_Heal`: Recover, Softboiled and Milk Drink take back half the
-## maximum; Rest takes back all of it and pays for that with two turns asleep.
-## The full-HP refusal is checked before anything else, so Rest at full health
-## fails and stays awake even when there is a status sitting on it that sleeping
-## would have cleared. Rest writes `REST_SLEEP_TURNS + 1` over the whole status
-## byte rather than into the sleep bits, which is why it is the one move that
-## cures a burn or a paralysis, and it clears Toxic's ramp with it.
+## `BattleCommand_Heal`. The full-HP refusal comes first, so Rest at full health
+## fails whatever status sits on it; it writes `REST_SLEEP_TURNS + 1` over the
+## whole status byte, which is why it cures a burn or a paralysis.
 static func _heal(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	if attacker.hp >= attacker.max_hp():
@@ -3435,12 +3335,9 @@ static func _heal(turn: Gen2Turn) -> void:
 	})
 
 
-## `BattleCommand_TimeBasedHealContinue`: Morning Sun, Synthesis and Moonlight.
-## Half the maximum by default. One step down the table outside the move's own
-## time of day, which is the cartridge's real rule: matching the clock buys
-## nothing, missing it costs. Then one step up in sun, or one step down in any
-## other weather, so the worst case is an eighth and the best is the whole bar.
-## Link battles skip the time step.
+## `BattleCommand_TimeBasedHealContinue`: half by default, one step down outside
+## the move's own time of day, one up in sun or down in other weather. Link
+## battles skip the time step.
 static func _timed_heal(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	if attacker.hp >= attacker.max_hp():
@@ -3501,12 +3398,8 @@ static func _skip_sun_charge(turn: Gen2Turn) -> void:
 		turn.skip_to = CHARGE
 
 
-## `PlayFXAnimID`. Nothing is drawn here: the animation is written down as an
-## event at its own place in the turn and the screen is what spends frames on it.
-## [param on_opponent] is `PlayOpponentBattleAnim`'s pair of
-## `BattleCommand_SwitchTurn` calls: the same event with `hBattleTurn` inverted
-## for the length of the animation, so it plays on the target rather than on
-## whoever is acting.
+## `PlayFXAnimID`, as an event the screen spends frames on. [param on_opponent]
+## is `PlayOpponentBattleAnim`'s `hBattleTurn` inversion.
 static func _play_fx_anim(
 	turn: Gen2Turn, index: int, after_anim: int, restore_user_pic: bool = false,
 	on_opponent: bool = false

--- a/game/battle/gen1_trainer_ai.gd
+++ b/game/battle/gen1_trainer_ai.gd
@@ -1,0 +1,320 @@
+class_name Gen1TrainerAI
+extends RefCounted
+
+## `engine/battle/trainer_ai.asm` and `SelectEnemyMove`: how a Generation 1
+## opponent picks its move and what a class does in front of it. [Gen2BattleAI]
+## is Crystal's, and no [Gen2Rules] flag reshapes this one.
+
+## `wBuffer`'s starting score, the disabled slot's, and layer 1's nudge.
+const BASE_SCORE: int = 10
+const DISABLED_SCORE: int = 0x50
+const STATUS_PENALTY: int = 5
+
+## `.chooseRandomMove`'s three `cp`s over one byte: 64, 64, 63 and 65 of 256.
+const SLOT_ROLL_BOUNDS: Array[int] = [64, 128, 191]
+## A refused slot is rolled again; the cap only bounds a party with no slot.
+const ROLL_CAP: int = 64
+
+## `StatusAilmentMoveEffects`, the cartridge's own bytes (`gen1_effect`).
+const STATUS_AILMENT_EFFECTS: Array[int] = [0x01, 0x20, 0x42, 0x43]
+## `AIMoveChoiceModification2`'s two `cp` ranges: ATTACK_UP1 to BIDE and
+## ATTACK_UP2 to POISON, each end exclusive.
+const SETUP_RANGES: Array = [[0x0A, 0x1A], [0x32, 0x42]]
+## `.loopMoves`' three effects, and `AIGetTypeEffectiveness`' initial `$10`
+## where EFFECTIVE is 10: a chart row of 10 would read as resisted.
+const SUPER_FANG_EFFECT: int = 0x28
+const SPECIAL_DAMAGE_EFFECT: int = 0x29
+const FLY_EFFECT: int = 0x2B
+const EFFECTIVENESS_INITIAL: int = 0x10
+
+## Items in Generation 1's numbering.
+const FULL_RESTORE: int = 0x10
+const HYPER_POTION: int = 0x12
+const SUPER_POTION: int = 0x13
+const POTION: int = 0x14
+const FULL_HEAL: int = 0x34
+const GUARD_SPEC: int = 0x37
+const X_ATTACK: int = 0x41
+const X_DEFEND: int = 0x42
+const X_SPEED: int = 0x43
+## `AIRecoverHP`'s three `ld b`s.
+const POTION_AMOUNTS: Dictionary = {POTION: 20, SUPER_POTION: 50, HYPER_POTION: 200}
+
+## `TrainerAIPointers`' routines as steps over one `Random` byte: `unless_*`
+## are the `ret`s, `if_*` Agatha's `jp c`, `do` the `AIUse*` or the switch.
+## `cooltrainer_f`'s `ret nc` is commented out, so its roll never applies.
+const ROUTINES: Dictionary = {
+	"generic": [],
+	"juggler": [{"unless_roll": 65}, {"do": "switch"}],
+	"blackbelt": [{"unless_roll": 32}, {"do": X_ATTACK}],
+	"giovanni": [{"unless_roll": 65}, {"do": GUARD_SPEC}],
+	"cooltrainer_m": [{"unless_roll": 65}, {"do": X_ATTACK}],
+	"cooltrainer_f": [{"if_hp": 10, "do": HYPER_POTION}, {"unless_hp": 5}, {"do": "switch"}],
+	"brock": [{"unless_status": true}, {"do": FULL_HEAL}],
+	"misty": [{"unless_roll": 65}, {"do": X_DEFEND}],
+	"lt_surge": [{"unless_roll": 65}, {"do": X_SPEED}],
+	"erika": [{"unless_roll": 129}, {"unless_hp": 10}, {"do": SUPER_POTION}],
+	"koga": [{"unless_roll": 65}, {"do": X_ATTACK}],
+	"koga_yellow": [{"unless_roll": 32}, {"do": X_ATTACK}],
+	"blaine": [{"unless_roll": 65}, {"do": SUPER_POTION}],
+	"blaine_yellow": [{"unless_roll": 65}, {"unless_hp": 10}, {"do": SUPER_POTION}],
+	"sabrina": [{"unless_roll": 65}, {"unless_hp": 10}, {"do": HYPER_POTION}],
+	"sabrina_yellow": [{"unless_roll": 65}, {"do": X_DEFEND}],
+	"rival2": [{"unless_roll": 32}, {"unless_hp": 5}, {"do": POTION}],
+	"rival3": [{"unless_roll": 32}, {"unless_hp": 5}, {"do": FULL_RESTORE}],
+	"lorelei": [{"unless_roll": 129}, {"unless_hp": 5}, {"do": SUPER_POTION}],
+	"bruno": [{"unless_roll": 65}, {"do": X_DEFEND}],
+	"agatha": [
+		{"if_roll": 20, "do": "switch"}, {"unless_roll": 129}, {"unless_hp": 4},
+		{"do": SUPER_POTION},
+	],
+	"lance": [{"unless_roll": 129}, {"unless_hp": 5}, {"do": HYPER_POTION}],
+}
+
+## `TrainerAI`'s `.done` tests on Yellow: the two status words' lock bits.
+const LOCKED_SUBSTATUSES: Array[int] = [
+	Gen2Substatus.CHARGING, Gen2Substatus.RAMPAGING, Gen2Substatus.BIDE, Gen2Substatus.RAGE,
+]
+
+## `wAICount`'s fresh value, replaced by the class's count on the first pass.
+const COUNT_UNLOADED: int = -1
+
+
+## `SelectEnemyMove` from `.canSelectMove` on. The locks in front of it keep
+## the old choice on the cartridge; here [method Gen2Battle.move_for] answers
+## for a locked Pokémon whatever slot it is asked for.
+static func select_slot(battle: Gen2Battle, rng: RandomNumberGenerator) -> int:
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	if enemy.moves.size() < 2 or int(enemy.moves[1]) == 0:
+		return 0
+	var enabled: Array = enabled_slots(battle) if battle.is_trainer_battle \
+		else _existing_slots(enemy)
+	for _attempt: int in ROLL_CAP:
+		var slot: int = roll_slot(rng)
+		if slot == enemy.disabled_slot or slot >= enemy.moves.size():
+			continue
+		if int(enemy.moves[slot]) == 0 or not bool(enabled[slot]):
+			continue
+		return slot
+	return 0
+
+
+## `.chooseRandomMove`'s one byte against its three bounds.
+static func roll_slot(rng: RandomNumberGenerator) -> int:
+	var roll: int = rng.randi_range(0, 255)
+	for slot: int in SLOT_ROLL_BOUNDS.size():
+		if roll < SLOT_ROLL_BOUNDS[slot]:
+			return slot
+	return SLOT_ROLL_BOUNDS.size()
+
+
+static func _existing_slots(enemy: Gen2BattleMon) -> Array:
+	var out: Array = []
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		out.append(slot < enemy.moves.size() and int(enemy.moves[slot]) != 0)
+	return out
+
+
+## `AIEnemyTrainerChooseMoves`: the slots the layers leave at the lowest score.
+static func enabled_slots(battle: Gen2Battle) -> Array:
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	var layers: Array = _attributes(battle).get("ai_layers", [])
+	if layers.is_empty():
+		return _existing_slots(enemy)
+	var scores: Array = score_slots(battle, layers)
+	var lowest: int = DISABLED_SCORE + 1
+	for slot: int in _move_count(enemy):
+		lowest = mini(lowest, int(scores[slot]))
+	var out: Array = []
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		out.append(slot < _move_count(enemy) and int(scores[slot]) == lowest)
+	return out
+
+
+## The four scores after every layer in [param layers] has run.
+static func score_slots(battle: Gen2Battle, layers: Array) -> Array:
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	var scores: Array = [BASE_SCORE, BASE_SCORE, BASE_SCORE, BASE_SCORE]
+	if enemy.disabled_slot >= 0 and enemy.disabled_slot < scores.size():
+		scores[enemy.disabled_slot] = DISABLED_SCORE
+	for layer: int in layers:
+		match layer:
+			1:
+				_discourage_status_moves(battle, scores)
+			2:
+				_encourage_setup_moves(battle, scores)
+			3:
+				_weigh_type_matchups(battle, scores)
+	return scores
+
+
+## `.loopDecrementEntries` stops at the first empty slot.
+static func _move_count(enemy: Gen2BattleMon) -> int:
+	for slot: int in enemy.moves.size():
+		if int(enemy.moves[slot]) == 0:
+			return slot
+	return enemy.moves.size()
+
+
+static func _attributes(battle: Gen2Battle) -> Dictionary:
+	if battle.data == null or battle.enemy_trainer_class <= 0:
+		return {}
+	return battle.data.trainer_attributes(battle.enemy_trainer_class)
+
+
+static func _move(battle: Gen2Battle, number: int) -> Dictionary:
+	return battle.data.move(number) if battle.data != null else {}
+
+
+## `AIMoveChoiceModification1`.
+static func _discourage_status_moves(battle: Gen2Battle, scores: Array) -> void:
+	if battle.mon(Gen2Battle.PLAYER).status == Gen2Status.NONE:
+		return
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	for slot: int in _move_count(enemy):
+		var move: Dictionary = _move(battle, int(enemy.moves[slot]))
+		if int(move.get("power", 0)) != 0:
+			continue
+		if STATUS_AILMENT_EFFECTS.has(int(move.get("gen1_effect", -1))):
+			scores[slot] = int(scores[slot]) + STATUS_PENALTY
+
+
+## `AIMoveChoiceModification2`, the opponent's second move alone.
+static func _encourage_setup_moves(battle: Gen2Battle, scores: Array) -> void:
+	if battle.gen1_enemy_moves != 1:
+		return
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	for slot: int in _move_count(enemy):
+		var effect: int = int(_move(battle, int(enemy.moves[slot])).get("gen1_effect", -1))
+		for range_pair: Array in SETUP_RANGES:
+			if effect >= int(range_pair[0]) and effect < int(range_pair[1]):
+				scores[slot] = int(scores[slot]) - 1
+				break
+
+
+## `AIMoveChoiceModification3`.
+static func _weigh_type_matchups(battle: Gen2Battle, scores: Array) -> void:
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	var player_types: Array = battle.mon(Gen2Battle.PLAYER).types()
+	for slot: int in _move_count(enemy):
+		var move: Dictionary = _move(battle, int(enemy.moves[slot]))
+		var effectiveness: int = battle.data.first_matchup(int(move.get("type", 0)), player_types)
+		if effectiveness < 0:
+			effectiveness = EFFECTIVENESS_INITIAL
+		if effectiveness == EFFECTIVENESS_INITIAL:
+			continue
+		if effectiveness > EFFECTIVENESS_INITIAL:
+			scores[slot] = int(scores[slot]) - 1
+		elif _has_better_move(battle, enemy, int(move.get("type", 0))):
+			scores[slot] = int(scores[slot]) + 1
+
+
+## `.loopMoves`, which walks the weighed move too and counts it by effect.
+static func _has_better_move(battle: Gen2Battle, enemy: Gen2BattleMon, type: int) -> bool:
+	for slot: int in _move_count(enemy):
+		var move: Dictionary = _move(battle, int(enemy.moves[slot]))
+		var effect: int = int(move.get("gen1_effect", -1))
+		if effect in [SUPER_FANG_EFFECT, SPECIAL_DAMAGE_EFFECT, FLY_EFFECT]:
+			return true
+		if int(move.get("type", 0)) != type and int(move.get("power", 0)) != 0:
+			return true
+	return false
+
+
+## `TrainerAI`: the item or switch taken instead of the move as a [Gen2Battle]
+## action, or empty for a turn the class lets the move through.
+static func trainer_action(battle: Gen2Battle, rng: RandomNumberGenerator) -> Dictionary:
+	if not battle.is_trainer_battle or battle.is_link_battle or battle.gen1_ai_count == 0:
+		return {}
+	if battle.data != null and Gen1Layout.trainer_ai_respects_lock(battle.data.id) \
+		and _locked(battle.mon(Gen2Battle.ENEMY)):
+		return {}
+	var attributes: Dictionary = _attributes(battle)
+	if attributes.is_empty():
+		return {}
+	if battle.gen1_ai_count == COUNT_UNLOADED:
+		battle.gen1_ai_count = int(attributes.get("ai_count", 0))
+	var roll: int = rng.randi_range(0, 255)
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	for step: Dictionary in ROUTINES.get(String(attributes.get("ai_routine", "")), []):
+		if _step_returns(step, enemy, roll):
+			return {}
+		if _step_taken(step, enemy, roll) and step.has("do"):
+			return _do(battle, step["do"])
+	return {}
+
+
+## The `ret`s.
+static func _step_returns(step: Dictionary, enemy: Gen2BattleMon, roll: int) -> bool:
+	if step.has("unless_roll") and roll >= int(step["unless_roll"]):
+		return true
+	if step.has("unless_hp") and not _hp_below(enemy, int(step["unless_hp"])):
+		return true
+	return step.has("unless_status") and enemy.status == Gen2Status.NONE
+
+
+## The conditional jumps, passed over when their test fails.
+static func _step_taken(step: Dictionary, enemy: Gen2BattleMon, roll: int) -> bool:
+	if step.has("if_roll") and roll >= int(step["if_roll"]):
+		return false
+	return not (step.has("if_hp") and not _hp_below(enemy, int(step["if_hp"])))
+
+
+static func _locked(enemy: Gen2BattleMon) -> bool:
+	for flag: int in LOCKED_SUBSTATUSES:
+		if Gen2Substatus.has(enemy.substatus, flag):
+			return true
+	return false
+
+
+## `AICheckIfHPBelowFraction`, the quotient truncated.
+static func _hp_below(enemy: Gen2BattleMon, fraction: int) -> bool:
+	@warning_ignore("integer_division")
+	return enemy.hp < enemy.max_hp() / fraction
+
+
+## A switch spends no count: `SwitchEnemyMon` skips `DecrementAICount`.
+static func _do(battle: Gen2Battle, what: Variant) -> Dictionary:
+	if what is String:
+		var index: int = switch_target(battle.party(Gen2Battle.ENEMY))
+		return Gen2Battle.switch_to(index) if index >= 0 else {}
+	battle.gen1_ai_count -= 1
+	return Gen2Battle.use_item(int(what))
+
+
+## `AISwitchIfEnoughMons`, then `EnemySendOutFirstMon`'s `.next2`: the first
+## standing member that is not out, or -1.
+static func switch_target(party: Gen2Party) -> int:
+	if party.healthy_count() < 2:
+		return -1
+	for index: int in party.size():
+		var member: Gen2BattleMon = party.at(index)
+		if index != party.active and member != null and not member.is_fainted():
+			return index
+	return -1
+
+
+## The `AIUse*` half, in the shape [method Gen2AIItems.apply] answers. Guard
+## Spec raises Mist whether or not it stands; an X item is
+## `StatModifierUpEffect` over the enemy.
+static func apply_item(battle: Gen2Battle, user: Gen2BattleMon, item: int) -> Dictionary:
+	if POTION_AMOUNTS.has(item):
+		return {"healed": user.heal(int(POTION_AMOUNTS[item]))}
+	if item == FULL_RESTORE:
+		var cured: bool = _cure_status(user)
+		return {"healed": user.heal(user.max_hp()), "cured": cured}
+	if item == FULL_HEAL:
+		return {"cured": _cure_status(user)}
+	if item == GUARD_SPEC:
+		user.substatus |= Gen2Substatus.MIST
+		return {"substatus": Gen2Substatus.MIST}
+	var raised: Dictionary = battle.apply_x_item(user, item)
+	return {"stat": String(raised.get("stat", "")), "raised": bool(raised.get("ok", false))}
+
+
+## `AICureStatus`: the status byte and `BADLY_POISONED`.
+static func _cure_status(user: Gen2BattleMon) -> bool:
+	var had: bool = user.status != Gen2Status.NONE
+	user.status = Gen2Status.NONE
+	user.toxic_counter = 0
+	return had

--- a/game/battle/gen1_trainer_ai.gd.uid
+++ b/game/battle/gen1_trainer_ai.gd.uid
@@ -1,0 +1,1 @@
+uid://dml3m3v31ft37

--- a/game/battle/trainer_party.gd
+++ b/game/battle/trainer_party.gd
@@ -16,8 +16,10 @@ extends RefCounted
 ##
 ## [param rules] defaults to the installed set, which is the run's; a caller
 ## holding a battle's own passes it rather than installing it.
+## [param context] is `ReadTrainer`'s `lone_attack` and `rival_starter`.
 static func build(
-	data: GameData, trainer_class: int, index: int, rules: Gen2Rules = null
+	data: GameData, trainer_class: int, index: int, rules: Gen2Rules = null,
+	context: Dictionary = {}
 ) -> Gen2Party:
 	if data == null:
 		return null
@@ -41,8 +43,47 @@ static func build(
 		members.append(
 			Gen2BattleMon.create(data, species, level, moves, dvs, trained, int(mon["item"]))
 		)
+	apply_special_moves(data, members, trainer.get("special_moves", []), context)
 
 	return Gen2Party.create(members)
+
+
+## `ReadTrainer`'s tail: each row a move written over one member's slot after
+## `AddPartyMon` filled it, gated on `wLoneAttackNo` or picked by
+## `wRivalStarter`. No PP is written beside it and the enemy's is never spent,
+## so an empty slot takes the move's own.
+static func apply_special_moves(
+	data: GameData, members: Array, rows: Array, context: Dictionary
+) -> void:
+	var lone: int = int(context.get("lone_attack", 0))
+	for row: Dictionary in rows:
+		if row.has("lone") and int(row["lone"]) != lone:
+			continue
+		var member: Gen2BattleMon = members[int(row["member"]) - 1] \
+			if int(row["member"]) <= members.size() else null
+		if member == null:
+			continue
+		var move: int = int(row.get("move", 0))
+		if row.has("starter"):
+			move = _starter_move(row["starter"], int(context.get("rival_starter", 0)))
+		var slot: int = int(row["slot"]) - 1
+		while member.moves.size() <= slot:
+			member.moves.append(0)
+			member.pp.append(0)
+		member.moves[slot] = move
+		if int(member.pp[slot]) == 0:
+			member.pp[slot] = int(data.move(move).get("pp", 0))
+
+
+## `.GiveStarterMove`: species 0 is the line every other value takes.
+static func _starter_move(rows: Array, starter: int) -> int:
+	var fallback: int = 0
+	for row: Dictionary in rows:
+		if int(row["species"]) == starter:
+			return int(row["move"])
+		if int(row["species"]) == 0:
+			fallback = int(row["move"])
+	return fallback
 
 
 ## What one of this trainer's Pokémon knows: its own stored moves if the

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1776,6 +1776,17 @@ func _matchup_row(key: int) -> Dictionary:
 	}
 
 
+## `AIGetTypeEffectiveness`: the first chart row hitting either of
+## [param defending], or -1. The walk returns on the first match, so a dual
+## type answers with whichever of its two the table lists first.
+func first_matchup(attacking: int, defending: Array) -> int:
+	for key: int in _matchups.keys():
+		for kind: int in defending:
+			if key == Gen2ContentOverlay.matchup_number(attacking, kind):
+				return int(_matchups[key])
+	return -1
+
+
 ## How effective [param attacking] is against a defender of one or two types, in
 ## tenths, accumulated the way the cartridge accumulates it: start at ten,
 ## multiply by each matching type in turn, truncate after each.
@@ -3008,6 +3019,8 @@ func trainer_party(number: int, index: int) -> Dictionary:
 		"name": String(entry.get("name", "")),
 		"type": int(entry.get("type", 0)),
 		"party": party,
+		## Generation 1's `ReadTrainer` rows, see [method Gen2TrainerParty.apply_special_moves].
+		"special_moves": (entry.get("special_moves", []) as Array).duplicate(true),
 	}
 
 
@@ -3020,12 +3033,19 @@ func trainer_attributes(number: int) -> Dictionary:
 		return {}
 
 	var attributes: Dictionary = entry.get("attributes", {})
+	var layers: Array = []
+	for layer: Variant in attributes.get("ai_layers", []) as Array:
+		layers.append(int(layer))
 	return {
 		"item1": int(attributes.get("item1", 0)),
 		"item2": int(attributes.get("item2", 0)),
 		"base_reward": int(attributes.get("base_reward", 0)),
 		"ai_move_weights": int(attributes.get("ai_move_weights", 0)),
 		"ai_item_switch": int(attributes.get("ai_item_switch", 0)),
+		## `TrainerClassMoveChoiceModifications` and `TrainerAIPointers`.
+		"ai_layers": layers,
+		"ai_count": int(attributes.get("ai_count", 0)),
+		"ai_routine": String(attributes.get("ai_routine", "")),
 	}
 
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -131,6 +131,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_dex_entries,
 	_verify_trainer_names,
 	_verify_trainer_parties,
+	_verify_trainer_ai,
 	_verify_palettes,
 	_verify_wild_constants,
 	_verify_pic_pointers,
@@ -185,6 +186,7 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"bicycle": ["bicycle_text", Gen1Layout.BICYCLE_TEXT_AT],
 	"poke_flute": ["poke_flute_text", Gen1Layout.POKE_FLUTE_TEXT_AT],
 	"safari_battle": ["safari_battle_text", Gen1Layout.SAFARI_BATTLE_TEXT_AT],
+	"trainer_ai": ["trainer_ai_text", Gen1Layout.TRAINER_AI_TEXT_AT],
 	"safari": ["safari_game_over_text", Gen1Layout.SAFARI_TEXT_AT],
 	"safari_item": ["safari_item_text", Gen1Layout.SAFARI_ITEM_TEXT_AT],
 	"start_menu": ["start_menu_text", Gen1Layout.START_MENU_TEXT_AT],
@@ -767,6 +769,33 @@ static func _verify_trainer_parties(rom: RomFile, layout: Dictionary) -> Diction
 	return _ok()
 
 
+## Every layer id, routine pointer and special-move row is one the tables name.
+static func _verify_trainer_ai(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var layers: Array = read_move_choices(rom, layout)
+	var ai: Array = read_trainer_ai(rom, layout)
+	for index: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		for layer: int in layers[index] as Array:
+			if layer < 1 or layer > Gen1Layout.TRAINER_AI_LAYER_COUNT:
+				return _fail("Trainer class %d runs AI layer %d." % [index + 1, layer])
+		if String((ai[index] as Dictionary)["routine"]).is_empty():
+			return _fail("Trainer class %d's AI routine is not named." % (index + 1))
+	var parties: Array = _read_trainer_parties(rom, layout)
+	_attach_special_moves(rom, layout, parties)
+	var rows: int = 0
+	for class_parties: Array in parties:
+		for party: Dictionary in class_parties:
+			for row: Dictionary in party.get("special_moves", []) as Array:
+				rows += 1
+				if int(row["slot"]) < 1 or int(row["slot"]) > Gen2Learnset.MOVE_SLOTS \
+					or int(row["member"]) < 1 or int(row["member"]) > Gen2Party.MAX_SIZE:
+					return _fail("A special move row names member %d, slot %d." % [
+						int(row["member"]), int(row["slot"]),
+					])
+	if rows == 0:
+		return _fail("No trainer carries a special move.")
+	return _ok()
+
+
 ## One facility box, already laid out. Empty for a stub that does not decode.
 static func facility_text(rom: RomFile, at: int) -> String:
 	if at < 0:
@@ -1245,6 +1274,8 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 			"effect": Gen1Layout.move_effect(
 				move, rom.u8(entry + Gen1Layout.MOVE_EFFECT)
 			),
+			# The byte itself too, which `AIMoveChoiceModification*` compare.
+			"gen1_effect": rom.u8(entry + Gen1Layout.MOVE_EFFECT),
 			"power": Gen1Layout.move_power(
 				move, rom.u8(entry + Gen1Layout.MOVE_POWER)
 			),
@@ -1813,10 +1844,14 @@ func _import_trainers(rom: RomFile, layout: Dictionary) -> Array:
 		MAX_NAME_LENGTH,
 	)
 	var parties: Array = _read_trainer_parties(rom, layout)
+	_attach_special_moves(rom, layout, parties)
+	var layers: Array = read_move_choices(rom, layout)
+	var ai: Array = read_trainer_ai(rom, layout)
 	var out: Array = []
 	for trainer_class: int in range(1, Gen1Layout.TRAINER_CLASS_COUNT + 1):
 		var row: int = int(layout["trainer_pics"]) \
 			+ (trainer_class - 1) * Gen1Layout.TRAINER_PIC_SIZE
+		var routine: Dictionary = ai[trainer_class - 1]
 		out.append({
 			"number": trainer_class,
 			"name": names[trainer_class - 1],
@@ -1826,10 +1861,116 @@ func _import_trainers(rom: RomFile, layout: Dictionary) -> Array:
 				"base_reward": _bcd3(
 					rom, row + Gen1Layout.POINTER_SIZE, Gen1Layout.POINTER_SIZE
 				),
+				"ai_layers": layers[trainer_class - 1],
+				"ai_count": int(routine["count"]),
+				"ai_routine": String(routine["routine"]),
 			},
 			"trainers": parties[trainer_class - 1],
 		})
 	return out
+
+
+## `TrainerClassMoveChoiceModifications`, one zero-ended list a class.
+static func read_move_choices(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout["trainer_move_choices"])
+	var out: Array = []
+	for _trainer_class: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		var layers: Array = []
+		while rom.in_bounds(at, 1) and rom.u8(at) != 0:
+			layers.append(rom.u8(at))
+			at += 1
+		at += 1
+		out.append(layers)
+	return out
+
+
+## `TrainerAIPointers`: a use count and the routine's name, empty for a
+## pointer [constant Gen1Layout.TRAINER_AI_ROUTINES] does not carry.
+static func read_trainer_ai(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout["trainer_ai_pointers"])
+	var out: Array = []
+	for trainer_class: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		var at: int = table + trainer_class * Gen1Layout.TRAINER_AI_ROW_SIZE
+		out.append({
+			"count": rom.u8(at),
+			"routine": Gen1Layout.trainer_ai_routine(rom.id, rom.u16le(at + 1)),
+		})
+	return out
+
+
+## The moves `ReadTrainer` writes over a filled party, `member` and `slot`
+## counted from one. Red and Blue's rows carry a `lone` gate, `wLoneAttackNo`'s
+## value or 0 for `.AddTeamMove`'s side.
+static func _attach_special_moves(rom: RomFile, layout: Dictionary, parties: Array) -> void:
+	if layout.has("special_trainer_moves"):
+		_attach_yellow_special_moves(rom, layout, parties)
+	else:
+		_attach_red_special_moves(rom, layout, parties)
+	for class_parties: Array in parties:
+		for party: Dictionary in class_parties:
+			party.erase("special")
+
+
+## `.SpecialTrainer`'s tail. `.LoopTrainerData` ends on `.FinishUp`, so a
+## level-shared party takes no row.
+static func _attach_red_special_moves(rom: RomFile, layout: Dictionary, parties: Array) -> void:
+	var lone: Array = []
+	var lone_at: int = int(layout["lone_moves"])
+	for row: int in Gen1Layout.LONE_MOVE_COUNT:
+		lone.append({
+			"member": rom.u8(lone_at + row * Gen1Layout.LONE_MOVE_SIZE) + 1,
+			"slot": Gen1Layout.SPECIAL_MOVE_SLOT,
+			"move": rom.u8(lone_at + row * Gen1Layout.LONE_MOVE_SIZE + 1),
+			"lone": row + 1,
+		})
+	var team: Dictionary = {}
+	var team_at: int = int(layout["team_moves"])
+	while rom.u8(team_at) != Gen1Layout.TEAM_MOVE_END:
+		team[rom.u8(team_at)] = rom.u8(team_at + 1)
+		team_at += Gen1Layout.LONE_MOVE_SIZE
+	for index: int in parties.size():
+		var trainer_class: int = index + 1
+		for party: Dictionary in parties[index] as Array:
+			if not bool(party.get("special", false)):
+				continue
+			var rows: Array = lone.duplicate(true)
+			if team.has(trainer_class):
+				rows.append({
+					"member": Gen1Layout.TEAM_MOVE_MEMBER, "slot": Gen1Layout.SPECIAL_MOVE_SLOT,
+					"move": int(team[trainer_class]), "lone": 0,
+				})
+			elif trainer_class == Gen1Layout.RIVAL3_CLASS:
+				rows.append({
+					"member": Gen1Layout.CHAMPION_BIRD_MEMBER, "slot": Gen1Layout.SPECIAL_MOVE_SLOT,
+					"move": Gen1Layout.CHAMPION_BIRD_MOVE, "lone": 0,
+				})
+				rows.append({
+					"member": Gen1Layout.CHAMPION_STARTER_MEMBER,
+					"slot": Gen1Layout.SPECIAL_MOVE_SLOT,
+					"starter": Gen1Layout.CHAMPION_STARTER_MOVES.duplicate(true), "lone": 0,
+				})
+			party["special_moves"] = rows
+
+
+## `SpecialTrainerMoves`: `db class, id`, `db member, slot, move` rows, a zero.
+static func _attach_yellow_special_moves(rom: RomFile, layout: Dictionary, parties: Array) -> void:
+	var at: int = int(layout["special_trainer_moves"])
+	while rom.in_bounds(at, 1) and rom.u8(at) != Gen1Layout.TEAM_MOVE_END:
+		var trainer_class: int = rom.u8(at)
+		var number: int = rom.u8(at + 1)
+		at += 2
+		var rows: Array = []
+		while rom.in_bounds(at, Gen1Layout.TRAINER_AI_ROW_SIZE) and rom.u8(at) != 0:
+			rows.append({
+				"member": rom.u8(at), "slot": rom.u8(at + 1), "move": rom.u8(at + 2),
+			})
+			at += Gen1Layout.TRAINER_AI_ROW_SIZE
+		at += 1
+		if trainer_class < 1 or trainer_class > parties.size():
+			continue
+		var class_parties: Array = parties[trainer_class - 1]
+		if number >= 1 and number <= class_parties.size():
+			(class_parties[number - 1] as Dictionary)["special_moves"] = rows
 
 
 ## `TrainerDataPointers`: one span a class, each a run of parties. A party opens
@@ -1860,6 +2001,7 @@ static func _read_trainer_class_parties(
 		var level: int = rom.u8(at)
 		at += 1
 		var party: Array = []
+		var special: bool = level == Gen1Layout.TRAINER_PARTY_LEVELS
 		while at < end and rom.u8(at) != 0:
 			var member_level: int = level
 			if level == Gen1Layout.TRAINER_PARTY_LEVELS:
@@ -1873,7 +2015,10 @@ static func _read_trainer_class_parties(
 			})
 			at += 1
 		at += 1
-		out.append({"name": "", "type": Gen2Layout.TRAINER_MON_NORMAL, "party": party})
+		out.append({
+			"name": "", "type": Gen2Layout.TRAINER_MON_NORMAL, "party": party,
+			"special": special,
+		})
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -608,6 +608,8 @@ const POKE_FLUTE_TEXT_AT: Dictionary = {
 	"no_effect": 0x00, "woke_up": 0x05, "had_effect": 0x0A,
 }
 const SAFARI_BATTLE_TEXT_AT: Dictionary = {"eating": 0x00, "angry": 0x05}
+## `AIBattleWithdrawText` and `AIBattleUseItemText`, $C3 apart on every cartridge.
+const TRAINER_AI_TEXT_AT: Dictionary = {"withdraw": 0x00, "use_item": 0xC3}
 const SAFARI_TEXT_AT: Dictionary = {"times_up": 0x00, "game_over": 0x05}
 const SAFARI_ITEM_TEXT_AT: Dictionary = {"bait": 0x00, "rock": 0x05}
 const SAFARI_LOW_COST_TEXT_AT: Dictionary = {"low_cost_1": 0x00, "low_cost_2": 0x05}
@@ -1896,6 +1898,47 @@ const TRAINER_PIC_SIZE: int = 5
 ## front of every species instead of one for the whole team.
 const TRAINER_PARTY_LEVELS: int = 0xFF
 
+## `AIMoveChoiceModificationFunctionPointers` names four layers.
+const TRAINER_AI_LAYER_COUNT: int = 4
+## `TrainerAIPointers`: a use count and a near pointer.
+const TRAINER_AI_ROW_SIZE: int = 3
+## Each cartridge's `TrainerAIPointers` targets by bank-local address; Yellow
+## retuned Koga, Blaine and Sabrina.
+const TRAINER_AI_ROUTINES: Dictionary = {
+	RomRegistry.RED: {
+		0x65E9: "juggler", 0x65EF: "blackbelt", 0x65F5: "giovanni",
+		0x65FB: "cooltrainer_m", 0x6601: "cooltrainer_f", 0x6614: "brock",
+		0x661C: "misty", 0x6622: "lt_surge", 0x6628: "erika", 0x6634: "koga",
+		0x663A: "blaine", 0x6640: "sabrina", 0x664C: "rival2", 0x6658: "rival3",
+		0x6664: "lorelei", 0x6670: "bruno", 0x6676: "agatha", 0x6687: "lance",
+		0x6693: "generic",
+	},
+	RomRegistry.YELLOW: {
+		0x667F: "juggler", 0x6685: "blackbelt", 0x668B: "giovanni",
+		0x6691: "cooltrainer_m", 0x6697: "cooltrainer_f", 0x66AA: "brock",
+		0x66B2: "misty", 0x66B8: "lt_surge", 0x66BE: "erika", 0x66CA: "koga_yellow",
+		0x66D0: "blaine_yellow", 0x66DC: "sabrina_yellow", 0x66E2: "rival2",
+		0x66EE: "rival3", 0x66FA: "lorelei", 0x6706: "bruno", 0x670C: "agatha",
+		0x671D: "lance", 0x6729: "generic",
+	},
+}
+## `LoneMoves`, `TeamMoves` and `.ChampionRival`, Red and Blue's own.
+const LONE_MOVE_COUNT: int = 8
+const LONE_MOVE_SIZE: int = 2
+const TEAM_MOVE_END: int = 0xFF
+## `wEnemyMon1Moves + 2`: every table move lands in the third slot.
+const SPECIAL_MOVE_SLOT: int = 3
+const TEAM_MOVE_MEMBER: int = 5
+const CHAMPION_BIRD_MEMBER: int = 1
+const CHAMPION_STARTER_MEMBER: int = 6
+## `.ChampionRival`'s `cp STARTER3` and `cp STARTER1`, Squirtle's line the rest.
+const CHAMPION_STARTER_MOVES: Array = [
+	{"species": 0x99, "move": 0x48}, {"species": 0xB0, "move": 0x7E},
+	{"species": 0, "move": 0x3B},
+]
+const CHAMPION_BIRD_MOVE: int = 0x8F
+const RIVAL3_CLASS: int = 0x2B
+
 ## Sides in tiles: `_LoadTrainerPic`'s `ld a, $77`, the widest front pic, and
 ## every back pic, which `ScaleSpriteByTwo` doubles before a battle draws it.
 const TRAINER_PIC_TILES: int = 7
@@ -1942,6 +1985,11 @@ const RED_BLUE: Dictionary = {
 	## `TrainerDataPointers` and the `TrainerAI` that bounds the last class.
 	"trainer_parties": 0x39D3B,
 	"trainer_parties_end": 0x3A52E,
+	"trainer_move_choices": 0x3989B,
+	"trainer_ai_pointers": 0x3A55C,
+	"trainer_ai_text": 0x3A781,
+	"lone_moves": 0x39D22,
+	"team_moves": 0x39D32,
 	## What a trainer header is read through, and what one of its texts may be.
 	"talk_to_trainer": 0x31CC,
 	"print_text": 0x3C49,
@@ -2420,6 +2468,10 @@ const YELLOW: Dictionary = {
 	"trainer_pics_bank": 0x13,
 	"trainer_parties": 0x39DD1,
 	"trainer_parties_end": 0x3A5B2,
+	"trainer_move_choices": 0x3981E,
+	"trainer_ai_pointers": 0x3A5F2,
+	"trainer_ai_text": 0x3A817,
+	"special_trainer_moves": 0x39C6B,
 	"talk_to_trainer": 0x3168,
 	"print_text": 0x3C36,
 	"event_flags": 0xD746,
@@ -2902,6 +2954,18 @@ static func for_id(id: StringName) -> Dictionary:
 
 static func is_characterised(id: StringName) -> bool:
 	return not for_id(id).is_empty()
+
+
+static func trainer_ai_routine(id: StringName, address: int) -> String:
+	var routines: Dictionary = TRAINER_AI_ROUTINES.get(
+		RomRegistry.YELLOW if id == RomRegistry.YELLOW else RomRegistry.RED, {}
+	)
+	return String(routines.get(address, ""))
+
+
+## `TrainerAI`'s `.done` guard on a locked opponent, Yellow's alone.
+static func trainer_ai_respects_lock(id: StringName) -> bool:
+	return id == RomRegistry.YELLOW
 
 
 ## A type number the cartridge really uses.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -3094,7 +3094,7 @@ static func _script_stored_named_more(
 		"gym_leader_no":
 			## `wLoneAttackNo` is the same byte: a gym leader's fight, which
 			## `InitBattle` tells the follower about and a map load clears.
-			out.append({"op": "volatile", "name": "gym_leader", "set": a != 0})
+			out.append({"op": "volatile", "name": "gym_leader", "set": a != 0, "value": a})
 	return STORE_OK
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 134
+const FORMAT_VERSION: int = 135
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5356,7 +5356,10 @@ func _gen1_node_map_load_bit(node: Dictionary, steps: Array, _run: Dictionary) -
 
 
 func _gen1_node_volatile(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
-	steps.append({"type": &"volatile", "name": String(node["name"]), "set": bool(node["set"])})
+	steps.append({
+		"type": &"volatile", "name": String(node["name"]), "set": bool(node["set"]),
+		"value": int(node.get("value", 1 if bool(node["set"]) else 0)),
+	})
 	return true
 
 
@@ -6701,6 +6704,22 @@ func _gen1_battle_last() -> void:
 		_gen1_steps = rest + battles
 
 
+## `ReadTrainer` reads `wLoneAttackNo` and `wRivalStarter` as they stand when
+## the fight opens: a gym's row writes the byte behind `InitBattleEnemyParameters`.
+func _gen1_stamped_request(request: Dictionary) -> Dictionary:
+	if StringName(request.get("kind", &"")) != &"battle_requested":
+		return request.duplicate(true)
+	var values: Variant = request.get("values", {})
+	if not values is Dictionary or StringName((values as Dictionary).get("kind", &"")) != &"trainer":
+		return request.duplicate(true)
+	var stamped: Dictionary = request.duplicate(true)
+	var stamped_values: Dictionary = stamped["values"]
+	stamped_values["lone_attack"] = int(_gen1_volatile.get("gym_leader", 0))
+	stamped_values["rival_starter"] = state.gen1_starter("rival") if state != null else 0
+	return stamped
+
+
+
 ## `SetLastBlackoutMap`, whose whole body is the rest-house list: healing in one
 ## of the Safari Zone's three leaves the map a blackout lands on where it was.
 func _gen1_record_blackout_map() -> void:
@@ -6724,7 +6743,7 @@ func _gen1_waiting_result(step: Dictionary) -> Dictionary:
 	if type == &"request":
 		return {
 			"ok": true, "status": &"waiting",
-			"event": {"type": &"runtime_request", "request": step["values"]},
+			"event": {"type": &"runtime_request", "request": _gen1_stamped_request(step["values"])},
 		}
 	if type == &"choice":
 		return {"ok": true, "status": &"waiting", "event": {"type": &"choice"}}
@@ -6820,7 +6839,8 @@ func _gen1_kept(step: Dictionary, events: Array) -> bool:
 			_gen1_scratch[int(step["address"])] = int(step["value"])
 			return true
 		&"volatile":
-			_gen1_volatile[String(step["name"])] = bool(step["set"])
+			## The byte itself, `wGymLeaderNo` being `wLoneAttackNo` too.
+			_gen1_volatile[String(step["name"])] = int(step.get("value", 1 if bool(step["set"]) else 0))
 			return true
 		&"map_load":
 			_gen1_map_load_pending |= 1 << int(step["bit"])
@@ -7282,7 +7302,7 @@ func script_stops_the_map() -> bool:
 func pending_runtime_request() -> Dictionary:
 	var step: Dictionary = _gen1_step(&"request")
 	if not step.is_empty():
-		return (step["values"] as Dictionary).duplicate(true)
+		return _gen1_stamped_request(step["values"])
 	return _active_script.pending_runtime_request() if _active_script != null else {}
 
 

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -74,7 +74,10 @@ static func prepare(
 			trainer_class = int(values.get("trainer_group", 0))
 			trainer_index = int(values.get("trainer_id", 0))
 			enemy_party = Gen2TrainerParty.build(
-				data, trainer_class, trainer_index, battle_rules
+				data, trainer_class, trainer_index, battle_rules, {
+					"lone_attack": int(values.get("lone_attack", 0)),
+					"rival_starter": int(values.get("rival_starter", 0)),
+				}
 			)
 			if enemy_party == null:
 				return _failure(&"invalid_trainer", {

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -581,12 +581,13 @@ static func _moves() -> Array:
 	# Name, power, type, accuracy, PP, effect, and the secondary effect's chance
 	# out of 256. Ember and Thunderbolt keep a chance of zero, which is never, so
 	# that the tests written before there were status conditions still see the
-	# plain attacks they were written against.
+	# plain attacks they were written against. An eighth entry is the Generation
+	# 1 effect byte, which its trainer AI reads; a row without one reads as 0.
 	var known: Dictionary = {
 		PAY_DAY: ["PAY DAY", 40, NORMAL, 255, 20, Gen2MoveEffect.PAY_DAY, 0],
 		TRANSFORM: ["TRANSFORM", 0, NORMAL, 255, 10, Gen2MoveEffect.TRANSFORM, 0],
 		TACKLE: ["TACKLE", 35, NORMAL, 255, 35, 0, 0],
-		GROWL: ["GROWL", 0, NORMAL, 255, 40, Gen2MoveEffect.STAT_DOWN_BASE, 0],
+		GROWL: ["GROWL", 0, NORMAL, 255, 40, Gen2MoveEffect.STAT_DOWN_BASE, 0, 0x12],
 		EMBER: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
 		THUNDERBOLT: ["THUNDERBOLT", 95, ELECTRIC, 255, 15, Gen2MoveEffect.PARALYZE_HIT, 0],
 		SLASH: ["SLASH", 70, NORMAL, 255, 20, 0, 0],
@@ -601,9 +602,9 @@ static func _moves() -> Array:
 		BIDE: ["BIDE", 0, NORMAL, 255, 10, Gen2MoveEffect.BIDE, 0],
 		RAGE: ["RAGE", 20, NORMAL, 255, 20, Gen2MoveEffect.RAGE, 0],
 		FUTURE_SIGHT: ["FUTURE SIGHT", 80, PSYCHIC_TYPE, 255, 15, Gen2MoveEffect.FUTURE_SIGHT, 0],
-		THUNDER_WAVE: ["THUNDERWAVE", 0, ELECTRIC, 255, 20, Gen2MoveEffect.PARALYZE, 0],
-		SLEEP_POWDER: ["SLEEP POWDER", 0, GRASS, 255, 15, Gen2MoveEffect.SLEEP, 0],
-		POISON_POWDER: ["POISONPOWDER", 0, POISON, 255, 35, Gen2MoveEffect.POISON, 0],
+		THUNDER_WAVE: ["THUNDERWAVE", 0, ELECTRIC, 255, 20, Gen2MoveEffect.PARALYZE, 0, 0x43],
+		SLEEP_POWDER: ["SLEEP POWDER", 0, GRASS, 255, 15, Gen2MoveEffect.SLEEP, 0, 0x20],
+		POISON_POWDER: ["POISONPOWDER", 0, POISON, 255, 35, Gen2MoveEffect.POISON, 0, 0x42],
 		# A chance of 256 is one the roll cannot fail, which is how a test gets a
 		# burn without a seed. Its opposite is a chance of zero.
 		EMBER_BURNS: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 256],
@@ -621,7 +622,7 @@ static func _moves() -> Array:
 			"BODY SLAM", 85, NORMAL, 255, 15, Gen2MoveEffect.PARALYZE_HIT, 256,
 		],
 		# Attack up by two, on the user, with no roll to miss.
-		SWORDS_DANCE: ["SWORDS DANCE", 0, NORMAL, 255, 30, Gen2MoveEffect.STAT_UP_2_BASE, 0],
+		SWORDS_DANCE: ["SWORDS DANCE", 0, NORMAL, 255, 30, Gen2MoveEffect.STAT_UP_2_BASE, 0, 0x32],
 		# Defense down by two, on the foe, which can still miss.
 		SCREECH: ["SCREECH", 0, NORMAL, 216, 40, Gen2MoveEffect.STAT_DOWN_2_BASE + 1, 0],
 		# Attack up on the user, behind a roll, the way Metal Claw does it.
@@ -643,7 +644,7 @@ static func _moves() -> Array:
 		# Confusion as the whole of the move, the way Supersonic does it.
 		SUPERSONIC: ["SUPERSONIC", 0, NORMAL, 255, 20, Gen2MoveEffect.CONFUSE, 0],
 		HYPER_BEAM: ["HYPER BEAM", 150, NORMAL, 255, 5, Gen2MoveEffect.RECHARGE_HIT, 0],
-		FLY: ["FLY", 70, FLYING, 242, 15, Gen2MoveEffect.FLY_OR_DIG, 0],
+		FLY: ["FLY", 70, FLYING, 242, 15, Gen2MoveEffect.FLY_OR_DIG, 0, 0x2B],
 		DIG: ["DIG", 100, GROUND, 255, 10, Gen2MoveEffect.FLY_OR_DIG, 0],
 		GUST: ["GUST", 40, FLYING, 255, 35, Gen2MoveEffect.GUST, 0],
 		THUNDER: ["THUNDER", 120, ELECTRIC, 178, 10, Gen2MoveEffect.THUNDER, 76],
@@ -673,9 +674,9 @@ static func _moves() -> Array:
 		TWINEEDLE_MOVE: ["TWINEEDLE", 25, POISON, 255, 20, Gen2MoveEffect.TWINEEDLE, 256],
 		DRAIN_MOVE: ["ABSORB", 20, GRASS, 255, 20, Gen2MoveEffect.LEECH_HIT, 0],
 		DREAM_EATER_MOVE: ["DREAM EATER", 100, PSYCHIC_TYPE, 255, 15, Gen2MoveEffect.DREAM_EATER, 0],
-		LEVEL_DAMAGE_MOVE: ["SEISMIC TOSS", 1, NORMAL, 255, 20, Gen2MoveEffect.LEVEL_DAMAGE, 0],
+		LEVEL_DAMAGE_MOVE: ["SEISMIC TOSS", 1, NORMAL, 255, 20, Gen2MoveEffect.LEVEL_DAMAGE, 0, 0x29],
 		STATIC_DAMAGE_MOVE: ["SONICBOOM", 20, NORMAL, 255, 20, Gen2MoveEffect.STATIC_DAMAGE, 0],
-		SUPER_FANG_MOVE: ["SUPER FANG", 1, NORMAL, 255, 10, Gen2MoveEffect.SUPER_FANG, 0],
+		SUPER_FANG_MOVE: ["SUPER FANG", 1, NORMAL, 255, 10, Gen2MoveEffect.SUPER_FANG, 0, 0x28],
 		PSYWAVE_MOVE: ["PSYWAVE", 1, PSYCHIC_TYPE, 255, 15, Gen2MoveEffect.PSYWAVE, 0],
 		OHKO_MOVE: ["GUILLOTINE", 0, NORMAL, 76, 5, Gen2MoveEffect.OHKO, 0],
 		DISABLE_MOVE: ["DISABLE", 0, NORMAL, 140, 20, Gen2MoveEffect.DISABLE, 0],
@@ -808,6 +809,7 @@ static func _moves() -> Array:
 			"accuracy": entry[3],
 			"pp": entry[4],
 			"effect_chance": entry[6],
+			"gen1_effect": int(entry[7]) if entry.size() > 7 else 0,
 		})
 	return out
 
@@ -854,6 +856,19 @@ const FALKNER: int = 1
 const FALKNER_BASE_REWARD: int = 25
 
 
+## Two Generation 1 classes beside it: a gym leader running all three layers
+## with Brock's routine and a five-use count, whose one party carries the three
+## shapes of `special_moves` row, and a juggler with no layer at all.
+const GEN1_LEADER: int = 2
+const GEN1_JUGGLER: int = 3
+const GEN1_LEADER_COUNT: int = 5
+const GEN1_LONE_MOVE: int = BIDE
+const GEN1_TEAM_MOVE: int = SWORDS_DANCE
+const GEN1_STARTER_MOVE: int = EMBER
+const GEN1_OTHER_STARTER_MOVE: int = THUNDERBOLT
+const GEN1_STARTER: int = 0xB0
+
+
 static func _trainers() -> Array:
 	return [{
 		"number": FALKNER,
@@ -864,7 +879,42 @@ static func _trainers() -> Array:
 			"item1": 0, "item2": 0, "base_reward": FALKNER_BASE_REWARD,
 			"ai_move_weights": 0, "ai_item_switch": 0,
 		},
-		"dvs": [],
+	}, {
+		"number": GEN1_LEADER,
+		"name": "LEADER",
+		"palette": [0, 0],
+		"trainers": [{
+			"name": "", "type": Gen2Layout.TRAINER_MON_NORMAL,
+			"party": [
+				{"level": 12, "species": GEODUDE, "item": 0, "moves": []},
+				{"level": 14, "species": CHARMANDER, "item": 0, "moves": []},
+			],
+			"special_moves": [
+				{"member": 2, "slot": 3, "move": GEN1_LONE_MOVE, "lone": 1},
+				{"member": 1, "slot": 3, "move": GEN1_TEAM_MOVE, "lone": 0},
+				{"member": 2, "slot": 4, "lone": 0, "starter": [
+					{"species": GEN1_STARTER, "move": GEN1_STARTER_MOVE},
+					{"species": 0, "move": GEN1_OTHER_STARTER_MOVE},
+				]},
+			],
+		}],
+		"attributes": {
+			"base_reward": 99, "ai_layers": [1, 2, 3], "ai_count": GEN1_LEADER_COUNT,
+			"ai_routine": "brock",
+		},
+	}, {
+		"number": GEN1_JUGGLER,
+		"name": "JUGGLER",
+		"palette": [0, 0],
+		"trainers": [{
+			"name": "", "type": Gen2Layout.TRAINER_MON_NORMAL,
+			"party": [
+				{"level": 20, "species": PIKACHU, "item": 0, "moves": []},
+				{"level": 20, "species": GEODUDE, "item": 0, "moves": []},
+				{"level": 20, "species": CHARMANDER, "item": 0, "moves": []},
+			],
+		}],
+		"attributes": {"base_reward": 35, "ai_layers": [], "ai_count": 3, "ai_routine": "juggler"},
 	}]
 
 

--- a/tests/unit/test_gen1_trainer_ai.gd
+++ b/tests/unit/test_gen1_trainer_ai.gd
@@ -1,0 +1,240 @@
+extends GutTest
+
+## `SelectEnemyMove`, `AIEnemyTrainerChooseMoves`' three layers, `TrainerAI`'s
+## routines and the moves `ReadTrainer` writes over a party, on the fixture's
+## two Generation 1 classes.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+## Seeds enough for a share of 64 in 256 to settle inside a fortieth.
+const SEEDS: int = 1024
+const SHARE_TOLERANCE: float = 0.025
+const DRAIN_MOVE: int = Fixture.DRAIN_MOVE
+
+var _directory: String = ""
+var _data: GameData = null
+var _rng: RandomNumberGenerator = null
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"gen1aitest", "0123456789abcdef")
+	_data = Fixture.build(_directory, "testgame", RomRegistry.GEN1)
+	_rng = RandomNumberGenerator.new()
+	_rng.seed = 7
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _mon(species: int, moves: Array, level: int = 50) -> Gen2BattleMon:
+	return Gen2BattleMon.create(_data, species, level, moves)
+
+
+## A trainer battle against [param enemy_party], the player's Pikachu with
+## Tackle. [param trainer_class] 0 is a wild.
+func _battle(enemy_party: Array, trainer_class: int, player: Gen2BattleMon = null) -> Gen2Battle:
+	var lead: Gen2BattleMon = player if player != null else _mon(Fixture.PIKACHU, [Fixture.TACKLE])
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(lead), Gen2Party.create(enemy_party), _rng, trainer_class > 0
+	)
+	if trainer_class > 0:
+		battle.init_enemy_trainer(trainer_class)
+	return battle
+
+
+func _shares(battle: Gen2Battle) -> Array:
+	var counts: Array = [0, 0, 0, 0]
+	for seed_value: int in SEEDS:
+		_rng.seed = seed_value
+		counts[Gen1TrainerAI.select_slot(battle, _rng)] += 1
+	return counts
+
+
+func test_a_wild_rolls_its_four_slots_at_the_cartridges_shares() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [
+		Fixture.TACKLE, Fixture.GROWL, Fixture.SLASH, Fixture.EMBER,
+	])], 0)
+	var counts: Array = _shares(battle)
+	for slot: int in 4:
+		var expected: float = [64.0, 64.0, 63.0, 65.0][slot] / 256.0
+		assert_almost_eq(
+			float(counts[slot]) / float(SEEDS), expected, SHARE_TOLERANCE,
+			".chooseRandomMove's slot %d share" % slot
+		)
+
+
+func test_a_disabled_or_empty_slot_is_rolled_again() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [
+		Fixture.TACKLE, Fixture.GROWL, Fixture.SLASH,
+	])], 0)
+	battle.mon(Gen2Battle.ENEMY).disabled_slot = 1
+	var counts: Array = _shares(battle)
+	assert_eq(counts[1], 0, "the disabled slot")
+	assert_eq(counts[3], 0, "the empty slot")
+	assert_eq(counts[0] + counts[2], SEEDS, "every roll landed on the two left")
+
+
+func test_a_single_move_is_slot_zero_without_a_roll() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [Fixture.TACKLE])], 0)
+	assert_eq(_shares(battle)[0], SEEDS, ".canSelectMove's one-move answer")
+
+
+func test_layer_one_discourages_status_moves_once_the_player_has_a_status() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [
+		Fixture.TACKLE, Fixture.THUNDER_WAVE, Fixture.SLEEP_POWDER,
+	])], Fixture.GEN1_LEADER)
+	assert_eq(Gen1TrainerAI.score_slots(battle, [1]), [10, 10, 10, 10], "a healthy player")
+	battle.mon(Gen2Battle.PLAYER).status = Gen2Status.PARALYSIS
+	assert_eq(Gen1TrainerAI.score_slots(battle, [1]), [10, 15, 15, 10], "a paralysed one")
+	assert_eq(Gen1TrainerAI.enabled_slots(battle), [true, false, false, false])
+
+
+func test_layer_two_encourages_setup_on_the_second_move_alone() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [
+		Fixture.TACKLE, Fixture.GROWL, Fixture.SWORDS_DANCE,
+	])], Fixture.GEN1_LEADER)
+	assert_eq(Gen1TrainerAI.score_slots(battle, [2]), [10, 10, 10, 10], "the first move")
+	battle.gen1_enemy_moves = 1
+	assert_eq(Gen1TrainerAI.score_slots(battle, [2]), [10, 9, 9, 10], "the second")
+	battle.gen1_enemy_moves = 2
+	assert_eq(Gen1TrainerAI.score_slots(battle, [2]), [10, 10, 10, 10], "the third")
+
+
+func test_layer_three_reads_the_first_chart_row_and_a_better_move() -> void:
+	var player: Gen2BattleMon = _mon(Fixture.GEODUDE, [Fixture.TACKLE])
+	var battle: Gen2Battle = _battle(
+		[_mon(Fixture.PIKACHU, [Fixture.TACKLE, DRAIN_MOVE, Fixture.THUNDER_WAVE])],
+		Fixture.GEN1_LEADER, player
+	)
+	## Normal on Rock is resisted and Absorb is a damaging move of another type;
+	## Grass on Rock is favoured; Electric's first row against Ground is 0, and
+	## Thunder Wave's better move is either damaging one.
+	assert_eq(Gen1TrainerAI.score_slots(battle, [3]), [11, 9, 11, 10])
+	assert_eq(Gen1TrainerAI.enabled_slots(battle), [false, true, false, false])
+	assert_eq(_data.first_matchup(Fixture.ELECTRIC, [Fixture.GROUND, Fixture.ROCK]), 0)
+	assert_eq(_data.first_matchup(Fixture.DARK, [Fixture.NORMAL, Fixture.NORMAL]), -1)
+
+
+func test_a_resisted_move_with_nothing_better_is_left_alone() -> void:
+	var battle: Gen2Battle = _battle(
+		[_mon(Fixture.PIKACHU, [Fixture.TACKLE, Fixture.GROWL])],
+		Fixture.GEN1_LEADER, _mon(Fixture.GEODUDE, [Fixture.TACKLE])
+	)
+	assert_eq(Gen1TrainerAI.score_slots(battle, [3]), [10, 10, 10, 10])
+
+
+func test_the_lowest_scores_are_what_the_roll_chooses_between() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [
+		Fixture.TACKLE, Fixture.THUNDER_WAVE, Fixture.SLASH,
+	])], Fixture.GEN1_LEADER)
+	battle.mon(Gen2Battle.PLAYER).status = Gen2Status.PARALYSIS
+	var counts: Array = _shares(battle)
+	assert_eq(counts[1], 0, "the discouraged status move")
+	assert_gt(counts[0], 0)
+	assert_gt(counts[2], 0)
+
+
+func test_brock_spends_a_full_heal_on_a_status_and_nothing_otherwise() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [Fixture.TACKLE])], Fixture.GEN1_LEADER)
+	assert_eq(Gen1TrainerAI.trainer_action(battle, _rng), {}, "no status")
+	assert_eq(battle.gen1_ai_count, Fixture.GEN1_LEADER_COUNT, "the count loads on the first pass")
+	battle.mon(Gen2Battle.ENEMY).status = Gen2Status.BURN
+	assert_eq(
+		Gen1TrainerAI.trainer_action(battle, _rng), Gen2Battle.use_item(Gen1TrainerAI.FULL_HEAL)
+	)
+	assert_eq(battle.gen1_ai_count, Fixture.GEN1_LEADER_COUNT - 1, "DecrementAICount")
+	battle.gen1_ai_count = 0
+	assert_eq(Gen1TrainerAI.trainer_action(battle, _rng), {}, "no uses left")
+
+
+func test_a_juggler_switches_a_quarter_of_the_time_to_the_first_other_member() -> void:
+	var battle: Gen2Battle = _battle([
+		_mon(Fixture.PIKACHU, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, [Fixture.TACKLE]),
+		_mon(Fixture.CHARMANDER, [Fixture.TACKLE]),
+	], Fixture.GEN1_JUGGLER)
+	var switched: int = 0
+	for seed_value: int in SEEDS:
+		_rng.seed = seed_value
+		var action: Dictionary = Gen1TrainerAI.trainer_action(battle, _rng)
+		if action.is_empty():
+			continue
+		assert_eq(action, Gen2Battle.switch_to(1))
+		switched += 1
+	assert_almost_eq(float(switched) / float(SEEDS), 65.0 / 256.0, SHARE_TOLERANCE)
+	assert_eq(battle.gen1_ai_count, 3, "a switch spends no count")
+	battle.party(Gen2Battle.ENEMY).at(1).hp = 0
+	battle.party(Gen2Battle.ENEMY).at(2).hp = 0
+	_rng.seed = 1
+	assert_eq(Gen1TrainerAI.trainer_action(battle, _rng), {}, "nobody left to send")
+
+
+func test_items_do_what_the_ai_use_routines_do() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [Fixture.TACKLE])], Fixture.GEN1_LEADER)
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	enemy.hp = 1
+	enemy.status = Gen2Status.POISON
+	assert_eq(Gen1TrainerAI.apply_item(battle, enemy, Gen1TrainerAI.POTION), {"healed": 20})
+	assert_eq(enemy.status, Gen2Status.POISON, "a potion cures nothing")
+	assert_eq(Gen1TrainerAI.apply_item(battle, enemy, Gen1TrainerAI.FULL_HEAL), {"cured": true})
+	enemy.status = Gen2Status.BURN
+	var restored: Dictionary = Gen1TrainerAI.apply_item(battle, enemy, Gen1TrainerAI.FULL_RESTORE)
+	assert_eq(restored, {"healed": enemy.max_hp() - 21, "cured": true})
+	assert_eq(enemy.hp, enemy.max_hp())
+	Gen1TrainerAI.apply_item(battle, enemy, Gen1TrainerAI.GUARD_SPEC)
+	assert_true(Gen2Substatus.has(enemy.substatus, Gen2Substatus.MIST))
+	var raised: Dictionary = Gen1TrainerAI.apply_item(battle, enemy, Gen1TrainerAI.X_ATTACK)
+	assert_eq(raised, {"stat": "attack", "raised": true})
+	assert_eq(enemy.stage("attack"), 1)
+
+
+func test_the_class_acts_where_its_move_would_have_been() -> void:
+	var battle: Gen2Battle = _battle(
+		[_mon(Fixture.GEODUDE, [Fixture.TACKLE])], Fixture.GEN1_LEADER,
+		_mon(Fixture.PIKACHU, [Fixture.GROWL])
+	)
+	battle.mon(Gen2Battle.ENEMY).status = Gen2Status.BURN
+	var events: Array = battle.take_turn(0, 0)
+	var kinds: Array = []
+	for event: Dictionary in events:
+		kinds.append(event["type"])
+	var used: int = kinds.find(Gen2Battle.TRAINER_USED_ITEM)
+	assert_gt(used, kinds.find(Gen2Battle.USED_MOVE), "after the faster player's move")
+	assert_eq(battle.mon(Gen2Battle.ENEMY).status, Gen2Status.NONE)
+	assert_eq(battle.gen1_enemy_moves, 0, "ExecuteEnemyMove was skipped")
+	events = battle.take_turn(0, 0)
+	assert_eq(battle.gen1_enemy_moves, 1, "and runs on the next turn")
+
+
+func test_an_opponents_pp_is_never_spent() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [Fixture.TACKLE])], 0)
+	battle.take_turn(0, 0)
+	assert_eq(battle.mon(Gen2Battle.ENEMY).pp_left(0), 35, "DecrementPP has no enemy half")
+	assert_eq(battle.mon(Gen2Battle.PLAYER).pp_left(0), 34)
+
+
+func test_quick_attack_goes_first_and_counter_last_by_move_number() -> void:
+	var battle: Gen2Battle = _battle([_mon(Fixture.GEODUDE, [Fixture.TACKLE])], 0)
+	var quick_attack: int = 98
+	assert_eq(battle.order({Gen2Battle.PLAYER: Fixture.TACKLE, Gen2Battle.ENEMY: Fixture.TACKLE}),
+		[Gen2Battle.PLAYER, Gen2Battle.ENEMY], "Pikachu outspeeds Geodude")
+	assert_eq(battle.order({Gen2Battle.PLAYER: Fixture.TACKLE, Gen2Battle.ENEMY: quick_attack}),
+		[Gen2Battle.ENEMY, Gen2Battle.PLAYER])
+	assert_eq(battle.order({Gen2Battle.PLAYER: Fixture.COUNTER, Gen2Battle.ENEMY: Fixture.TACKLE}),
+		[Gen2Battle.ENEMY, Gen2Battle.PLAYER])
+	assert_eq(battle.order({Gen2Battle.PLAYER: Fixture.COUNTER, Gen2Battle.ENEMY: Fixture.COUNTER}),
+		[Gen2Battle.PLAYER, Gen2Battle.ENEMY], "both used it, so speed")
+
+
+func test_special_moves_land_by_the_lone_attack_and_the_starter() -> void:
+	var lone: Gen2Party = Gen2TrainerParty.build(_data, Fixture.GEN1_LEADER, 0, null, {"lone_attack": 1})
+	assert_eq(lone.at(1).moves, [Fixture.EMBER, 0, Fixture.GEN1_LONE_MOVE], "LoneMoves' row")
+	assert_eq(lone.at(1).pp_left(2), 10, "the slot takes the move's own PP")
+	assert_eq(lone.at(0).moves, [Fixture.GROWL, Fixture.SLASH], "and nothing else")
+	var champion: Gen2Party = Gen2TrainerParty.build(
+		_data, Fixture.GEN1_LEADER, 0, null, {"rival_starter": Fixture.GEN1_STARTER}
+	)
+	assert_eq(champion.at(0).moves, [Fixture.GROWL, Fixture.SLASH, Fixture.GEN1_TEAM_MOVE])
+	assert_eq(champion.at(1).moves, [Fixture.EMBER, 0, 0, Fixture.GEN1_STARTER_MOVE])
+	var other: Gen2Party = Gen2TrainerParty.build(_data, Fixture.GEN1_LEADER, 0, null, {})
+	assert_eq(other.at(1).moves, [Fixture.EMBER, 0, 0, Fixture.GEN1_OTHER_STARTER_MOVE])

--- a/tests/unit/test_gen1_trainer_ai.gd.uid
+++ b/tests/unit/test_gen1_trainer_ai.gd.uid
@@ -1,0 +1,1 @@
+uid://dnjecjx21tkys

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -21,7 +21,7 @@ const MAX_COMMENT_BLOCK: int = 8
 ## the shared code, the largest of them 152 the region map, 150 the battle
 ## animation engine, 140 the transition, 131 the field moves, 130 the Pokedex,
 ## 108 the three PCs, 90 the Safari Zone, 52 the menus a row draws.
-const MAX_COMMENT_LINES: int = 41874
+const MAX_COMMENT_LINES: int = 41873
 
 ## What no comment block ever ends on. A pass that meets the ceiling above trims
 ## the second line of a two-line block and leaves the first mid-sentence, which

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -170,7 +170,12 @@ func _a_wild_fight() -> void:
 
 ## [param moves] empty takes whatever the level gives, which is what a wild
 ## encounter and a party member both carry.
-func _fight(player_level: int, enemy_level: int, moves: Array, seed_value: int) -> Gen2Battle:
+## The Pidgey's own Whirlwind outspeeds a Bulbasaur and ends a wild battle, so
+## a routine drill hands [param enemy_moves] SPLASH.
+func _fight(
+	player_level: int, enemy_level: int, moves: Array, seed_value: int,
+	enemy_moves: Array = []
+) -> Gen2Battle:
 	var generator := RandomNumberGenerator.new()
 	generator.seed = seed_value
 	var player_moves: Array = moves if not moves.is_empty() \
@@ -180,7 +185,8 @@ func _fight(player_level: int, enemy_level: int, moves: Array, seed_value: int) 
 		Gen2BattleMon.create(_r.data, SWEEP_PLAYER, player_level, player_moves),
 		Gen2BattleMon.create(
 			_r.data, SWEEP_ENEMY, enemy_level,
-			_r.data.moves_at_level(SWEEP_ENEMY, enemy_level)
+			enemy_moves if not enemy_moves.is_empty()
+			else _r.data.moves_at_level(SWEEP_ENEMY, enemy_level)
 		),
 		generator
 	)
@@ -201,6 +207,7 @@ const WRAP_MOVE: int = 35
 const CONVERSION_MOVE: int = 160
 const TELEPORT_MOVE: int = 100
 const ROAR_MOVE: int = 46
+const SPLASH_MOVE: int = 150
 ## `TYPE_NORMAL` and `TYPE_FLYING` as `type_constants.asm` numbers them.
 const PIDGEY_TYPES: Array[int] = [0, 2]
 
@@ -217,7 +224,7 @@ const TRAP_TOLERANCE: float = 0.025
 ## screens, and the target's own status byte with them. Crystal's
 ## `EFFECT_RESET_STATS` clears the stages and nothing else.
 func _haze_clears_more_than_stages() -> void:
-	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [HAZE_MOVE], SWEEP_SEED)
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [HAZE_MOVE], SWEEP_SEED, [SPLASH_MOVE])
 	if not _r.check(battle != null, "no battle could be built for HAZE"):
 		return
 	battle.player.change_stage("attack", 2)
@@ -247,7 +254,7 @@ func _haze_clears_more_than_stages() -> void:
 ## the first hit's damage over again. `MoveHitTest.moveMissed` clears the flag,
 ## so the run walks until a Wrap actually binds.
 func _a_trapping_move_holds_its_target() -> void:
-	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [WRAP_MOVE], SWEEP_SEED)
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [WRAP_MOVE], SWEEP_SEED, [SPLASH_MOVE])
 	if not _r.check(battle != null, "no battle could be built for WRAP"):
 		return
 	var bound: int = 0
@@ -306,7 +313,7 @@ func _the_trap_counter_distribution() -> void:
 ## own Conversion samples the user's own moves for one.
 func _conversion_copies_the_target() -> void:
 	var battle: Gen2Battle = _fight(
-		SWEEP_LEVEL, SWEEP_LEVEL, [CONVERSION_MOVE], SWEEP_SEED
+		SWEEP_LEVEL, SWEEP_LEVEL, [CONVERSION_MOVE], SWEEP_SEED, [SPLASH_MOVE]
 	)
 	if not _r.check(battle != null, "no battle could be built for CONVERSION"):
 		return
@@ -322,13 +329,13 @@ func _conversion_copies_the_target() -> void:
 ## all three outright.
 func _teleport_ends_the_battle() -> void:
 	for move: int in [TELEPORT_MOVE, ROAR_MOVE]:
-		var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED)
+		var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED, [SPLASH_MOVE])
 		if not _r.check(battle != null, "no battle could be built for move %d" % move):
 			return
 		battle.take_turn(0, 0)
 		_r.check(battle.is_over(), "move %d did not end the wild battle" % move)
 
-		var trainer: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED)
+		var trainer: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED, [SPLASH_MOVE])
 		trainer.is_trainer_battle = true
 		var events: Array = trainer.take_turn(0, 0)
 		_r.check(not trainer.is_over(), "move %d ended a trainer battle" % move)

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -60,6 +60,72 @@ const FIGHT_LEAD_LEVEL: int = 50
 const FIGHT_SEED: int = 20260930
 const FIGHT_TURN_CAP: int = 64
 
+## Classes running each layer, classes past `GenericAI`, and the use counts
+## summed. Yellow drops layer 3 from four classes.
+const AI_CENSUS: Dictionary = {
+	&"red": {"layer1": 45, "layer2": 8, "layer3": 21, "routines": 19, "uses": 116},
+	&"blue": {"layer1": 45, "layer2": 8, "layer3": 21, "routines": 19, "uses": 116},
+	&"yellow": {"layer1": 45, "layer2": 8, "layer3": 17, "routines": 19, "uses": 116},
+}
+## Each routine's action at 1 HP with a status, as the `Random` bytes of 256
+## that reach it: `cp n / ret nc` is n, Agatha's potion 129 - 20, no roll 256.
+const ROUTINE_SHARES: Dictionary = {
+	"generic": {},
+	"juggler": {"switch": 65},
+	"blackbelt": {Gen1TrainerAI.X_ATTACK: 32},
+	"giovanni": {Gen1TrainerAI.GUARD_SPEC: 65},
+	"cooltrainer_m": {Gen1TrainerAI.X_ATTACK: 65},
+	"cooltrainer_f": {Gen1TrainerAI.HYPER_POTION: 256},
+	"brock": {Gen1TrainerAI.FULL_HEAL: 256},
+	"misty": {Gen1TrainerAI.X_DEFEND: 65},
+	"lt_surge": {Gen1TrainerAI.X_SPEED: 65},
+	"erika": {Gen1TrainerAI.SUPER_POTION: 129},
+	"koga": {Gen1TrainerAI.X_ATTACK: 65},
+	"koga_yellow": {Gen1TrainerAI.X_ATTACK: 32},
+	"blaine": {Gen1TrainerAI.SUPER_POTION: 65},
+	"blaine_yellow": {Gen1TrainerAI.SUPER_POTION: 65},
+	"sabrina": {Gen1TrainerAI.HYPER_POTION: 65},
+	"sabrina_yellow": {Gen1TrainerAI.X_DEFEND: 65},
+	"rival2": {Gen1TrainerAI.POTION: 32},
+	"rival3": {Gen1TrainerAI.FULL_RESTORE: 32},
+	"lorelei": {Gen1TrainerAI.SUPER_POTION: 129},
+	"bruno": {Gen1TrainerAI.X_DEFEND: 65},
+	"agatha": {"switch": 20, Gen1TrainerAI.SUPER_POTION: 109},
+	"lance": {Gen1TrainerAI.HYPER_POTION: 129},
+}
+const ROUTINE_SEEDS: int = 512
+const SHARE_TOLERANCE: float = 0.04
+
+## Class, party, member, slot, move and `wLoneAttackNo`: Brock's Onix,
+## Lorelei's fifth and the champion's Pidgeot and Venusaur.
+const BROCK_CLASS: int = 34
+const LORELEI_CLASS: int = 44
+const RIVAL3_CLASS: int = 43
+const BULBASAUR_INDEX: int = 0x99
+const SPECIAL_MOVE_ROWS: Dictionary = {
+	&"red": [
+		[BROCK_CLASS, 0, 2, 3, 0x75, 1], [LORELEI_CLASS, 0, 5, 3, 0x3B, 0],
+		[RIVAL3_CLASS, 0, 1, 3, 0x8F, 0], [RIVAL3_CLASS, 0, 6, 3, 0x48, 0],
+	],
+	&"blue": [
+		[BROCK_CLASS, 0, 2, 3, 0x75, 1], [LORELEI_CLASS, 0, 5, 3, 0x3B, 0],
+		[RIVAL3_CLASS, 0, 1, 3, 0x8F, 0], [RIVAL3_CLASS, 0, 6, 3, 0x48, 0],
+	],
+	&"yellow": [
+		[BROCK_CLASS, 0, 2, 3, 0x14, 0], [BROCK_CLASS, 0, 2, 4, 0x75, 0],
+		[LORELEI_CLASS, 0, 5, 3, 0x3B, 0], [RIVAL3_CLASS, 0, 6, 3, 0x62, 0],
+	],
+}
+## Pewter Gym, Brock's cell, and Onix's third slot: `LoneMoves`' BIDE behind
+## his row's `ld a, $1` on Red and Blue, Yellow's own ungated BIND.
+const PEWTER_GYM: int = 0x36
+const BROCK_APPROACH := Vector2i(4, 2)
+const BROCK_LONE_ATTACK: int = 1
+const BROCK_ONIX_MOVE: Dictionary = {&"red": 0x75, &"blue": 0x75, &"yellow": 0x14}
+
+## Every row, `LoneMoves`' eight on each `$FF` party of Red and Blue.
+const SPECIAL_MOVE_CENSUS: Dictionary = {&"red": 314, &"blue": 314, &"yellow": 102}
+
 ## Where the player stands to talk to an object, and which way that faces.
 const APPROACHES: Array = [
 	[Vector2i.DOWN, Gen2WorldSprite.FACING_UP],
@@ -78,11 +144,137 @@ func run(r: RefCounted) -> void:
 
 func _one_game() -> void:
 	_the_party_table()
+	_the_ai_tables()
+	_the_special_moves()
 	_the_headers()
 	_every_trainer_is_talked_to()
 	_every_trainer_sees()
 	_a_trainer_is_beaten()
+	_the_gym_leader_stamps_the_lone_move()
+	_every_routine_acts()
 	_the_trainer_transitions()
+
+
+func _the_ai_tables() -> void:
+	var census: Dictionary = {"layer1": 0, "layer2": 0, "layer3": 0, "routines": 0, "uses": 0}
+	for trainer_class: int in range(1, CLASS_COUNT + 1):
+		var attributes: Dictionary = _r.data.trainer_attributes(trainer_class)
+		for layer: int in attributes["ai_layers"]:
+			census["layer%d" % layer] = int(census.get("layer%d" % layer, 0)) + 1
+		census["uses"] += int(attributes["ai_count"])
+		var routine: String = String(attributes["ai_routine"])
+		if not _r.check(Gen1TrainerAI.ROUTINES.has(routine),
+			"class %d names AI routine '%s'." % [trainer_class, routine]):
+			continue
+		if routine != "generic":
+			census["routines"] += 1
+	_r.check(census == AI_CENSUS[_r.game_id],
+		"the AI tables read %s, pinned %s." % [str(census), str(AI_CENSUS[_r.game_id])])
+
+
+func _the_special_moves() -> void:
+	var rows: int = 0
+	for trainer_class: int in range(1, CLASS_COUNT + 1):
+		for index: int in _r.data.trainer_party_count(trainer_class):
+			rows += (_r.data.trainer_party(trainer_class, index)["special_moves"] as Array).size()
+	_r.check(rows == int(SPECIAL_MOVE_CENSUS[_r.game_id]),
+		"%d special move rows, pinned %d." % [rows, int(SPECIAL_MOVE_CENSUS[_r.game_id])])
+	for row: Array in SPECIAL_MOVE_ROWS[_r.game_id]:
+		var context: Dictionary = {"lone_attack": int(row[5]), "rival_starter": BULBASAUR_INDEX}
+		var party: Gen2Party = Gen2TrainerParty.build(_r.data, int(row[0]), int(row[1]), null, context)
+		var member: Gen2BattleMon = party.at(int(row[2]) - 1) if party != null else null
+		if not _r.check(member != null, "class %d party %d has no member %d." % [row[0], row[1], row[2]]):
+			continue
+		var slot: int = int(row[3]) - 1
+		var move: int = int(member.moves[slot]) if slot < member.moves.size() else 0
+		_r.check(move == int(row[4]) and member.pp_left(slot) > 0,
+			"class %d member %d slot %d knows move %d with %d PP, wanted %d." % [
+				row[0], row[2], row[3], move, member.pp_left(slot), row[4],
+			])
+		if int(row[5]) == 0:
+			continue
+		var plain: Gen2Party = Gen2TrainerParty.build(_r.data, int(row[0]), int(row[1]))
+		var without: int = int(plain.at(int(row[2]) - 1).moves[slot]) \
+			if slot < plain.at(int(row[2]) - 1).moves.size() else 0
+		_r.check(without != int(row[4]),
+			"class %d member %d knows its lone move with wLoneAttackNo clear." % [row[0], row[2]])
+
+
+## `wGymLeaderNo` is written behind `InitBattleEnemyParameters`, so the request
+## carries it as it stands when the fight opens and `ReadTrainer` reads it.
+func _the_gym_leader_stamps_the_lone_move() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, PEWTER_GYM, BROCK_APPROACH)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(not world.interact().is_empty(), "Brock said nothing."):
+		return
+	var request: Dictionary = _request_after(world)
+	var values: Dictionary = request.get("values", {})
+	if not _r.check(int(values.get("trainer_group", 0)) == BROCK_CLASS
+		and int(values.get("lone_attack", 0)) == BROCK_LONE_ATTACK,
+		"Brock's row asked for %s." % str(request)):
+		return
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_r.data, request, Gen2WorldBattleAdapter.fallback_party(_r.data)
+	)
+	var onix: Gen2BattleMon = (prepared.get("enemy_party") as Gen2Party).at(1) \
+		if bool(prepared.get("ok", false)) else null
+	var known: Array = onix.moves if onix != null else []
+	_r.check(known.size() > 2 and int(known[2]) == int(BROCK_ONIX_MOVE[_r.game_id]),
+		"Brock's Onix knows %s." % str(known))
+	world.complete_runtime_request({"outcome": Gen2WorldBattleAdapter.OUTCOME_WON})
+
+
+## `TrainerAI` over every class's first party at 1 HP with a burn and a bench,
+## so every gate but the roll passes.
+func _every_routine_acts() -> void:
+	var generator := RandomNumberGenerator.new()
+	var lead: Gen2BattleMon = Gen2BattleMon.create(
+		_r.data, FIGHT_LEAD, FIGHT_LEAD_LEVEL, _r.data.moves_at_level(FIGHT_LEAD, FIGHT_LEAD_LEVEL)
+	)
+	var routines: Dictionary = {}
+	for trainer_class: int in range(1, CLASS_COUNT + 1):
+		var routine: String = String(_r.data.trainer_attributes(trainer_class)["ai_routine"])
+		if routines.has(routine) or _r.data.trainer_party_count(trainer_class) == 0:
+			continue
+		routines[routine] = true
+		var enemy: Gen2Party = Gen2TrainerParty.build(_r.data, trainer_class, 0)
+		if enemy.size() < 2:
+			enemy = Gen2Party.create([enemy.at(0), Gen2BattleMon.create(
+				_r.data, FIGHT_LEAD, FIGHT_LEAD_LEVEL, [1]
+			)])
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			_r.data, Gen2Party.of(lead), enemy, generator, true, 0
+		)
+		battle.init_enemy_trainer(trainer_class, true)
+		var census: Dictionary = {}
+		for seed_value: int in ROUTINE_SEEDS:
+			generator.seed = seed_value
+			battle.gen1_ai_count = Gen1TrainerAI.COUNT_UNLOADED
+			battle.mon(Gen2Battle.ENEMY).hp = 1
+			battle.mon(Gen2Battle.ENEMY).status = Gen2Status.BURN
+			var action: Dictionary = Gen1TrainerAI.trainer_action(battle, generator)
+			if action.is_empty():
+				continue
+			var kind: Variant = int(action.get("item", 0))
+			if StringName(action["type"]) == Gen2Battle.ACTION_SWITCH:
+				kind = "switch"
+			census[kind] = int(census.get(kind, 0)) + 1
+		var expected: Dictionary = ROUTINE_SHARES[routine]
+		var same_kinds: bool = census.size() == expected.size()
+		for kind: Variant in expected:
+			same_kinds = same_kinds and census.has(kind)
+		if not _r.check(same_kinds,
+			"%s reached %s, expected %s." % [routine, str(census), str(expected.keys())]):
+			continue
+		for kind: Variant in expected:
+			var share: float = float(census[kind]) / float(ROUTINE_SEEDS)
+			_r.check(absf(share - float(expected[kind]) / 256.0) < SHARE_TOLERANCE,
+				"%s reached %s on %.3f of rolls, expected %d of 256." % [
+					routine, str(kind), share, int(expected[kind]),
+				])
+	_r.note("gen1 trainers %d AI routines act at their shares" % routines.size())
 
 
 ## `CheckFightingMapTrainers` walked from every cell of every trainer's own
@@ -390,6 +582,10 @@ func _a_trainer_is_beaten() -> void:
 		turns += 1
 	_r.check(battle.winner() == Gen2Battle.PLAYER,
 		"the trainer fight ended on %s after %d turns." % [battle.winner(), turns])
+	for member: Gen2BattleMon in enemy.mons:
+		for slot: int in member.moves.size():
+			_r.check(member.pp_left(slot) == int(_r.data.move(int(member.moves[slot])).get("pp", 0)),
+				"an opponent's move %d spent PP." % int(member.moves[slot]))
 
 
 ## Each of those rows run to `BlackScreen`.

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -40,6 +40,10 @@ const BALL_QUANTITIES: Dictionary = {
 ## before the question is asked.
 const TRAINER_CLASS: int = 1
 const PLAYER_SPECIES: Array[int] = [155, 152, 158]
+## A Generation 1 cache's stand-ins: Brock, whose Full Heal `gen1_item`
+## photographs, and three of Kanto's.
+const GEN1_TRAINER_CLASS: int = 34
+const GEN1_PLAYER_SPECIES: Array[int] = [25, 1, 4]
 const PLAYER_LEVEL: int = 30
 ## Four moves on the lead, so `MoveSelectionScreen`'s list is a full one:
 ## TACKLE, GROWL, TAIL_WHIP and BITE (constants/move_constants.asm).
@@ -340,29 +344,42 @@ func _open_world_stage() -> void:
 
 func _open_battle_stage() -> void:
 	var data: GameData = _screen.get("_data")
+	var gen1: bool = data.generation == RomRegistry.GEN1
+	var trainer_class: int = GEN1_TRAINER_CLASS if gen1 else TRAINER_CLASS
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 3
 	var members: Array = []
-	for species: int in PLAYER_SPECIES:
+	for species: int in GEN1_PLAYER_SPECIES if gen1 else PLAYER_SPECIES:
 		var lead: Array[int] = INFO_MOVES if _informing() else LEAD_MOVES
 		members.append(Gen2BattleMon.create(
 			data, species, PLAYER_LEVEL,
 			lead.duplicate() if members.is_empty() else [33]
 		))
-	var enemy: Gen2Party = Gen2TrainerParty.build(data, TRAINER_CLASS, 0)
+	var enemy: Gen2Party = Gen2TrainerParty.build(data, trainer_class, 0)
 	if enemy == null or enemy.size() < 2:
-		push_error("Trainer class %d has no bench to switch from" % TRAINER_CLASS)
+		push_error("Trainer class %d has no bench to switch from" % trainer_class)
 		quit(1)
 		return
 
 	## `AskUseNextPokemon` prints in a wild battle and returns at once in a
 	## trainer one, which is the only thing separating the two faint stages.
-	_screen.show_trainer(TRAINER_CLASS, 0, PLAYER_SPECIES[0], PLAYER_LEVEL)
+	_screen.show_trainer(trainer_class, 0, members[0].species, PLAYER_LEVEL)
 	var battle: Gen2Battle = Gen2Battle.create_parties(
 		data, Gen2Party.create(members), enemy, rng, _stage != "use_next"
 	)
 	battle.battle_style_set = false
+	battle.init_enemy_trainer(trainer_class)
 	_screen.set("_battle", battle)
+	if _stage == "gen1_item":
+		## A burned Geodude and the player's Growl, so the second half is the Full Heal.
+		battle.enemy.status = Gen2Status.BURN
+		_screen.set("_pending", battle.take_actions(
+			Gen2Battle.use_move(1), Gen2Battle.use_move(0)
+		))
+		_drain_to_line("FULL HEAL")
+		_screen.finish()
+		_settle_icons()
+		return
 	if _stage in ["use_next", "replace"]:
 		## Through the screen's own quarter, so the HUD in the picture is the HUD
 		## the faint left rather than the one the intro drew, and then the
@@ -517,6 +534,16 @@ func _drain_to_menu() -> void:
 func _drain() -> void:
 	for _press: int in 60:
 		if String(_screen.battle_snapshot()["switch_stage"]) != "":
+			return
+		_settle()
+		_screen.finish()
+		_screen.advance()
+
+
+## Presses through the turn until the box holds [param needle].
+func _drain_to_line(needle: String) -> void:
+	for _press: int in 60:
+		if String(_screen.battle_snapshot()["message"]).contains(needle):
 			return
 		_settle()
 		_screen.finish()


### PR DESCRIPTION
## Added
- `Gen1TrainerAI`: `SelectEnemyMove`'s four-way slot roll with its retries on a disabled or empty slot, `AIEnemyTrainerChooseMoves`' three layers over `TrainerClassMoveChoiceModifications`, and `TrainerAIPointers`' nineteen routines with `wAICount`, run inside the turn where `MainInBattleLoop` runs `TrainerAI`: in front of `ExecuteEnemyMove` on either ordering, so a potion answers the hit that just landed and a class's own switch offers the player nothing.
- `ReadTrainer`'s tail on every party: `LoneMoves` gated on `wLoneAttackNo`, `TeamMoves`, `.ChampionRival`'s starter row off `wRivalStarter`, and Yellow's `SpecialTrainerMoves`. Brock's Onix knows BIDE and the champion's Pidgeot SKY ATTACK.
- `AIBattleWithdrawText` and `AIBattleUseItemText` as the `trainer_ai` text run, drawn with the trainer's own name.
- `gen1_trainers.gd` pins both tables' census on all three cartridges, every routine's action share at 1 HP over 512 rolls, the four table moves and Brock's stamp; `test_gen1_trainer_ai.gd` covers the layers, the roll, the routines and the special-move rows; `tools/preview_battle_switch.gd -- red <out.png> gen1_item` photographs the Full Heal.

## Fixed
- An opponent's PP was spent on a Generation 1 cache, where `DecrementPP` has no enemy half.
- Quick Attack and Counter had no priority on a Generation 1 cache, both effect bytes being NO_ADDITIONAL_EFFECT; `MainInBattleLoop`'s two `cp`s and its `50 percent + 1` tie decide the order now.
- The source budget was over its own ceiling on `main` (41940 of 41874) and `_run_turn` was over the complexity ceiling; both are under again and the ceiling is 41873.

## Changed
- Cache format 135: a move row keeps its `gen1_effect` byte, a trainer class carries `ai_layers`, `ai_count` and `ai_routine`, and a party its `special_moves`.
