### PR TITLE
Build the Generation 1 opening from the copyright screen to the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ whatever shape it is, with a way back to the shipped art. It is kept under
 | Trainers, NPC trades | Class names, pics, palettes, AI flags, DVs and parties; trade records with DVs and OT data |
 | Sprites, palettes | Front/back for 251 species and 26 Unown forms; normal and shiny 15-bit colours |
 | Font, borders, HUD | 128 glyphs, eight text-box frames, HP/EXP bars and panels |
-| Splash, title, intro | Each cartridge's opening art, tilemaps and palette runs, including Crystal's 35-entry intro section |
+| Splash, title, intro | Each cartridge's opening art, tilemaps and palette runs, including Crystal's 35-entry intro section and Generation 1's `PlayIntro`, `DisplayTitleScreen` and `YellowIntro` tables |
 | Region map | Three graphics sheets, both region tilemaps, the per-tile palette map and 96 landmarks |
 | Prof Oak's PC, credits | The 19 `OakRatings` rows and their texts; `CreditsScript`'s whole command stream, or Generation 1's `CreditsOrder`, its strings, `CreditsMons` and `TheEndGfx` |
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
@@ -366,7 +366,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits of all six cartridges, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, the key-item and usable-item tables behind the bag, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, all 202 or 203 battle animations, the Hall of Fame's own pages, and Yellow's follower: its emotion table, its faces, its cries and the spawn every warp leaves it |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, the key-item and usable-item tables behind the bag, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, all 202 or 203 battle animations, the Hall of Fame's own pages, the opening from the copyright screen to the title on all three, and Yellow's follower: its emotion table, its faces, its cries and the spawn every warp leaves it |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/battle/accuracy.gd
+++ b/game/battle/accuracy.gd
@@ -1,12 +1,9 @@
 class_name Gen2Accuracy
 extends RefCounted
 
-## Whether a move connects.
-## Accuracy is a byte out of 255, not a percentage: "100%" stores 255 and "90%"
-## stores 229. Kept as the byte, because the roll is against it and a stored 255
-## is a special case that never misses.
-## Accuracy and evasion use their own multiplier table, a different shape from
-## the other stats', so -1 accuracy and -1 Attack are different fractions.
+## Whether a move connects. Accuracy is a byte out of 255, kept as the byte
+## because the roll is against it and a stored 255 never misses. Accuracy and
+## evasion have their own multiplier table, so -1 accuracy and -1 Attack differ.
 
 ## The move accuracy that cannot miss. Anything the stages leave below this rolls.
 const ALWAYS_HITS: int = 255

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -1,13 +1,11 @@
 class_name Gen2BattleAI
 extends RefCounted
 
-## Scores an enemy trainer's move choice the way the cartridge's own AI does.
-## Every slot starts at 20, or 80 with no PP. Each bit set in the trainer class's
-## [constant Gen2Layout.ATTR_AI_MOVE_WEIGHTS] runs one scoring layer over the four
-## slots, nudging scores up (discourage) or down (encourage); lowest wins, ties
-## broken at random. `scoring.asm` finds that minimum by decrementing counters,
-## which is an argmin rather than a rule, so [method choose_slot] takes it
-## directly. Percent chances use the cartridge's `X * 255 / 100` macro.
+## The cartridge's own AI move scoring: every slot starts at 20, or 80 with no
+## PP; each bit of the class's [constant Gen2Layout.ATTR_AI_MOVE_WEIGHTS] runs
+## one layer, discouraging up and encouraging down; lowest wins, ties at random.
+## `scoring.asm`'s decrementing counters are an argmin, which
+## [method choose_slot] takes directly. Chances use `X * 255 / 100`.
 
 ## Everything one scoring layer is allowed to read, which the cartridge reads
 ## straight out of WRAM.

--- a/game/battle/ai_items.gd
+++ b/game/battle/ai_items.gd
@@ -1,13 +1,11 @@
 class_name Gen2AIItems
 extends RefCounted
 
-## What a trainer reaches into its bag for, and what happens when it does:
-## `AI_TryItem` and the `EnemyUsed*` routines in `engine/battle/ai/items.asm`. A
-## class carries at most two item numbers (`TRNATTR_ITEM1` and `_ITEM2`, already
-## in the cache as [method GameData.trainer_attributes]) and its
-## `TRNATTR_AI_ITEM_SWITCH` word decides how freely they are spent. What the
-## player's own pack does with the same items is
-## [method Gen2Battle.use_bag_item]; nothing here is reached from it.
+## `AI_TryItem` and the `EnemyUsed*` routines (`engine/battle/ai/items.asm`). A
+## class carries at most two items (`TRNATTR_ITEM1` and `_ITEM2`, in
+## [method GameData.trainer_attributes]) and its `TRNATTR_AI_ITEM_SWITCH` word
+## decides how freely they are spent. The player's pack is
+## [method Gen2Battle.use_bag_item].
 
 ## The thirteen items the AI knows, at their cartridge numbers.
 const FULL_RESTORE: int = 0x0E

--- a/game/battle/ai_switch.gd
+++ b/game/battle/ai_switch.gd
@@ -1,13 +1,10 @@
 class_name Gen2AISwitch
 extends RefCounted
 
-## Whether a trainer pulls its Pokemon out, and which one it sends instead:
-## `CheckAbleToSwitch` and its five party scans in `engine/battle/ai/switch.asm`,
-## plus the three frequency gates in `items.asm`.
-## The cartridge works in six-bit masks and reuses one variable as both a score
-## and a party index; here the masks are arrays of indices and the two uses are
-## separate return values. Nothing changes: every scan keeps party order, and
-## every mask-to-index conversion takes the lowest index set.
+## `CheckAbleToSwitch` and its five party scans (`engine/battle/ai/switch.asm`)
+## plus the three frequency gates in `items.asm`. The cartridge's six-bit masks
+## are arrays of indices here; every scan keeps party order and a mask-to-index
+## conversion takes the lowest index set.
 
 ## `BASE_AI_SWITCH_SCORE`, where [method matchup_score] starts before anything
 ## nudges it.

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1,13 +1,11 @@
 class_name Gen2Battle
 extends RefCounted
 
-## A battle: two parties, a turn at a time. Scene-free with randomness injected,
-## so a whole battle can be fought in a test with no display.
-## A turn answers with events carrying their own numbers, never a string:
-## sentences, animation and draining bars are the screen's job. A side is a party
-## and a wild encounter a party of one. A turn ending with somebody down says so
-## through [method must_replace] and stands still until [method replace_fallen],
-## the only entry point besides [method take_actions] that moves a battle on.
+## A battle: two parties, a turn at a time, scene-free with randomness injected.
+## A turn answers with events carrying numbers, never a string. A turn ending
+## with somebody down says so through [method must_replace] and stands still
+## until [method replace_fallen], the only entry point besides
+## [method take_actions] that moves a battle on.
 
 ## Plain numbers rather than an enum: they are dictionary keys and event payloads
 ## throughout, and everything reading one compares it against these two.

--- a/game/battle/battle_anim_bg_effect.gd
+++ b/game/battle/battle_anim_bg_effect.gd
@@ -2,13 +2,10 @@ class_name Gen2BattleAnimBgEffect
 extends RefCounted
 
 ## One `battle_bg_effect` (macros/ram.asm): the four bytes a `wActiveBGEffects`
-## slot holds.
-##
-## `id` is `BG_EFFECT_STRUCT_FUNCTION`, and zero is what frees the slot, the way
-## a zero index frees an animation object. It stays the cartridge's own effect
-## number and is never normalised across the profiles: pokegold has no
-## `BATTLE_BG_EFFECT_BODY_SLAM` and its list runs one lower from $25 on, so the
-## same byte names a different effect in the two games.
+## slot holds. `id` is `BG_EFFECT_STRUCT_FUNCTION` and zero frees the slot. It
+## stays the cartridge's own number: pokegold has no
+## `BATTLE_BG_EFFECT_BODY_SLAM`, so the same byte from $25 on names a different
+## effect in the two games.
 
 var id: int = 0
 var jumptable_index: int = 0

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -1,13 +1,10 @@
 class_name Gen2BattleAnimBgEffects
 extends RefCounted
 
-## The `BATTLE_BG_EFFECT_*` jumptable and the routines it dispatches
-## (engine/battle_anims/bg_effects.asm): the screen shakes, the scanline
-## deformations, the palette fades and the tilemap edits. Five run at once.
-## An effect id is profile-local and is never normalised: pokegold ships no
-## `BATTLE_BG_EFFECT_BODY_SLAM`, so every id from $25 on names a different effect
-## in the two games; both jumptables are kept whole and dispatch is by name. The
-## Color branch is taken wherever the source asks `hCGB`, as everywhere else here.
+## The `BATTLE_BG_EFFECT_*` jumptable and its routines
+## (engine/battle_anims/bg_effects.asm); five run at once. An effect id is
+## profile-local: pokegold ships no `BATTLE_BG_EFFECT_BODY_SLAM`, so every id
+## from $25 on names a different effect, and dispatch is by name.
 
 ## `BattleBGEffects`, Crystal's own order. The index is the cartridge's effect
 ## id and entry 0 is `BattleBGEffect_End`, which is also the free-slot marker.

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -1,12 +1,10 @@
 class_name Gen2BattleAnimData
 extends RefCounted
 
-## The imported battle animation tables, read the way the cartridge reads them.
-## An importer caches a table as a whole region because every pointer inside one
-## is bank-local; this resolves them, an address minus the region's base being an
-## index into its bytes, which is what `add hl, de` does with the bank paged in.
-## Crystal gives each table a region; Generation 1 interleaves all four through
-## bank $1E, so it caches one and [method gen1_pointer] takes the table.
+## The imported battle animation tables. A table is cached as a whole region
+## because every pointer inside one is bank-local: an address minus the region's
+## base indexes its bytes. Generation 1 interleaves all four through bank $1E,
+## so it caches one and [method gen1_pointer] takes the table.
 
 ## `BattleAnimObjects` row fields, in the order `InitBattleAnimation` copies them.
 const OBJECT_FIELDS: Array[StringName] = [

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -2,12 +2,10 @@ class_name Gen2BattleAnimFunctions
 extends RefCounted
 
 ## The eighty motion callbacks `DoBattleAnimFrame` dispatches
-## (engine/battle_anims/functions.asm), plus the five helpers they are built from.
-## Nearly every one is a `BattleAnim_AnonJumptable` over two to four states, which
-## is a match on the object's own `jumptable_index`, and every value is a
-## cartridge byte and wraps like one. Scene-free: the three that reach past the
-## object, the ball palette, Sky Attack's `wOBP0` cycle and Surf's scanline
-## window, write player state a renderer reads rather than drawing.
+## (engine/battle_anims/functions.asm). Nearly every one is a
+## `BattleAnim_AnonJumptable` over the object's own `jumptable_index`, and every
+## value wraps like a cartridge byte. The ball palette, Sky Attack's `wOBP0`
+## cycle and Surf's scanline window write state a renderer reads.
 
 ## `BattleAnimSineWave` has 32 samples over half a turn, so the full turn is 64
 ## and `BattleAnim_Sine` masks its argument with $3f.

--- a/game/battle/battle_anim_object.gd
+++ b/game/battle/battle_anim_object.gd
@@ -1,12 +1,9 @@
 class_name Gen2BattleAnimObject
 extends RefCounted
 
-## One animation object: a `battle_anim_struct` and the two routines that read it
-## (engine/battle_anims/core.asm, helpers.asm). `anim_obj` names a row of
-## `BattleAnimObjects`, which supplies the frameset, the motion callback, the
-## palette and the graphics sheet, and a place to put it.
-## Every field is a cartridge byte: coordinates wrap at 256, and an object walking
-## off one side is that wrap rather than a clamp. `frame` starts at -1 because
+## One animation object: a `battle_anim_struct` (engine/battle_anims/core.asm,
+## helpers.asm). `anim_obj` names a `BattleAnimObjects` row. Every field is a
+## cartridge byte, so coordinates wrap at 256; `frame` starts at -1 because
 ## `GetBattleAnimFrame` increments before it reads.
 
 ## Byte positions inside the struct, as `battleanimobj` orders them. Only the

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -2,12 +2,10 @@ class_name Gen2BattleAnimScript
 extends RefCounted
 
 ## The battle animation command interpreter (engine/battle_anims/anim_commands.asm).
-## Nothing here draws, plays a sound or touches a palette: the commands are
-## reported and whoever is drawing decides what they look like.
-## Anything below [constant FIRST_COMMAND] is a delay rather than a command, so
-## `anim_wait N` is exactly N frames. The control flow is the cartridge's single
-## `wBattleAnimParent` word and single `wBattleAnimLoops` byte, so a call inside a
-## call loses the outer one; both are reproduced rather than generalised.
+## Nothing here draws: the commands are reported. Anything below
+## [constant FIRST_COMMAND] is a delay of exactly that many frames. The control
+## flow is one `wBattleAnimParent` word and one `wBattleAnimLoops` byte, so a
+## call inside a call loses the outer one.
 
 ## `FIRST_BATTLE_ANIM_CMD` (macros/scripts/battle_anims.asm). Every byte under it
 ## is a delay.

--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -1,14 +1,11 @@
 class_name Gen2BattleIntro
 extends RefCounted
 
-## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm) is a background
-## scroll, not a moving object: `SCX` is rewritten part way down the frame so the
-## top band comes in from one side and the middle from the other, and a band edge
-## falls inside the status panel, hence per scanline. The one part of the battle
-## presentation the two games do not share: Crystal drives `wLYOverrides` while
-## pokegold busy-waits on `rLY`. Neither band lands on zero, and
+## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm): `SCX` is
+## rewritten part way down the frame, so the top band comes in from one side
+## and the middle from the other, per scanline. Crystal drives `wLYOverrides`
+## while pokegold busy-waits on `rLY`. Neither band lands on zero;
 ## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles it.
-## [method sprites] says why the player is in two pieces while it runs.
 
 ## 32 tiles of 8, what an offset wraps at; past the screen's 160 is blank.
 const MAP_WIDTH: int = 256

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -1,14 +1,9 @@
 class_name Gen2BattleMenu
 extends RefCounted
 
-## What the player is asked on their own turn: `BattleMenu`'s FIGHT/PKMN/PACK/RUN
-## and `MoveSelectionScreen`'s move list (`engine/battle/core.asm`,
-## `engine/battle/menu.asm`).
-##
-## Scene-free, like [Gen2BattleSwitchMenu]: the geometry is [Gen2MenuBox]'s, the
-## rows and the cursor rules are here, and the battle screen owns the presses and
-## the drawing. Nothing here reads a battle; a caller builds the move rows from
-## the Pokemon that is out.
+## `BattleMenu`'s FIGHT/PKMN/PACK/RUN and `MoveSelectionScreen`'s move list
+## (`engine/battle/core.asm`, `engine/battle/menu.asm`), scene-free: the rows
+## and cursor rules are here, the battle screen owns the presses and drawing.
 
 ## `wBattleMenuCursorPosition`, which `BattleMenu.next` compares against: the
 ## menu's own 1-based position, counted along the rows.

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -1,13 +1,9 @@
 class_name Gen2BattleMon
 extends RefCounted
 
-## One Pokémon as a battle sees it: its stats, what it knows, how much is left
-## and how far its stats have been pushed around. Scene-free, reading cartridge
-## content through [GameData] and never a ROM.
-##
-## Stats are worked out at build time, which is when the cartridge works them
-## out, and only a level up recalculates them. Stages are applied on the way out
-## to the unmodified stat every time, hence stored separately.
+## One Pokémon as a battle sees it. Stats are worked out at build time, as the
+## cartridge does, and only a level up recalculates them; stages apply on the
+## way out to the unmodified stat every time, hence stored separately.
 
 ## What a Pokémon can carry into a battle, which is the same four slots
 ## [Gen2Learnset] fills.

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -1,12 +1,10 @@
 class_name Gen2BattleRenderer
 extends Control
 
-## Draws the battle field: two pics, two status panels, two HP bars, the exp bar
-## and whatever an animation is putting over them. Call [method set_battle_data]
-## once, then [method set_view] whenever the screen has new display values.
-## The pics are drawn through `wTilemap` rather than placed at a corner, because
-## that map is what an animation edits. Panels compose into one screen-sized index
-## buffer with index 0 transparent. Every background layer is one plane, so the
+## Draws the battle field: pics, status panels, HP and exp bars and whatever an
+## animation puts over them. [method set_battle_data] once, then
+## [method set_view] per display change. The pics go through `wTilemap`, which
+## is what an animation edits; every background layer is one plane, so the
 ## per-scanline scroll applies to all of them and to none of the objects.
 
 const TILE: int = Gen2Font.TILE

--- a/game/battle/battle_switch_menu.gd
+++ b/game/battle/battle_switch_menu.gd
@@ -2,13 +2,11 @@ class_name Gen2BattleSwitchMenu
 extends RefCounted
 
 ## `PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`
-## (`engine/battle/core.asm`): three callers, one list. `OfferSwitch`'s YES can be
-## backed out of; Baton Pass reaches `ForcePickPartyMonInBattle`, which cannot and
-## answers a refusal with `SFX_WRONG` and the list again; `ForcePlayerMonChoice`
-## is that forced list one wrapper lower, so it makes no `SwitchMonAlreadyOut`
-## check. Scene-free: [Gen2PartyMenuPage] draws the rows and the battle screen
-## owns the presses, and CANCEL is a row in both variants because
-## `SetUpBattlePartyMenu` goes through `InitPartyMenuWithCancel`.
+## (`engine/battle/core.asm`): `OfferSwitch`'s YES can be backed out of; Baton
+## Pass reaches `ForcePickPartyMonInBattle`, which answers a refusal with
+## `SFX_WRONG`; `ForcePlayerMonChoice` makes no `SwitchMonAlreadyOut` check.
+## CANCEL is a row in both because `SetUpBattlePartyMenu` goes through
+## `InitPartyMenuWithCancel`.
 
 ## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, its only movement flag.
 const WRAPS: bool = true

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -2,13 +2,11 @@ class_name Gen2BattleTransition
 extends RefCounted
 
 ## `DoBattleTransition` (engine/battle/battle_transition.asm) and Generation 1's
-## `BattleTransition` (engine/battle/battle_transitions.asm): what the overworld
-## does between the encounter and the battle screen. Node-free, so a whole one
-## steps headless, answering with a screen of cells, a DMG palette order and a
-## per-scanline offset. Crystal walks a jumptable an entry a frame and
-## Generation 1 is straight-line, but `BattleTransition_CircleData1` to `...5`
-## are [constant WEDGES] byte for byte and the two half-circle tables cover
-## [constant SPIN_QUADRANTS]' twenty positions.
+## `BattleTransition` (engine/battle/battle_transitions.asm), node-free: a whole
+## one steps headless into cells, a DMG palette order and a per-scanline offset.
+## Crystal walks a jumptable an entry a frame and Generation 1 is straight-line,
+## but `BattleTransition_CircleData1` to `...5` are [constant WEDGES] byte for
+## byte and the two half-circle tables cover [constant SPIN_QUADRANTS].
 
 const COLUMNS: int = 20
 const ROWS: int = 18

--- a/game/battle/battle_world_context.gd
+++ b/game/battle/battle_world_context.gd
@@ -1,12 +1,9 @@
 class_name Gen2BattleWorldContext
 extends RefCounted
 
-## Where a battle is being fought, as the world was when it started: the map and
-## its tileset, the player's cell and facing, and the time of day. A renderer
-## staging the fight on the map rather than on a white field needs the place as
-## well as the display values [Gen2BattleScreen] hands it. A copy taken at battle
-## start, not a handle on the world, so the two screens stay independent; the map
-## and tileset are named by number, which is what [method GameData.world_map]
+## Where a battle is fought, as the world was when it started: map, tileset,
+## the player's cell and facing, the time of day. A copy, not a handle on the
+## world; map and tileset are numbers, which is what [method GameData.world_map]
 ## takes.
 
 ## Group and number, the pair every map is addressed by, as

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -1,14 +1,11 @@
 class_name Gen2Damage
 extends RefCounted
 
-## The damage formula, in the order and the arithmetic the hardware uses. Every
-## step truncates and none of them commute, so this is a sequence rather than an
-## expression: the matchup applies one type at a time with a truncation between,
-## the critical multiplier lands before the cap and minimum, and the spread after
-## everything. The cartridge's four commands are [method damage_stats],
-## [method damage_calc], [method stab_damage] and [method apply_variation], run
-## one at a time because half a dozen effects write between two of them;
-## [method calculate_with] is the composition.
+## The damage formula in the hardware's order: every step truncates and none
+## commute, so it is a sequence. The cartridge's four commands are
+## [method damage_stats], [method damage_calc], [method stab_damage] and
+## [method apply_variation], run one at a time because half a dozen effects
+## write between two of them; [method calculate_with] is the composition.
 
 ## The cap lands before the minimum is added, so the biggest hit is 999 and the
 ## smallest that connects at all is 2.

--- a/game/battle/exp_bar_animation.gd
+++ b/game/battle/exp_bar_animation.gd
@@ -1,13 +1,10 @@
 class_name Gen2ExpBarAnimation
 extends RefCounted
 
-## The exp bar filling, one pixel at a time (`AnimateExpBar`). Not the HP bar
-## again: `.LoopLevels` fills to the end, raises the level and refills from empty,
-## so this is a list of segments, one per level crossed plus `.FinishExpBar`'s
-## partial fill. Its text ordering is the opposite of the HP bar's:
-## `Text_MonGainedExpPoint` is printed before `AnimateExpBar` and
-## `BattleText_StringBuffer1GrewToLevel` inside the loop. The three guards Gold
-## and Silver lack are unreachable from a gain, so nothing here is profile split.
+## `AnimateExpBar`, a pixel at a time: `.LoopLevels` fills to the end, raises
+## the level and refills, so this is a list of segments plus `.FinishExpBar`'s
+## partial fill. `Text_MonGainedExpPoint` prints before it and
+## `BattleText_StringBuffer1GrewToLevel` inside the loop.
 
 ## `EXP_BAR_LENGTH * TILE_WIDTH`: `CalcExpBar` returns `$40 - b` over eight
 ## tiles.

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -1,14 +1,10 @@
 class_name Gen2HeldItem
 extends RefCounted
 
-## `ITEMATTR_EFFECT` and `ITEMATTR_PARAM` read: tables and arithmetic, the shape
-## [Gen2Status], [Gen2Substatus] and [Gen2Weather] have.
-##
-## Only the effects a real item carries are named; the twenty more
-## `constants/item_data_constants.asm` defines reach no item, which
-## `HandleStatBoostingHeldItems`' own comment says. Thick Club and Light Ball
-## carry no held effect at all and are checked by number through
-## `SpeciesItemBoost`.
+## `ITEMATTR_EFFECT` and `ITEMATTR_PARAM` read. Only the effects a real item
+## carries are named; the twenty more `constants/item_data_constants.asm`
+## defines reach no item, as `HandleStatBoostingHeldItems`' own comment says.
+## Thick Club and Light Ball are checked by number through `SpeciesItemBoost`.
 
 const NONE: int = 0
 

--- a/game/battle/hp_bar_animation.gd
+++ b/game/battle/hp_bar_animation.gd
@@ -1,12 +1,10 @@
 class_name Gen2HpBarAnimation
 extends RefCounted
 
-## The HP bar draining or filling, one pixel at a time
-## (engine/battle/anim_hp_bar.asm). The bar arrives before the message that
-## describes the hit: `NormalHit` runs `applydamage` before `criticaltext`.
-## `_AnimateHPBar`'s two branches are keyed on whether the maximum reaches
-## `HP_BAR_LENGTH_PX`; both redraw one pixel per iteration, and what differs is
-## the HP number [method hp] answers.
+## The HP bar draining or filling a pixel at a time (engine/battle/anim_hp_bar.asm).
+## It arrives before the hit's message: `NormalHit` runs `applydamage` before
+## `criticaltext`. `_AnimateHPBar`'s two branches key on whether the maximum
+## reaches `HP_BAR_LENGTH_PX`; what differs is the HP number [method hp] answers.
 
 ## `HP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels.
 const LENGTH_PX: int = Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE

--- a/game/battle/party.gd
+++ b/game/battle/party.gd
@@ -1,12 +1,9 @@
 class_name Gen2Party
 extends RefCounted
 
-## The Pokémon one side of a battle has, and which of them is out.
-## An ordered list and a cursor into it, not a set: the order is what a switch
-## menu shows and what a replacement is chosen from, and the first entry leads. A
-## wild battle is a party of one, so it needs no special case.
-## Fainted Pokémon stay in the list, still counting against the six. A battle is
-## lost when all of them are down, not when the list runs out.
+## The Pokémon one side has and which is out: an ordered list and a cursor, the
+## order a switch menu shows. A wild battle is a party of one. Fainted Pokémon
+## stay in the list; a battle is lost when all of them are down.
 
 ## What a trainer can carry. Six is a rule of these games rather than of this
 ## class, but a party that is longer is a bug somewhere upstream and is worth

--- a/game/battle/screens.gd
+++ b/game/battle/screens.gd
@@ -1,12 +1,9 @@
 class_name Gen2Screens
 extends RefCounted
 
-## `wPlayerScreens` and `wEnemyScreens`: the flags that belong to a side of the
-## field rather than to whoever is standing on it. Nothing clears these on a
-## switch, which is the whole difference between them and [Gen2Substatus]: a
-## Reflect put up by one Pokemon still halves damage for the one sent out behind
-## it. Only the counters ending them do. Pure arithmetic and no state, the same
-## shape as [Gen2Weather].
+## `wPlayerScreens` and `wEnemyScreens`: flags that belong to a side of the
+## field. Nothing but their counters clears them on a switch, the whole
+## difference from [Gen2Substatus]. Pure arithmetic, like [Gen2Weather].
 
 ## `constants/battle_constants.asm`'s bit numbers, kept rather than renumbered so
 ## a `bit SCREENS_REFLECT` in the source reads across. Bit 1 is skipped there and

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -1,12 +1,9 @@
 class_name Gen2Stats
 extends RefCounted
 
-## Base stats, DVs and stat experience into the numbers a battle is fought with.
-##
-## Integer arithmetic in the hardware's order: every division truncates, and a
-## tidier rearrangement gives a different answer often enough to matter. A DV is
-## four bits per stat, and HP's is assembled from the other four rather than
-## stored, which is the same reading that decides shininess.
+## Base stats, DVs and stat experience into the numbers a battle is fought with,
+## in the hardware's integer order: every division truncates. HP's DV is
+## assembled from the other four, the same reading that decides shininess.
 
 ## The floors the formula ends on: a level 1 Pokémon still has 5 and 11.
 const STAT_MIN_NORMAL: int = 5

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -1,13 +1,10 @@
 class_name Gen2Status
 extends RefCounted
 
-## One byte as the cartridge stores it: the low three bits are turns of sleep
-## left and the four above are one flag each. That is the rule as well as the
-## storage, since one status at a time falls out of checking the byte whole.
-##
-## Sleep, freeze and paralysis are checked before a move; burn and paralysis bend
-## a stat where it is read; burn and poison take a slice at the end of the turn.
-## The arithmetic behind that, holding no state.
+## One status byte as the cartridge stores it: the low three bits are turns of
+## sleep left and the four above are one flag each, which is why one status
+## holds at a time. Sleep, freeze and paralysis are checked before a move; burn
+## and paralysis bend a stat where it is read; burn and poison bite at turn end.
 
 ## The low three bits: turns of sleep left, from 1 to 7.
 const SLEEP_MASK: int = 0b111

--- a/game/battle/trainer_party.gd
+++ b/game/battle/trainer_party.gd
@@ -1,13 +1,9 @@
 class_name Gen2TrainerParty
 extends RefCounted
 
-## Turns one of a trainer class's individual trainers into a battle-ready party.
-## Lives here rather than beside [Gen2Learnset] because it produces
-## [Gen2BattleMon]s and the data layer holds no battle types.
-##
-## A NORMAL or ITEM trainer's Pokemon knows what its level teaches; a MOVES or
-## ITEM_MOVES trainer's knows exactly the moves stored with it. DVs are the
-## per-class word rather than [constant Gen2BattleMon.PERFECT_DVS]. This is also
+## One of a trainer class's individual trainers as a battle-ready party. A
+## NORMAL or ITEM trainer's Pokemon knows what its level teaches; MOVES and
+## ITEM_MOVES know the stored moves. DVs are the per-class word. This is also
 ## where [constant Gen2Rules.CHALLENGE_HARD]'s rules land, one rule not 800 teams.
 
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -81,6 +81,7 @@ var _unown_words: PackedStringArray = PackedStringArray()
 var _unown_walls: PackedStringArray = PackedStringArray()
 var _odd_eggs: Array = []
 var _credits: Dictionary = {}
+var _opening: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _unown_puzzle: Dictionary = {}
 var _diploma: Dictionary = {}
@@ -199,6 +200,7 @@ const MANIFEST_DICTIONARIES: Dictionary = {
 	"decorations": "_decorations",
 	"mom_phone": "_mom_phone",
 	"credits": "_credits",
+	"opening": "_opening",
 	"intro_movie": "_intro_movie",
 	"unown_puzzle": "_unown_puzzle",
 	"diploma": "_diploma",
@@ -2289,6 +2291,12 @@ func credits_string(index: int) -> PackedByteArray:
 ## string printed from column 2. -1 on a cache without the credits.
 func credits_index(name: String) -> int:
 	return int(_credits.get(name, -1))
+
+
+## `PlayIntro`'s and `DisplayTitleScreen`'s tables, as [method Gen1Importer.read_opening]
+## wrote them. Empty on a cache with no Generation 1 opening.
+func opening() -> Dictionary:
+	return _opening
 
 
 ## Generation 1's own `db -n` column per string; -1 outside the table.

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -142,12 +142,44 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_facility_text,
 	_verify_dex_ratings,
 	_verify_credits,
+	_verify_opening,
 	_verify_overworld_coords,
 	_verify_field_moves,
 	_verify_intro,
 	_verify_world,
 	_verify_gym_gates,
 ]
+
+## The opening's art, each strip under its layout pin; a pin a cartridge lacks
+## is a sheet it has no screen for.
+const OPENING_TILE_SHEETS: Dictionary = {
+	"splash_star": {"pin": "splash_falling_star", "tiles": Gen1Layout.SPLASH_STAR_TILES, "first_code": 0, "bits": 2},
+	"splash_logo": {"pin": "splash_logo_tiles", "tiles": Gen1Layout.SPLASH_LOGO_TILES, "first_code": 0, "bits": 2},
+	"intro_back_mon": {"pin": "intro_back_mon", "tiles": Gen1Layout.INTRO_BACK_MON_TILES, "first_code": 0, "bits": 2},
+	"intro_front_mon": {
+		"pin": "intro_front_mon",
+		"tiles": Gen1Layout.INTRO_FRONT_MON_POSE_TILES * Gen1Layout.INTRO_FRONT_MON_POSES,
+		"first_code": 0, "bits": 2,
+	},
+	"title_logo": {
+		"pin": "title_logo_tiles",
+		"tiles": {
+			RomRegistry.RED: Gen1Layout.TITLE_LOGO_TILES_RED_BLUE,
+			RomRegistry.BLUE: Gen1Layout.TITLE_LOGO_TILES_RED_BLUE,
+			RomRegistry.YELLOW: Gen1Layout.TITLE_LOGO_TILES_YELLOW,
+		},
+		"first_code": 0, "bits": 2,
+	},
+	"title_version": {"pin": "title_version_tiles", "tiles": Gen1Layout.TITLE_VERSION_TILES, "first_code": 0, "bits": 1},
+	"title_player": {"pin": "title_player_tiles", "tiles": Gen1Layout.TITLE_PLAYER_TILES, "first_code": 0, "bits": 2},
+	"title_logo_corner": {"pin": "title_logo_corner", "tiles": Gen1Layout.TITLE_LOGO_CORNER_TILES, "first_code": 0, "bits": 2},
+	"title_pikachu_bg": {"pin": "title_pikachu_bg", "tiles": Gen1Layout.TITLE_PIKACHU_BG_TILES, "first_code": 0, "bits": 2},
+	"title_pikachu_ob": {"pin": "title_pikachu_ob", "tiles": Gen1Layout.TITLE_PIKACHU_OB_TILES, "first_code": 0, "bits": 2},
+	"title_nine": {"pin": "title_nine_tile", "tiles": 1, "first_code": 0, "bits": 2},
+	"yellow_intro_gfx_1": {"pin": "yellow_intro_gfx_1", "tiles": Gen1Layout.YELLOW_INTRO_GFX_1_TILES, "first_code": 0, "bits": 2},
+	"yellow_intro_gfx_2": {"pin": "yellow_intro_gfx_2", "tiles": Gen1Layout.YELLOW_INTRO_GFX_2_TILES, "first_code": 0, "bits": 2},
+	"yellow_intro_clouds": {"pin": "yellow_intro_clouds", "tiles": Gen1Layout.YELLOW_INTRO_CLOUD_TILES, "first_code": 0, "bits": 2},
+}
 
 const NEW_NAME: String = "NEW NAME"
 
@@ -572,6 +604,34 @@ static func _verify_intro(rom: RomFile, layout: Dictionary) -> Dictionary:
 		or rom.u8(warp + Gen1Layout.NEW_GAME_WARP_TILESET_AT) \
 			>= Gen1Layout.tileset_count(rom.id):
 		return _fail("NewGameWarp names map %d." % rom.u8(warp))
+	return _ok()
+
+
+## The opening's tables, each pinned by a byte only it carries.
+static func _verify_opening(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var waves: Array = read_small_star_waves(rom, layout)
+	if waves.size() != Gen1Layout.SPLASH_SMALL_STAR_WAVES:
+		return _fail("SmallStarsWaveCoordsPointerTable does not hold four waves.")
+	for name: String in ["pal_packet_splash", "pal_packet_intro", "pal_packet_title"]:
+		if rom.u8(int(layout[name])) != Gen1Layout.PAL_SET_COMMAND:
+			return _fail("%s does not open on PAL_SET." % name)
+	for name: String in ["blk_packet_splash", "blk_packet_intro", "blk_packet_title"]:
+		if read_attr_blocks(rom, int(layout[name])).size() != Gen1Layout.ATTR_BLK_MAX_ROWS:
+			return _fail("%s does not hold three ATTR_BLK rows." % name)
+	for index: int in Gen1Layout.INTRO_TILEMAPS:
+		var row: Dictionary = read_tile_id_list(rom, layout, Gen1Layout.INTRO_TILEMAP_FIRST + index)
+		if int(row.get("columns", 0)) != Gen2PicImage.FRONTPIC_TILES \
+				or int(row.get("rows", 0)) != Gen2PicImage.FRONTPIC_TILES:
+			return _fail("GengarIntroTiles%d is not 7x7." % (index + 1))
+	if layout.has("title_mons"):
+		for slot: int in Gen1Layout.TITLE_MONS:
+			if Gen1Layout.dex_of_index(rom, layout, rom.u8(int(layout["title_mons"]) + slot)) < 1:
+				return _fail("TitleMons row %d is no species." % slot)
+		if read_nidorino_animations(rom, layout).size() != Gen1Layout.INTRO_NIDORINO_ANIMS:
+			return _fail("IntroNidorinoAnimation1 to 7 do not each end on ANIMATION_END.")
+	if layout.has("yellow_intro_frames") \
+			and read_animated_object_frames(rom, layout).size() != Gen1Layout.YELLOW_INTRO_FRAMESETS:
+		return _fail("YellowIntro_AnimatedObjectFramesData does not hold eleven framesets.")
 	return _ok()
 
 
@@ -1014,6 +1074,7 @@ func import_rom(
 		"special_text": _import_facility_text(rom, layout),
 		"oak_ratings": _import_dex_ratings(rom, layout),
 		"credits": read_credits(rom, layout),
+		"opening": read_opening(rom, layout),
 		"vending": _import_vending(rom, layout, items),
 		"prizes": _import_prizes(rom, layout),
 		"town_map": _import_town_map(rom, layout),
@@ -1630,6 +1691,241 @@ static func read_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
 	}
 
 
+## Everything `PlayIntro` and `DisplayTitleScreen` read that is not a tile.
+static func read_opening(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {
+		"shooting_star_oam": read_oam_rows(
+			rom, int(layout["splash_shooting_star_oam"]), Gen1Layout.SPLASH_SHOOTING_STAR_SPRITES
+		),
+		"logo_oam": read_oam_rows(
+			rom, int(layout["splash_logo_oam"]), Gen1Layout.SPLASH_LOGO_OAM_SPRITES
+		),
+		"small_star_oam": read_oam_rows(rom, int(layout["splash_small_star_oam"]), 1)[0],
+		"small_star_waves": read_small_star_waves(rom, layout),
+		"palettes": {},
+		"blocks": {},
+	}
+	for name: String in ["splash", "intro", "title", "generic", "beach"]:
+		if layout.has("pal_packet_%s" % name):
+			out["palettes"][name] = read_pal_packet(rom, layout, int(layout["pal_packet_%s" % name]))
+		if layout.has("blk_packet_%s" % name):
+			out["blocks"][name] = read_attr_blocks(rom, int(layout["blk_packet_%s" % name]))
+	var tilemaps: Array = []
+	for index: int in Gen1Layout.INTRO_TILEMAPS:
+		tilemaps.append(
+			read_tile_id_list(rom, layout, Gen1Layout.INTRO_TILEMAP_FIRST + index)["ids"]
+		)
+	out["gengar_tilemaps"] = tilemaps
+	if layout.has("title_mons"):
+		out["nidorino_anims"] = read_nidorino_animations(rom, layout)
+		var mons: Array = []
+		for slot: int in Gen1Layout.TITLE_MONS:
+			mons.append(Gen1Layout.dex_of_index(rom, layout, rom.u8(int(layout["title_mons"]) + slot)))
+		out["title_mons"] = mons
+		out["version_text"] = Array(_bytes_until(
+			rom, int(layout["title_version_text"]), Gen1Text.TERMINATOR,
+			Gen1Layout.TITLE_VERSION_TEXT_MAX
+		))
+	if layout.has("yellow_intro_frames"):
+		out["yellow"] = read_yellow_opening(rom, layout)
+	return out
+
+
+## `dbsprite` rows as `[y, x, tile, attributes]`.
+static func read_oam_rows(rom: RomFile, at: int, count: int) -> Array:
+	var out: Array = []
+	for index: int in count:
+		var row: int = at + index * Gen1Layout.OAM_ROW_SIZE
+		out.append([rom.u8(row), rom.u8(row + 1), rom.u8(row + 2), rom.u8(row + 3)])
+	return out
+
+
+## `SmallStarsWaveCoordsPointerTable`'s four waves of four `[y, x]`; Yellow's
+## Color palette byte behind each pair is stepped over by the stride.
+static func read_small_star_waves(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout["splash_small_star_waves"])
+	var bank: int = RomFile.bank_of(table)
+	var out: Array = []
+	var starts: Array[int] = []
+	for wave: int in Gen1Layout.SPLASH_SMALL_STAR_WAVES + 1:
+		starts.append(Gen1Layout.banked(bank, rom.u16le(table + wave * Gen1Layout.POINTER_SIZE)))
+	if rom.u8(starts[Gen1Layout.SPLASH_SMALL_STAR_WAVES]) != 0xFF:
+		return []
+	var stride: int = (starts[1] - starts[0]) / Gen1Layout.SPLASH_SMALL_STAR_WAVE_SPRITES
+	if stride < 2:
+		return []
+	for wave: int in Gen1Layout.SPLASH_SMALL_STAR_WAVES:
+		var rows: Array = []
+		for sprite: int in Gen1Layout.SPLASH_SMALL_STAR_WAVE_SPRITES:
+			var at: int = starts[wave] + sprite * stride
+			rows.append([rom.u8(at), rom.u8(at + 1)])
+		out.append(rows)
+	return out
+
+
+static func read_nidorino_animations(rom: RomFile, layout: Dictionary) -> Array:
+	var out: Array = []
+	var at: int = int(layout["intro_nidorino_anims"])
+	for table: int in Gen1Layout.INTRO_NIDORINO_ANIMS:
+		var rows: Array = []
+		while rom.in_bounds(at, 2) and rom.u8(at) != Gen1Layout.INTRO_ANIMATION_END:
+			rows.append([_signed(rom.u8(at)), _signed(rom.u8(at + 1))])
+			at += 2
+			if rows.size() > Gen1Layout.INTRO_ANIMATION_END:
+				return []
+		if not rom.in_bounds(at, 1):
+			return []
+		at += 1
+		out.append(rows)
+	return out
+
+
+static func read_tile_id_list(rom: RomFile, layout: Dictionary, index: int) -> Dictionary:
+	var table: int = int(layout["tile_id_lists"])
+	var row: int = table + index * Gen1Layout.TILE_ID_LIST_ROW_SIZE
+	var at: int = Gen1Layout.banked(RomFile.bank_of(table), rom.u16le(row))
+	var shape: int = rom.u8(row + Gen1Layout.POINTER_SIZE)
+	var columns: int = shape & 0xF
+	var rows: int = shape >> 4
+	var ids: Array = []
+	for cell: int in columns * rows:
+		ids.append(rom.u8(at + cell))
+	return {"ids": ids, "columns": columns, "rows": rows}
+
+
+## `PAL_SET`'s four palettes as `SuperPalettes` rows.
+static func read_pal_packet(rom: RomFile, layout: Dictionary, at: int) -> Array:
+	var out: Array = []
+	for slot: int in Gen1Layout.PAL_SET_PALETTES:
+		var named: int = rom.u16le(at + Gen1Layout.PAL_SET_ROW + slot * Gen1Layout.POINTER_SIZE)
+		var row: int = Gen1Layout.super_palette_offset(layout, named)
+		var colors: Array = []
+		for index: int in Gen1Layout.SUPER_PALETTE_COLORS:
+			colors.append(rom.u16le(row + index * PokePalette.COLOR_BYTES))
+		out.append(colors)
+	return out
+
+
+static func read_attr_blocks(rom: RomFile, at: int) -> Array:
+	var count: int = rom.u8(at + Gen1Layout.ATTR_BLK_COUNT_AT)
+	if count < 1 or count > Gen1Layout.ATTR_BLK_MAX_ROWS:
+		return []
+	var out: Array = []
+	for index: int in count:
+		var row: int = at + Gen1Layout.ATTR_BLK_ROWS_AT + index * Gen1Layout.ATTR_BLK_ROW_SIZE
+		var values: Array = []
+		for byte: int in Gen1Layout.ATTR_BLK_ROW_SIZE:
+			values.append(rom.u8(row + byte))
+		out.append(values)
+	return out
+
+
+## Yellow's own intro and title tables.
+static func read_yellow_opening(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var tilemaps: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_TILEMAPS.size():
+		var shape: Vector2i = Gen1Layout.YELLOW_INTRO_TILEMAPS[index]
+		var ids: Array = []
+		var at: int = int(layout["yellow_intro_tilemap_%d" % (index + 1)])
+		for cell: int in shape.x * shape.y:
+			ids.append(rom.u8(at + cell))
+		tilemaps.append({"columns": shape.x, "rows": shape.y, "ids": ids})
+	var bars: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_SPEED_BARS:
+		var at: int = int(layout["yellow_intro_speed_bars"]) + index * 3
+		bars.append([rom.u8(at), rom.u8(at + 1), rom.u8(at + 2)])
+	var spawns: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_SPAWN_STATES:
+		var at: int = int(layout["yellow_intro_spawn_states"]) + index * 3
+		spawns.append([rom.u8(at), rom.u8(at + 1), rom.u8(at + 2)])
+	var sine: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_SINE_BYTES:
+		sine.append(_signed(rom.u8(int(layout["yellow_intro_sine"]) + index)))
+	var words: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_SINE_WORDS:
+		words.append(rom.u16le(int(layout["yellow_intro_sine_words"]) + index * 2))
+	return {
+		"tilemaps": tilemaps,
+		"speed_bars": bars,
+		"pal_flash": Array(_bytes_until(
+			rom, int(layout["yellow_intro_pal_flash"]), Gen1Layout.YELLOW_INTRO_PAL_END, 64
+		)),
+		"pal_fade": Array(_bytes_until(
+			rom, int(layout["yellow_intro_pal_fade"]), Gen1Layout.YELLOW_INTRO_PAL_END, 64
+		)),
+		"spawn_states": spawns,
+		"frames": read_animated_object_frames(rom, layout),
+		"oam_sets": read_animated_object_oam(rom, layout),
+		"title_logo_tilemap": _tilemap_rows(rom, int(layout["title_logo_tilemap"]), Gen1Layout.TITLE_LOGO_TILEMAP),
+		"title_bubble_tilemap": _tilemap_rows(rom, int(layout["title_bubble_tilemap"]), Gen1Layout.TITLE_BUBBLE_TILEMAP),
+		"title_pikachu_tilemap": _tilemap_rows(rom, int(layout["title_pikachu_tilemap"]), Gen1Layout.TITLE_PIKACHU_TILEMAP),
+		"title_eyes_oam": read_oam_rows(rom, int(layout["title_eyes_oam"]), Gen1Layout.TITLE_EYES_SPRITES),
+		"sine": sine,
+		"sine_words": words,
+	}
+
+
+## `YellowIntro_AnimatedObjectFramesData`, `endanim` kept as -1 and `dorestart` as -2.
+static func read_animated_object_frames(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout["yellow_intro_frames"])
+	var bank: int = RomFile.bank_of(table)
+	var out: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_FRAMESETS:
+		var at: int = Gen1Layout.banked(bank, rom.u16le(table + index * Gen1Layout.POINTER_SIZE))
+		var rows: Array = []
+		while rom.in_bounds(at, 1):
+			var command: int = rom.u8(at)
+			if command == Gen1Layout.ANIM_FRAME_END:
+				rows.append([-1, 0])
+				break
+			if command == Gen1Layout.ANIM_FRAME_RESTART:
+				rows.append([-2, 0])
+				break
+			rows.append([command, rom.u8(at + 1)])
+			at += 2
+			if rows.size() > 64:
+				return []
+		if rows.is_empty() or rows[rows.size() - 1][0] >= 0:
+			return []
+		out.append(rows)
+	return out
+
+
+## `YellowIntro_AnimatedObjectOAMData`: a tile offset and a counted list a row.
+static func read_animated_object_oam(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout["yellow_intro_oam"])
+	var bank: int = RomFile.bank_of(table)
+	var out: Array = []
+	for index: int in Gen1Layout.YELLOW_INTRO_OAM_SETS:
+		var row: int = table + index * 3
+		var at: int = Gen1Layout.banked(bank, rom.u16le(row + 1))
+		out.append({
+			"tile": rom.u8(row),
+			"sprites": read_oam_rows(rom, at + 1, rom.u8(at)),
+		})
+	return out
+
+
+static func _tilemap_rows(rom: RomFile, at: int, shape: Vector2i) -> Array:
+	var ids: Array = []
+	for cell: int in shape.x * shape.y:
+		ids.append(rom.u8(at + cell))
+	return ids
+
+
+static func _bytes_until(rom: RomFile, at: int, stop: int, limit: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	for index: int in limit:
+		if not rom.in_bounds(at + index, 1) or rom.u8(at + index) == stop:
+			return out
+		out.append(rom.u8(at + index))
+	return out
+
+
+static func _signed(byte: int) -> int:
+	return byte - 0x100 if byte >= 0x80 else byte
+
+
 static func read_credits_order(rom: RomFile, layout: Dictionary) -> PackedByteArray:
 	var out := PackedByteArray()
 	var at: int = int(layout["credits_order"])
@@ -2190,6 +2486,14 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for sheet: String in BATTLE_TILE_SHEETS:
 		var run: Dictionary = (BATTLE_TILE_SHEETS[sheet] as Dictionary).duplicate()
 		run["offset"] = int(layout[sheet])
+		sheets[sheet] = run
+	for sheet: String in OPENING_TILE_SHEETS:
+		var run: Dictionary = (OPENING_TILE_SHEETS[sheet] as Dictionary).duplicate()
+		if not layout.has(run["pin"]):
+			continue
+		run["offset"] = int(layout[run["pin"]])
+		if run["tiles"] is Dictionary:
+			run["tiles"] = int(run["tiles"].get(rom.id, 0))
 		sheets[sheet] = run
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var out: Dictionary = {}

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -783,6 +783,60 @@ const COPYRIGHT_TILES_RED_BLUE: int = 28
 const COPYRIGHT_TILES_YELLOW: int = 30
 const COPYRIGHT_ROWS: int = 3
 
+## `PlayIntro` and `DisplayTitleScreen`: `GameFreakIntro` is thirteen tiles,
+## six and a blank; the Gengar 95 and a blank; the front mon three poses of 36.
+const SPLASH_LOGO_TILES: int = 20
+const SPLASH_STAR_TILES: int = 1
+const INTRO_BACK_MON_TILES: int = 96
+const INTRO_FRONT_MON_POSE_TILES: int = 36
+const INTRO_FRONT_MON_POSES: int = 3
+const INTRO_NIDORINO_ANIMS: int = 7
+const INTRO_ANIMATION_END: int = 80
+const INTRO_TILEMAP_FIRST: int = 3
+const INTRO_TILEMAPS: int = 3
+const TILE_ID_LIST_ROW_SIZE: int = 3
+const SPLASH_LOGO_OAM_SPRITES: int = 16
+const SPLASH_SHOOTING_STAR_SPRITES: int = 4
+const SPLASH_SMALL_STAR_WAVES: int = 4
+const SPLASH_SMALL_STAR_WAVE_SPRITES: int = 4
+const TITLE_LOGO_TILES_RED_BLUE: int = 112
+const TITLE_LOGO_TILES_YELLOW: int = 115
+const TITLE_PLAYER_TILES: int = 35
+const TITLE_MONS: int = 16
+const TITLE_VERSION_TILES: Dictionary = {RomRegistry.RED: 10, RomRegistry.BLUE: 8}
+const TITLE_VERSION_TEXT_MAX: int = 16
+const TITLE_LOGO_CORNER_TILES: int = 3
+const TITLE_PIKACHU_BG_TILES: int = 64
+const TITLE_PIKACHU_OB_TILES: int = 12
+const TITLE_EYES_SPRITES: int = 8
+const TITLE_LOGO_TILEMAP: Vector2i = Vector2i(16, 7)
+const TITLE_BUBBLE_TILEMAP: Vector2i = Vector2i(7, 4)
+const TITLE_PIKACHU_TILEMAP: Vector2i = Vector2i(12, 9)
+## `YellowIntroGraphics2` less the last tile `CopyVideoData` is told to leave.
+const YELLOW_INTRO_GFX_1_TILES: int = 128
+const YELLOW_INTRO_GFX_2_TILES: int = 255
+const YELLOW_INTRO_CLOUD_TILES: int = 8
+const YELLOW_INTRO_TILEMAPS: Array[Vector2i] = [Vector2i(20, 6), Vector2i(4, 3), Vector2i(2, 2)]
+const YELLOW_INTRO_SPEED_BARS: int = 8
+const YELLOW_INTRO_SPAWN_STATES: int = 11
+const YELLOW_INTRO_FRAMESETS: int = 11
+const YELLOW_INTRO_OAM_SETS: int = 20
+const YELLOW_INTRO_SINE_BYTES: int = 32
+const YELLOW_INTRO_SINE_WORDS: int = 32
+const YELLOW_INTRO_PAL_END: int = 0xFF
+const ANIM_FRAME_END: int = 0xFF
+const ANIM_FRAME_RESTART: int = 0xFE
+const ANIM_FRAME_DURATION_MASK: int = 0x3F
+## `PAL_SET`'s and `ATTR_BLK`'s bytes.
+const PAL_SET_COMMAND: int = 0x51
+const PAL_SET_ROW: int = 1
+const OAM_ROW_SIZE: int = 4
+const PAL_SET_PALETTES: int = 4
+const ATTR_BLK_COUNT_AT: int = 1
+const ATTR_BLK_ROWS_AT: int = 2
+const ATTR_BLK_ROW_SIZE: int = 6
+const ATTR_BLK_MAX_ROWS: int = 3
+
 ## `LoadPokedexTilePatterns`: `PokedexTileGraphics` at `vChars2 tile $60`, over
 ## the text box sheet, with `PokeballTileGraphics`' first tile at $72 behind it.
 const POKEDEX_TILES: int = 18
@@ -1370,6 +1424,12 @@ const PIKACHU_CRIES: int = 43
 const PIKACHU_CRY_ROW_SIZE: int = 3
 const PIKACHU_CRY_LEAD_FRAMES: int = 3
 const PIKACHU_CRY_SAMPLES_PER_FRAME: int = 394
+
+
+## `PlayPikachuSoundClip`'s frames for a clip of [param clip_bytes].
+static func pikachu_cry_frames(clip_bytes: int) -> int:
+	return PIKACHU_CRY_LEAD_FRAMES \
+		+ ceili(float(clip_bytes * 8) / float(PIKACHU_CRY_SAMPLES_PER_FRAME))
 ## `DisplayTextIDInit`'s `CopyScreenTileBufferToVRAM` and `LoadFontTilePatterns`,
 ## measured from the A press to `TalkToPikachu` on the cartridge.
 const TEXT_INIT_FRAMES: int = 20
@@ -2144,6 +2204,28 @@ const RED_BLUE: Dictionary = {
 	"credits_the_end": 0x7473E,
 	"copyright_tiles": 0x120C8,
 	"copyright_text": 0x04556,
+	"splash_falling_star": 0x70190,
+	"splash_logo_tiles": 0x41959,
+	"splash_small_star_oam": 0x700EE,
+	"splash_small_star_waves": 0x700F2,
+	"splash_logo_oam": 0x70140,
+	"splash_shooting_star_oam": 0x70180,
+	"intro_back_mon": 0x41A99,
+	"intro_front_mon": 0x42099,
+	"intro_nidorino_anims": 0x41910,
+	"tile_id_lists": 0x79AEA,
+	"title_logo_tiles": 0x11380,
+	"title_version_tiles": 0x6802F,
+	"title_player_tiles": 0x126A8,
+	"title_mons": 0x04588,
+	"title_version_text": 0x045A1,
+	"pal_packet_title": 0x72488,
+	"pal_packet_intro": 0x724B8,
+	"pal_packet_splash": 0x724C8,
+	"pal_packet_generic": 0x724A8,
+	"blk_packet_title": 0x7228E,
+	"blk_packet_intro": 0x722C1,
+	"blk_packet_splash": 0x723DD,
 	"change_box_text": 0x73909,
 	"choose_box_text": 0x739D4,
 	"dex_ratings": 0x441D1,
@@ -2607,6 +2689,44 @@ const YELLOW: Dictionary = {
 	"credits_the_end": 0xF181B,
 	"copyright_tiles": 0x10C48,
 	"copyright_text": 0x04355,
+	"splash_falling_star": 0x701B6,
+	"splash_logo_tiles": 0x41AA6,
+	"splash_small_star_oam": 0x70101,
+	"splash_small_star_waves": 0x70105,
+	"splash_logo_oam": 0x70166,
+	"splash_shooting_star_oam": 0x701A6,
+	"tile_id_lists": 0x79C46,
+	"title_logo_tiles": 0xF46FB,
+	"title_logo_corner": 0xF4E2B,
+	"title_pikachu_bg": 0xF4E5B,
+	"title_pikachu_ob": 0xF525B,
+	"title_nine_tile": 0x10E08,
+	"title_logo_tilemap": 0xF45F9,
+	"title_bubble_tilemap": 0xF4673,
+	"title_pikachu_tilemap": 0xF468F,
+	"title_eyes_oam": 0xF45C7,
+	"yellow_intro_gfx_1": 0xFA35A,
+	"yellow_intro_gfx_2": 0xFAB5A,
+	"yellow_intro_clouds": 0xF9C2C,
+	"yellow_intro_tilemap_1": 0xF9B6E,
+	"yellow_intro_tilemap_2": 0xF9BE6,
+	"yellow_intro_tilemap_3": 0xF9BF2,
+	"yellow_intro_speed_bars": 0xF99F0,
+	"yellow_intro_pal_flash": 0xF9DD6,
+	"yellow_intro_pal_fade": 0xF9E0A,
+	"yellow_intro_spawn_states": 0xF9FDA,
+	"yellow_intro_frames": 0xFA0EA,
+	"yellow_intro_oam": 0xFA13D,
+	"yellow_intro_sine": 0xF9ED8,
+	"yellow_intro_sine_words": 0xFA0AA,
+	"pal_packet_title": 0x727C1,
+	"pal_packet_intro": 0x727F1,
+	"pal_packet_splash": 0x72801,
+	"pal_packet_generic": 0x727E1,
+	"pal_packet_beach": 0x72811,
+	"blk_packet_title": 0x72681,
+	"blk_packet_intro": 0x726A1,
+	"blk_packet_splash": 0x72731,
 	"change_box_text": 0x73C52,
 	"choose_box_text": 0x73D10,
 	"dex_ratings": 0x441D1,

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 135
+const FORMAT_VERSION: int = 136
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/input/button.gd
+++ b/game/input/button.gd
@@ -1,13 +1,9 @@
 class_name PokeButton
 extends RefCounted
 
-## The eight buttons the hardware had, and the input actions that stand for them.
-##
-## Every screen that reads the cartridge's own controls speaks this vocabulary
-## and nothing else, so a key, a pad button and an on-screen button are already
-## the same thing by the time a screen sees one. What a device has to do to
-## produce a button is [PokeInputActions]' business, and which device the player
-## is holding is [PokeInputDevice]'s.
+## The eight buttons the hardware had. Every screen speaks this vocabulary and
+## nothing else; what a device does to produce one is [PokeInputActions]'
+## business, and which device the player is holding is [PokeInputDevice]'s.
 
 const NONE: int = 0
 const UP: int = 1

--- a/game/input/debug_keys.gd
+++ b/game/input/debug_keys.gd
@@ -1,13 +1,10 @@
 class_name PokeDebugKeys
 extends RefCounted
 
-## Whether the development shortcuts and readouts are live. The game screens carry
-## scaffolding that reaches parts of the world no cartridge control does: fishing
-## rods by number, the phone list, a renderer switch, a snapshot write and battle
-## drivers. The editor, a headless run and a debug export all answer true; a
-## release export answers false and offers exactly the eight buttons the hardware
-## had. Each shortcut's method stays public either way, so the preview tools drive
-## the same paths in a release build without a key press.
+## Whether the development shortcuts and readouts are live. The editor, a
+## headless run and a debug export answer true; a release export answers false
+## and offers exactly the eight buttons. Each shortcut's method stays public
+## either way, so the preview tools drive the same paths in a release build.
 
 static func enabled() -> bool:
 	return OS.is_debug_build()

--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -1,12 +1,10 @@
 class_name Gen2FocusGuard
 extends Node
 
-## Gives a controller somewhere to start, and somewhere to go. Godot moves focus
-## on `ui_up` and the rest of that family, but only once something already has
-## it, and nothing does when a screen opens. The ring goes up only for a keyboard
-## or a pad, and is never taken away, since a click that dropped focus would
-## empty the field it had just filled. A modal takes the whole guard with it, or
-## the geometric search joins a control in it to one on the page behind.
+## Gives a controller somewhere to start. Godot moves focus on `ui_up` only once
+## something has it, and nothing does when a screen opens. The ring goes up only
+## for a keyboard or a pad and is never taken away, since a click that dropped
+## focus would empty the field it had just filled. A modal takes the guard with it.
 
 ## Nodes in this group are modal: while one is in the tree it is the only part of
 ## the screen the guard looks at. Named rather than typed, so the guard owes

--- a/game/input/input_actions.gd
+++ b/game/input/input_actions.gd
@@ -1,14 +1,11 @@
 class_name PokeInputActions
 extends RefCounted
 
-## What a device has to do to produce a [PokeButton], as data: a plain dictionary,
-## so the whole control scheme survives a trip through the options file and the
-## remap UI can describe one without holding an [InputEvent]. Three kinds cover
-## every device the engine reports, `key`, `pad_button` and `pad_axis`, each with
-## a `code` and the axis one a `sign`. Keys bind by physical keycode, so the d-pad
-## keeps the WASD positions on a layout that does not spell WASD there, and
-## [method describe] asks the platform what that key is labelled. Nothing here
-## reads or writes the options file.
+## What a device has to do to produce a [PokeButton], as a plain dictionary so
+## the scheme survives the options file. Three kinds, `key`, `pad_button` and
+## `pad_axis`, each with a `code` and the axis one a `sign`. Keys bind by
+## physical keycode, so the d-pad keeps the WASD positions on any layout, and
+## [method describe] asks the platform what that key is labelled.
 
 const KIND_KEY: StringName = &"key"
 const KIND_PAD_BUTTON: StringName = &"pad_button"

--- a/game/input/input_device.gd
+++ b/game/input/input_device.gd
@@ -1,14 +1,11 @@
 class_name PokeInputDevice
 extends RefCounted
 
-## Which kind of device an event came from.
-##
-## The engine reports what happened, never what the player is holding, and the
-## two questions have different answers: a phone with a pad plugged in has a
-## touchscreen it is not using, and a laptop with a touchscreen has one the
-## player touches once an hour. Only the device actually in use should decide
-## whether on-screen controls are drawn or a focus ring is shown, so
-## [Gen2InputRuntime] keeps the last answer this gives and publishes it.
+## Which kind of device an event came from. The engine reports what happened,
+## never what the player is holding: a phone with a pad plugged in has a
+## touchscreen it is not using. Only the device in use decides whether on-screen
+## controls are drawn or a focus ring shown, so [Gen2InputRuntime] keeps the
+## last answer this gives.
 
 const KEYBOARD: StringName = &"keyboard"
 const MOUSE: StringName = &"mouse"

--- a/game/input/touch_layout.gd
+++ b/game/input/touch_layout.gd
@@ -2,12 +2,9 @@ class_name PokeTouchLayout
 extends RefCounted
 
 ## Where the on-screen controller's five clusters sit, how big they are and how
-## much of the screen they hide. Geometry only: [Gen2TouchPad] draws and reads
-## touches, which is what lets the settings page show a live preview and a test
-## check placement without a viewport. Positions are a fraction of the area the
-## controller was given rather than pixels, so a layout arranged on a phone means
-## the same on a tablet; portrait and landscape keep separate positions, because a
-## cluster reachable by the thumb in one is mid-screen in the other.
+## solid. Geometry only, so the settings page previews it without a viewport.
+## Positions are a fraction of the controller's area, so a phone's layout means
+## the same on a tablet; portrait and landscape keep separate positions.
 
 const GROUP_PAD: StringName = &"pad"
 const GROUP_A: StringName = &"a"

--- a/game/input/touch_pad.gd
+++ b/game/input/touch_pad.gd
@@ -1,12 +1,11 @@
 class_name Gen2TouchPad
 extends Control
 
-## The on-screen controller: a d-pad, A and B, START and SELECT. It draws what
-## [PokeTouchLayout] places and turns a finger into the same button a key or a pad
-## produces, so no screen has to know a touchscreen exists. Touches are read in
-## [method _input] rather than [method _gui_input] because more than one finger is
-## normal here and the GUI layer only tracks one pointer. In edit mode nothing is
-## pressed and a drag moves a cluster instead, editing the layout in place.
+## The on-screen controller: it draws what [PokeTouchLayout] places and turns a
+## finger into the same button a key produces. Touches are read in
+## [method _input], not [method _gui_input], because the GUI layer tracks one
+## pointer and more than one finger is normal here. In edit mode a drag moves a
+## cluster instead.
 
 const FILL: Color = Color(0.04, 0.06, 0.09, 0.80)
 const FILL_PRESSED: Color = Color(0.30, 0.55, 0.80, 0.95)

--- a/game/launcher/about_page.gd
+++ b/game/launcher/about_page.gd
@@ -2,12 +2,9 @@ class_name Gen2AboutPage
 extends VBoxContainer
 
 ## What this build is, which cartridges it accepts, the release check, and the
-## two places a player can reach the project from.
-##
-## The check only ever runs from its button: it reaches a third party and says
-## this build exists, so it is the player's act and never a side effect of
-## opening the launcher. Every link here is the same: nothing leaves the machine
-## until a button is pressed.
+## project's links. The check reaches a third party and says this build exists,
+## so it runs from its button alone; nothing leaves the machine until a button
+## is pressed.
 
 signal update_check_requested
 

--- a/game/launcher/binding_sheet.gd
+++ b/game/launcher/binding_sheet.gd
@@ -1,13 +1,10 @@
 class_name Gen2BindingSheet
 extends Gen2LauncherSheet
 
-## What one button is bound to, and how to change it.
-##
-## A button carries several bindings at once, normally a key or two and a pad
-## button, so this lists them rather than offering a single slot. The last one
-## cannot be removed: a button with nothing bound is a button the player cannot
-## press, and the options file would silently put the default back on the next
-## load anyway.
+## What one button is bound to, and how to change it. A button carries several
+## bindings at once, so this lists them. The last one cannot be removed: a
+## button with nothing bound cannot be pressed, and the options file would put
+## the default back on the next load anyway.
 
 signal bindings_changed()
 

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -1,12 +1,10 @@
 class_name Gen2Cartridge
 extends Control
 
-## One cartridge on the stage: an empty bay until its dump is imported, and the
-## cartridge itself once it is.
-##
-## The cartridge owns only presentation, and not even its own presses: importing,
-## verification and launching belong to the launcher, and reading a press belongs
-## to the stage, which is the only node that knows whether one became a drag.
+## One cartridge on the stage: an empty bay until its dump is imported. It owns
+## only presentation: importing, verification and launching belong to the
+## launcher, and reading a press to the stage, which alone knows whether one
+## became a drag.
 
 const ART: Dictionary = {
 	&"red": preload("res://assets/cartridges/red.webp"),

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -1,13 +1,10 @@
 class_name Gen2CartridgeStage
 extends Control
 
-## The shelf itself: a carousel that wraps, with the selected cartridge always in
-## the middle at full size and every other one the same step smaller beside it.
-##
-## Placement runs off one continuous [member _scroll] rather than off the integer
-## selection, so a step animates as a slide and the cartridge that has to cross
-## the row does it off the edge instead of through the middle. Children are placed
-## by hand because a container would fight the animations for the same
+## The shelf: a wrapping carousel with the selected cartridge in the middle at
+## full size. Placement runs off one continuous [member _scroll], so a step
+## slides and the cartridge crossing the row goes off the edge. Children are
+## placed by hand because a container would fight the animations for
 ## [member Control.position].
 
 signal selection_changed(game_id: StringName)

--- a/game/launcher/controls_section.gd
+++ b/game/launcher/controls_section.gd
@@ -1,12 +1,9 @@
 class_name Gen2ControlsSection
 extends VBoxContainer
 
-## The controls card in the launcher's settings: what each of the eight buttons
-## is bound to, and how the on-screen controller behaves.
-##
-## Every change is written straight to the options file and installed in the
-## live [InputMap], the same as the rest of the settings page: there is no state
-## here worth an apply button.
+## The controls card in the launcher's settings: the eight bindings and the
+## on-screen controller. Every change is written straight to the options file
+## and installed in the live [InputMap]; there is no state worth an apply button.
 
 ## Emitted after a change that the page has to write.
 signal changed()

--- a/game/launcher/launcher_audio.gd
+++ b/game/launcher/launcher_audio.gd
@@ -1,12 +1,9 @@
 class_name Gen2LauncherAudio
 extends Node
 
-## The launcher's own sound effects, separate from [Gen2AudioPlayer] because
-## none of these come from a cartridge.
-##
-## Clips are synthesised by `tools/generate_launcher_sfx.gd`. Volume follows the
-## app block's sound setting, and a muted setting silences the launcher without
-## touching the game.
+## The launcher's own sound effects, synthesised by
+## `tools/generate_launcher_sfx.gd`. Volume follows the app block's sound
+## setting, so a muted launcher leaves the game alone.
 
 const CLIPS: Dictionary = {
 	&"hover": preload("res://assets/launcher/sfx/hover.wav"),

--- a/game/launcher/launcher_battery.gd
+++ b/game/launcher/launcher_battery.gd
@@ -1,14 +1,12 @@
 class_name Gen2LauncherBattery
 extends HBoxContainer
 
-## The charge indicator in the top right. Godot reports no power state on any
-## platform, so every reading here is this project's own. There is one probe per
+## The charge indicator. Godot reports no power state, so there is one probe per
 ## platform and no fallback: a machine whose charge cannot be read draws no
-## indicator rather than a full cell that is not true, which is what
-## [method reading_available] answers. macOS reads `pmset -g batt` and Windows
-## `Get-CimInstance Win32_Battery`, both on a worker thread; Linux and BSD read
-## `/sys/class/power_supply`; Android and iOS come through the platform plugin.
-## Anything else, the Switch build included, has no probe and no indicator.
+## indicator, which [method reading_available] answers. macOS reads
+## `pmset -g batt` and Windows `Get-CimInstance Win32_Battery` on a worker
+## thread; Linux and BSD read `/sys/class/power_supply`; Android and iOS come
+## through the platform plugin; the Switch build has no probe.
 
 const FULL: int = 100
 ## The cell, without the terminal on its right end.

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -1,13 +1,12 @@
 class_name Gen2LauncherFilePicker
 extends FileDialog
 
-## The one file picker every launcher dialog is built from, reached through
-## [method Gen2LauncherUI.file_picker] and shown with [method show_picker]. Four
-## ways a platform offers a file, in the order they are preferred: the engine's
-## native dialog, which Windows, macOS, Linux and Android answer and whose Android
-## grant covers the one file chosen; the `NativeFilePicker` singleton for iOS,
+## The one file picker every launcher dialog is built from, through
+## [method Gen2LauncherUI.file_picker] and [method show_picker]. In order of
+## preference: the engine's native dialog (Windows, macOS, Linux, Android, whose
+## grant covers the one file chosen); the `NativeFilePicker` singleton for iOS,
 ## where `DisplayServerIOS` implements no `file_dialog_show`; [Gen2BrowseSheet]
-## wherever there is no pointer; and the engine's own browser for the rest.
+## wherever there is no pointer; the engine's own browser for the rest.
 
 ## The plugin's singleton, present only on a build that carries it.
 const NATIVE_SINGLETON: StringName = &"NativeFilePicker"

--- a/game/launcher/launcher_icon.gd
+++ b/game/launcher/launcher_icon.gd
@@ -1,14 +1,12 @@
 class_name PokeLauncherIcon
 extends TextureRect
 
-## The launcher's custom filled icon set, rasterised from SVG at the size it is
-## drawn; the sources stay editable in `assets/launcher/icons` and their
-## `currentColor` fill is replaced with the palette colour at runtime. `github`,
-## `discord` and `bug` are the project's own drawings, so the Material Symbols
-## licence beside them does not cover those three. Each source carries
-## `importer="keep"` because this reads the SVG text rather than Godot's imported
-## texture: an imported `.svg` ships as its `.ctex` alone, so every glyph drew
-## nothing on an exported build. `test_launcher_ui.gd` asserts the importer.
+## The launcher's icon set, rasterised from `assets/launcher/icons` with
+## `currentColor` replaced by the palette colour at runtime. `github`, `discord`
+## and `bug` are the project's own drawings, outside the Material Symbols
+## licence beside them. Each source carries `importer="keep"` because this reads
+## the SVG text: an imported `.svg` ships as its `.ctex` alone, so every glyph
+## drew nothing on an exported build. `test_launcher_ui.gd` asserts the importer.
 const GRID: int = 24
 
 const ICON_DIRECTORY: String = "res://assets/launcher/icons"

--- a/game/launcher/launcher_scroll.gd
+++ b/game/launcher/launcher_scroll.gd
@@ -1,12 +1,10 @@
 class_name Gen2LauncherScroll
 extends ScrollContainer
 
-## A vertical scroll pane that can be read without a pointer, which Godot does
-## not give. A pad walking the controls inside brings the pane with it; a pane of
-## prose has nothing focusable, so it takes focus itself and reads an up or a down
-## as scrolling. A finger is the third way: [constant Control.MOUSE_FILTER_STOP]
-## ends a pointer event at the button it reaches, so the pane reads the touch in
-## [method Node._input] and leaves the engine's own drag off.
+## A vertical scroll pane readable without a pointer. A pad walking the controls
+## inside brings the pane with it; a pane of prose takes focus itself and reads
+## up and down as scrolling. [constant Control.MOUSE_FILTER_STOP] ends a pointer
+## event at the button it reaches, so touch is read in [method Node._input].
 
 ## How far one press moves the pane, as a fraction of what it shows.
 const PAGE: float = 0.42

--- a/game/launcher/launcher_sheet.gd
+++ b/game/launcher/launcher_sheet.gd
@@ -1,13 +1,11 @@
 class_name Gen2LauncherSheet
 extends Control
 
-## A modal card over the launcher, used instead of an OS dialog: Godot's own open
-## a second window with its own decorations, which no amount of theming makes
-## belong here and which mobile has no place to put. Sized against the window
-## rather than against its own content, because a [CenterContainer] grants a card
-## its minimum size whatever that is and a sheet with more rows than the window is
-## tall hung its actions off the bottom edge. The body scrolls and the card is
-## capped, so the title, the actions and the way out are always on screen.
+## A modal card over the launcher in place of an OS dialog, which opens a second
+## window mobile has no place for. Sized against the window, not its content: a
+## [CenterContainer] grants a card its minimum size, and a sheet taller than the
+## window hung its actions off the bottom edge. The body scrolls and the card is
+## capped.
 
 signal closed
 

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -1,12 +1,10 @@
 class_name Gen2LauncherShell
 extends Control
 
-## The frame every launcher screen sits in: a backdrop, a top bar carrying the
-## clock, the tabs and the charge, the page, and the bar of button hints along
-## the bottom. Neither bar changes edge with the window; what changes is whether
-## the tabs are named. The strip above the page is what makes a pad predictable:
-## up leaves the page, down returns, and the shoulders step the strip from
-## anywhere without moving the ring.
+## The frame every launcher screen sits in: backdrop, top bar with clock, tabs
+## and charge, the page, and the button hints along the bottom. The strip above
+## the page is what makes a pad predictable: up leaves the page, down returns,
+## and the shoulders step the strip from anywhere.
 
 signal page_selected(id: StringName)
 

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -1,12 +1,10 @@
 class_name Gen2LauncherTheme
 extends RefCounted
 
-## Colours, metrics and a stock-control [Theme] for every launcher screen. One
-## instance describes one appearance; screens read [method active], which follows
-## `ui_theme` in the options file, and rebuild themselves when it changes, since
-## everything the launcher draws is built in code. Depth is carried by fills and
-## hairlines rather than shadows, so a shadow is never cut off by the scroll or
-## margin container it happens to sit in.
+## Colours, metrics and a stock-control [Theme] for every launcher screen.
+## Screens read [method active], which follows `ui_theme` in the options file,
+## and rebuild when it changes. Depth is fills and hairlines, never shadows,
+## which a scroll or margin container would cut off.
 
 const LIGHT: StringName = &"light"
 const DARK: StringName = &"dark"

--- a/game/launcher/launcher_toast.gd
+++ b/game/launcher/launcher_toast.gd
@@ -1,13 +1,10 @@
 class_name Gen2LauncherToast
 extends Control
 
-## What the launcher has to say about the last thing that happened, shown only
-## while it is worth saying: a screen with nothing to report should look like one.
-## Success and information fade out on their own; a refusal and a running import
-## stay until they are replaced, and a message that stays carries a dismiss
-## button. A running import is the exception, since a button offering to hide it
-## would be offering to cancel something it cannot: its glyph turns instead, which
-## is the whole difference between a launcher that is working and one stopped.
+## What the launcher has to say about the last thing that happened. Success and
+## information fade out; a refusal stays with a dismiss button; a running import
+## stays with no button, since hiding it would look like cancelling it, and its
+## glyph turns instead.
 
 ## How long a message that reports no problem stays up.
 const LINGER: float = 3.6

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -1,12 +1,9 @@
 class_name Gen2ModDetailPage
 extends VBoxContainer
 
-## One mod's own page: what it is, where it came from, and its settings.
-##
-## Everything the list deliberately does not carry is here, which is why the
-## list can stay one line per mod. The settings are built from what the mod
-## registered on [Gen2ModHost] rather than from anything written here, so this
-## page and the game's own MODS menu are one registration seen twice.
+## One mod's own page: what it is, where it came from, and its settings, built
+## from what the mod registered on [Gen2ModHost], so this page and the game's
+## own MODS menu are one registration seen twice.
 
 signal closed
 signal enabled_changed(row: Dictionary, on: bool)

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2ModsPage
 extends VBoxContainer
 
-## The mod manager: a list grouped by where each mod came from, a page per mod,
-## and a page for the sources the player follows. The model is a package
-## manager's, so removing a mod a source lists uninstalls it and leaves it listed
-## while removing one from a file deletes the only copy; [Gen2ModCatalogue]
-## decides both. A change is applied where it is made: the host is reset and every
-## entry script runs again, nothing here withdrawing one registration on its own.
+## The mod manager: a list grouped by source, a page per mod, and a page for the
+## sources followed. Removing a mod a source lists uninstalls it and leaves it
+## listed; removing one from a file deletes the only copy; [Gen2ModCatalogue]
+## decides both. A change resets the host and runs every entry script again.
 
 ## Asks the launcher for its file picker: the page owns no OS dialog.
 signal install_requested

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2SettingsPage
 extends BoxContainer
 
-## Edits [Gen2Options] in five sections: how the launcher looks, how the app
-## behaves, the controls, the rules a run is created with, and the cartridge's
-## own OPTION menu. Every change writes immediately, because a half-applied file
-## is worse than none. One section shows at a time, from a rail beside the rows
-## on a wide window and a strip above them on a narrow one: five cards in one
-## pane was forty focus stops from the first row to the last.
+## Edits [Gen2Options] in five sections, every change written immediately. One
+## section shows at a time, from a rail beside the rows on a wide window and a
+## strip above them on a narrow one: five cards in one pane was forty focus
+## stops from the first row to the last.
 
 signal appearance_changed
 

--- a/game/launcher/title_backdrop.gd
+++ b/game/launcher/title_backdrop.gd
@@ -1,12 +1,10 @@
 class_name Gen2LauncherTitleBackdrop
 extends Node
 
-## A non-interactive title-screen loop, picture and music, for the launcher
-## backdrop. It hosts only [Gen2TitleScene] and [Gen2TitlePage]; the boot cinema
-## that advances into the intro and menu is never created. What it does create is
-## the cartridge sound driver, so the screen is heard as well as seen: the same
-## `MUSIC_TITLE` the title screen plays, at [constant VOLUME_SCALE] of the
-## player's settings, looping for as long as the backdrop is up.
+## A non-interactive title-screen loop for the launcher backdrop: only
+## [Gen2TitleScene] and [Gen2TitlePage], never the boot cinema, plus the
+## cartridge sound driver playing `MUSIC_TITLE` at [constant VOLUME_SCALE] of
+## the player's settings.
 
 const FRAME_TIME: float = 1.0 / 60.0
 const MAX_STEPS_PER_TICK: int = 4

--- a/game/launcher/touch_layout_sheet.gd
+++ b/game/launcher/touch_layout_sheet.gd
@@ -2,12 +2,9 @@ class_name Gen2TouchLayoutSheet
 extends Control
 
 ## Arranging the on-screen controller: drag each cluster where a thumb wants it,
-## and set how large and how solid it is. Full screen rather than a card, because
-## what is being arranged is measured against the rectangle the game hands the
-## controller and a preview in a box of its own would place it against the wrong
-## one. The layout is per orientation and this edits the one the window is in;
-## turning the device sideways is both how the other is reached and the only way
-## to see what it will look like.
+## set how large and how solid it is. Full screen, because the layout is
+## measured against the rectangle the game hands the controller. It edits the
+## orientation the window is in; turning the device sideways reaches the other.
 
 signal closed()
 

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -1,12 +1,10 @@
 class_name Gen2Options
 extends RefCounted
 
-## Player options, in two independent blocks.
-## The cartridge block is the real `wOptions` .. `wOptionsEnd` bytes, so the
-## in-game OPTION menu and this launcher screen can never disagree about what a
-## setting means. The app block is everything the hardware had no concept of.
-## `data/default_options.asm` is byte identical between the two pins, so nothing
-## here is profile split.
+## Player options in two blocks: the cartridge's real `wOptions` .. `wOptionsEnd`
+## bytes, so the OPTION menu and the launcher never disagree, and the app block
+## the hardware had no concept of. `data/default_options.asm` is byte identical
+## between the two pins.
 
 const FORMAT_VERSION: int = 2
 

--- a/game/options/options_store.gd
+++ b/game/options/options_store.gd
@@ -1,12 +1,9 @@
 class_name Gen2OptionsStore
 extends RefCounted
 
-## Persistence for [Gen2Options].
-##
-## Deliberately not the save store's checksummed two-file container. Options
-## carry no player progress and [method Gen2Options.parse] clamps every field,
-## so the worst a damaged file costs is a return to defaults. A save cannot
-## afford that, which is why it keeps the heavier scheme.
+## Persistence for [Gen2Options], deliberately not the save store's checksummed
+## container: [method Gen2Options.parse] clamps every field, so a damaged file
+## costs a return to defaults.
 
 const PATH: String = "user://options.json"
 ## Where a test writes instead. The suite shares `user://` with the game, so

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -1,14 +1,12 @@
 class_name Gen2Rules
 extends RefCounted
 
-## Which behaviour a run is played under: the places this project and the
-## cartridge disagree on purpose, and which challenge the run was created under.
-## Separate from [Gen2Options], because a rule changes what the engine DOES and so
-## belongs to the run that produced a save. A flag is edited in Settings and the
-## next new game takes a copy; [member challenge] is chosen when the game is made
-## and never moves again. Every flag is named for the cartridge's behaviour, so a
-## flag that is off is this project's corrected answer and a flag added later
-## defaults to whatever [constant MODE_CURRENT] says.
+## The places this project and the cartridge disagree on purpose, and which
+## challenge the run was created under. Separate from [Gen2Options] because a
+## rule changes what the engine DOES and belongs to the save. A flag is edited
+## in Settings and the next new game takes a copy; [member challenge] never
+## moves. Every flag is named for the cartridge's behaviour, so off is this
+## project's corrected answer and a flag added later takes [constant MODE_CURRENT].
 
 ## Every named flag, mapped to what [constant MODE_CURRENT] does today. The
 ## descriptions belong beside the branch, not here; each key names the

--- a/game/render/battle_annotations.gd
+++ b/game/render/battle_annotations.gd
@@ -1,12 +1,10 @@
 class_name Gen2BattleAnnotations
 extends RefCounted
 
-## What a registered battle-information provider draws on the hardware interface,
-## validated once and drawn once. The grid is the cartridge's own screen in tiles,
-## so a placement is said in the same coordinates `hlcoord` is and lands in the
-## same cells whichever renderer is underneath. A mod supplies a string or a tile
-## and nothing else: where a cell may be drawn, what a tile's bytes mean, which
-## provider owns a cell and when the layer is hidden are all the host's.
+## What a registered battle-information provider draws on the hardware
+## interface, validated once and drawn once, in `hlcoord`'s own cells. A mod
+## supplies a string or a tile; where a cell may be drawn, what a tile's bytes
+## mean and when the layer is hidden are the host's.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = Gen2Screen.WIDTH / TILE

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -1,12 +1,10 @@
 class_name Gen2BattleTiles
 extends RefCounted
 
-## The battle screen's tile page, assembled the way the hardware assembles it. A
-## battle loads four sheets into one run of tile numbers, overlapping on purpose:
-## the battle font goes in first and the two HUD borders over the middle of it, so
-## thirteen of its tiles are never seen. This copies them in the same order into
-## one strip and keeps the cartridge's tile numbers, so the constants below are
-## the disassembly's own. Node-free like the rest of the drawing layer.
+## The battle screen's tile page as the hardware assembles it: four sheets into
+## one run, overlapping on purpose, the font first and the two HUD borders over
+## its middle, so thirteen font tiles are never seen. The constants below are
+## the disassembly's own tile numbers.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/card_flip_page.gd
+++ b/game/render/card_flip_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2CardFlipPage
 extends RefCounted
 
-## `_CardFlip`'s screen: `CardFlipTilemap` and the two card slots beside it, under
-## the border and cursor objects `CardFlip_CopyOAM` writes. Node-free, so the
-## whole table can be read back headless. Four things a reading gets wrong: every
-## object here is eight by eight, since `_CardFlip` never touches
-## `B_LCDC_OBJ_SIZE`; the objects are drawn in the map's own palettes, since
-## `DmgToCgbObjPals` reorders with the identity; the lamps are characters, copied
-## over the font's gender signs; and Crystal's digits stand one pixel higher, from
-## `CardFlip_ShiftDigitsUpOnePixel`, which pokegold marks unreferenced.
+## `_CardFlip`'s screen: `CardFlipTilemap`, the two card slots, and the objects
+## `CardFlip_CopyOAM` writes, node-free. Every object is eight by eight, since
+## `_CardFlip` never touches `B_LCDC_OBJ_SIZE`; objects use the map's own
+## palettes, since `DmgToCgbObjPals` reorders with the identity; the lamps are
+## characters over the font's gender signs; Crystal's digits stand one pixel
+## higher, from `CardFlip_ShiftDigitsUpOnePixel`, unreferenced in pokegold.
 
 const TILE: int = Gen2Font.TILE
 const SCREEN_COLUMNS: int = Gen2CardFlip.SCREEN_COLUMNS

--- a/game/render/copyright_page.gd
+++ b/game/render/copyright_page.gd
@@ -1,13 +1,10 @@
 class_name Gen2CopyrightPage
 extends RefCounted
 
-## The copyright screen (`Copyright`, `engine/menus/intro_menu.asm`), on the tile
-## grid the hardware uses. The whole screen is one graphic and one code run:
-## `ClearTilemap` blanks the map, `CopyrightGFX` is requested into
-## `vTiles2 tile $60`, and `CopyrightString` is placed at (2,7). None of its codes
-## is a character, so nothing here reads the font. `PlaceString` pushes the line's
-## own start and `NextLineChar` pops it and adds `SCREEN_WIDTH * 2`, so the three
-## rows start in the same column two rows apart. Node-free.
+## The copyright screen (`Copyright`, `engine/menus/intro_menu.asm`): `ClearTilemap`,
+## `CopyrightGFX` into `vTiles2 tile $60`, `CopyrightString` at (2,7). None of
+## its codes is a character. `PlaceString` pushes the line's start and
+## `NextLineChar` adds `SCREEN_WIDTH * 2`, so the rows sit two apart. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/credits_page.gd
+++ b/game/render/credits_page.gd
@@ -1,12 +1,11 @@
 class_name Gen2CreditsPage
 extends RefCounted
 
-## The credits screen, on the tile grid the hardware uses. [Gen2Credits] owns the
-## BG map and the attribute map; this resolves a tile number to pixels and
-## colours it through `CreditsPalettes`. The VRAM window is the banner's 4x4 mon
-## cell at $00, `CreditsBorderGFX` at $20, `TheEndGFX` at $40, `CopyrightGFX` at
-## $60 and the font from $80. `Credits_LYOverride` scrolls the two border bands
-## alone, two pixels a cycle.
+## The credits screen. [Gen2Credits] owns the BG and attribute maps; this
+## colours a tile through `CreditsPalettes`. The VRAM window is the banner's
+## 4x4 mon cell at $00, `CreditsBorderGFX` at $20, `TheEndGFX` at $40,
+## `CopyrightGFX` at $60 and the font from $80. `Credits_LYOverride` scrolls
+## the two border bands alone, two pixels a cycle.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = Gen2Credits.COLUMNS

--- a/game/render/diploma_page.gd
+++ b/game/render/diploma_page.gd
@@ -1,14 +1,11 @@
 class_name Gen2DiplomaPage
 extends RefCounted
 
-## `PlaceDiplomaOnScreen` and `PrintDiplomaPage2` (`engine/events/diploma.asm`),
-## the two whole screens the diploma is. Each is a stored tilemap with a few
-## strings written into it, so this owns the tilemap walk and the strings and
-## nothing else; node-free, so a check can read it back headless.
-##
-## A cell under `FONT_FIRST_CODE` names a tile of `DiplomaGFX` and a cell at or
-## above it names a font glyph, which is the hardware's own split: the art is
-## loaded into `vTiles2` and the font is already at the codes it prints under.
+## `PlaceDiplomaOnScreen` and `PrintDiplomaPage2` (`engine/events/diploma.asm`):
+## a stored tilemap each with a few strings written in, node-free. A cell under
+## `FONT_FIRST_CODE` names a tile of `DiplomaGFX` and one at or above it a font
+## glyph, the hardware's own split: the art is in `vTiles2` and the font already
+## at the codes it prints under.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -1,14 +1,10 @@
 class_name Gen2Font
 extends RefCounted
 
-## The cartridge's own font, drawn a tile at a time. Text here is tilemapped, not
-## typeset: every character is one 8x8 tile of equal width and a character code is
-## already the tile number that draws it, so nothing is measured or kerned. A code
-## with no tile draws nothing rather than a placeholder, which is what the space
-## at $7F is. Three sheets, because the hardware has three loaded at once and one
-## changes: `_LoadFontsBattleExtra` replaces $60 to $78, and which is up is
-## [Gen2Text]'s font argument, so a caller says which screen it is drawing rather
-## than which sheet a byte came from. Node-free.
+## The cartridge's own font: a character code is already the tile number that
+## draws it, and a code with no tile draws nothing, which is what the space at
+## $7F is. Three sheets because `_LoadFontsBattleExtra` replaces $60 to $78;
+## which is up is [Gen2Text]'s font argument. Node-free.
 
 const TILE: int = 8
 

--- a/game/render/game_frame.gd
+++ b/game/render/game_frame.gd
@@ -1,14 +1,11 @@
 class_name Gen2GameFrame
 extends Control
 
-## Places the hardware screen and the on-screen controller, in either orientation
-## and at any window size. Portrait sends the screen to the top and gives the
-## controller the room under it, the only arrangement where a thumb is not over
-## the map; landscape centres the screen and leaves the margins either side, where
-## the thumbs already are. With no controller on screen both cases centre in the
-## whole frame. The frame also owns the way back from hidden controls, watched
-## here rather than in [Gen2TouchPad] because a hidden pad is exactly when it is
-## needed and it has to be reachable from anywhere on the game screen.
+## Places the hardware screen and the on-screen controller at any window size.
+## Portrait sends the screen to the top and gives the controller the room under
+## it; landscape centres the screen and leaves the margins to the thumbs. The
+## frame owns the way back from hidden controls, because a hidden pad is exactly
+## when it is needed and it has to be reachable from anywhere on the screen.
 
 ## How much of a portrait screen the controller may take. The hardware screen is
 ## 10:9, so even a tall phone has this much left over once the map has its share.

--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -1,13 +1,11 @@
 class_name Gen2GameFreakPresentsPage
 extends RefCounted
 
-## The GameFreak Presents screen, on the tile grid the hardware uses: a cleared
-## background with two `PlaceString`s and one object layer over the top, which is
-## where the two profiles part. Crystal's Ditto comes out of `GameFreakDittoGFX`
-## and reads eleven OAM sets off one 16x16 sheet, while Gold and Silver's logo,
-## star and sparkles are the tail of `GameFreakLogoGFX` followed by
-## `GameFreakLogoStarsGFX`, one contiguous run from `vTiles1` tile $0d.
-## [Gen2GameFreakPresents] owns the frames and the positions; this owns the pixels.
+## The GameFreak Presents screen: two `PlaceString`s and one object layer.
+## Crystal's Ditto reads eleven OAM sets off `GameFreakDittoGFX`; Gold and
+## Silver's logo, star and sparkles are the tail of `GameFreakLogoGFX` followed
+## by `GameFreakLogoStarsGFX`, one run from `vTiles1` tile $0d.
+## [Gen2GameFreakPresents] owns the frames and positions; this owns the pixels.
 
 const TILE: int = PokeTiles.TILE_WIDTH
 const COLUMNS: int = 20

--- a/game/render/gen1_lcd.gd
+++ b/game/render/gen1_lcd.gd
@@ -1,0 +1,289 @@
+class_name Gen1Lcd
+extends RefCounted
+
+## The Game Boy's picture state: 384 tiles of VRAM, the two BG maps, forty OAM
+## slots, `rLCDC`, the scroll and window registers and the DMG palettes.
+## [method render] draws a frame a scanline at a time, as shades; the page
+## colours them through the Super Game Boy block each cell sits in.
+
+const WIDTH: int = 160
+const HEIGHT: int = 144
+const MAP_SIDE: int = 32
+const MAP_BYTES: int = MAP_SIDE * MAP_SIDE
+const TILE: int = PokeTiles.TILE_WIDTH
+const TILE_PIXELS: int = PokeTiles.TILE_PIXELS
+## `vChars0`, `vChars1` and `vChars2`: $8000 to $97FF is 384 tiles.
+const TILE_COUNT: int = 384
+const BLOCK_TILES: int = 128
+## `LCDC_BLOCK21`'s tile 0, which is `vChars2`.
+const SIGNED_BASE: int = 2 * BLOCK_TILES
+const OAM_SLOTS: int = 40
+const OAM_BYTES: int = 4
+const OAM_X_OFFSET: int = 8
+const OAM_Y_OFFSET: int = 16
+const SPRITES_PER_LINE: int = 10
+const WINDOW_X_OFFSET: int = 7
+
+## `rLCDC` bits, from `constants/hardware.inc`.
+const LCDC_ON: int = 1 << 7
+const LCDC_WIN_MAP: int = 1 << 6
+const LCDC_WINDOW: int = 1 << 5
+const LCDC_BLOCKS: int = 1 << 4
+const LCDC_BG_MAP: int = 1 << 3
+const LCDC_OBJS: int = 1 << 1
+const LCDC_BG: int = 1 << 0
+## `LCDC_DEFAULT`, which `Init` writes and the title screen runs under.
+const LCDC_DEFAULT: int = LCDC_ON | LCDC_WIN_MAP | LCDC_WINDOW | LCDC_OBJS | LCDC_BG
+
+const OAM_PRIO: int = 1 << 7
+const OAM_YFLIP: int = 1 << 6
+const OAM_XFLIP: int = 1 << 5
+const OAM_PAL1: int = 1 << 4
+
+## Per-pixel colour indices, one byte each, tile after tile.
+var tiles: PackedByteArray = PackedByteArray()
+## `vBGMap0` and `vBGMap1`.
+var maps: Array[PackedByteArray] = []
+var oam: PackedByteArray = PackedByteArray()
+var lcdc: int = LCDC_DEFAULT
+var scx: int = 0
+var scy: int = 0
+var wy: int = 0
+var wx: int = WINDOW_X_OFFSET
+var bgp: int = 0
+var obp0: int = 0
+var obp1: int = 0
+## A scroll register per scanline, -1 leaving the register alone.
+var line_scx: PackedInt32Array = PackedInt32Array()
+var line_scy: PackedInt32Array = PackedInt32Array()
+## Lines an override lands late: 0 from an `rLY` poll, 1 from the `LCD` interrupt.
+var line_lag: int = 0
+
+
+func _init() -> void:
+	tiles.resize(TILE_COUNT * TILE_PIXELS)
+	var map0 := PackedByteArray()
+	map0.resize(MAP_BYTES)
+	var map1 := PackedByteArray()
+	map1.resize(MAP_BYTES)
+	maps = [map0, map1]
+	oam.resize(OAM_SLOTS * OAM_BYTES)
+
+
+func clear_vram() -> void:
+	tiles.fill(0)
+	maps[0].fill(0)
+	maps[1].fill(0)
+
+
+func clear_oam() -> void:
+	oam.fill(0)
+
+
+## [param count] tiles of a decoded strip into VRAM from tile [param at].
+func load_tiles(at: int, strip: PackedByteArray, strip_tiles: int, first: int, count: int) -> void:
+	var stride: int = strip_tiles * TILE
+	if strip_tiles <= 0 or strip.size() < strip_tiles * TILE_PIXELS:
+		return
+	for index: int in count:
+		var tile: int = at + index
+		var source: int = first + index
+		if tile < 0 or tile >= TILE_COUNT or source < 0 or source >= strip_tiles:
+			continue
+		for row: int in TILE:
+			var from: int = row * stride + source * TILE
+			var to: int = tile * TILE_PIXELS + row * TILE
+			for column: int in TILE:
+				tiles[to + column] = strip[from + column]
+
+
+## One tile of one colour, which Yellow's intro writes by hand.
+func fill_tile(at: int, index: int) -> void:
+	if at < 0 or at >= TILE_COUNT:
+		return
+	for pixel: int in TILE_PIXELS:
+		tiles[at * TILE_PIXELS + pixel] = index
+
+
+func write_map(which: int, at: Vector2i, columns: int, rows: int, ids: PackedByteArray) -> void:
+	var map: PackedByteArray = maps[which]
+	for row: int in rows:
+		var y: int = at.y + row
+		if y < 0 or y >= MAP_SIDE:
+			continue
+		for column: int in columns:
+			var x: int = at.x + column
+			var source: int = row * columns + column
+			if x < 0 or x >= MAP_SIDE or source >= ids.size():
+				continue
+			map[y * MAP_SIDE + x] = ids[source]
+
+
+func fill_map(which: int, id: int) -> void:
+	maps[which].fill(id)
+
+
+func set_sprite(slot: int, y: int, x: int, tile: int, attributes: int) -> void:
+	if slot < 0 or slot >= OAM_SLOTS:
+		return
+	var at: int = slot * OAM_BYTES
+	oam[at] = y & 0xFF
+	oam[at + 1] = x & 0xFF
+	oam[at + 2] = tile & 0xFF
+	oam[at + 3] = attributes & 0xFF
+
+
+func sprite(slot: int) -> Dictionary:
+	var at: int = slot * OAM_BYTES
+	return {"y": oam[at], "x": oam[at + 1], "tile": oam[at + 2], "attributes": oam[at + 3]}
+
+
+## The forty slots as `{ y, x, tile, attributes }`.
+func shadow_oam() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for slot: int in OAM_SLOTS:
+		out.append(sprite(slot))
+	return out
+
+
+## The screen as DMG shades, a byte a pixel; an LCD that is off is white.
+func render() -> PackedByteArray:
+	var shades := PackedByteArray()
+	shades.resize(WIDTH * HEIGHT)
+	if lcdc & LCDC_ON == 0:
+		return shades
+	var background := PackedByteArray()
+	background.resize(WIDTH * HEIGHT)
+	var bg_shades: PackedByteArray = _palette_shades(bgp)
+	var window_line: int = 0
+	for y: int in HEIGHT:
+		var row: int = y * WIDTH
+		var line_x: int = _line_value(line_scx, y - line_lag, scx)
+		var line_y: int = _line_value(line_scy, y - line_lag, scy)
+		if lcdc & LCDC_BG:
+			_render_map_line(background, row, _bg_map(), line_x, line_y + y)
+		if lcdc & LCDC_WINDOW and y >= wy and wx - WINDOW_X_OFFSET < WIDTH:
+			_render_window_line(background, row, window_line)
+			window_line += 1
+		for x: int in WIDTH:
+			shades[row + x] = bg_shades[background[row + x]]
+	if lcdc & LCDC_OBJS:
+		_render_objects(shades, background)
+	return shades
+
+
+## The override a line is drawn with, or the register when none stands.
+static func _line_value(overrides: PackedInt32Array, line: int, register: int) -> int:
+	if line < 0 or line >= overrides.size() or overrides[line] < 0:
+		return register
+	return overrides[line]
+
+
+func _bg_map() -> PackedByteArray:
+	return maps[1] if lcdc & LCDC_BG_MAP else maps[0]
+
+
+func _window_map() -> PackedByteArray:
+	return maps[1] if lcdc & LCDC_WIN_MAP else maps[0]
+
+
+## One background line, wrapping the map both ways.
+func _render_map_line(
+	target: PackedByteArray, row: int, map: PackedByteArray, from_x: int, map_y: int
+) -> void:
+	var y: int = map_y & 0xFF
+	var map_row: int = (y >> 3) * MAP_SIDE
+	var tile_row: int = (y & 7) * TILE
+	var x: int = 0
+	while x < WIDTH:
+		var map_x: int = (from_x + x) & 0xFF
+		var tile: int = _bg_tile(map[map_row + (map_x >> 3)]) * TILE_PIXELS + tile_row
+		var column: int = map_x & 7
+		while column < TILE and x < WIDTH:
+			target[row + x] = tiles[tile + column]
+			column += 1
+			x += 1
+
+
+func _render_window_line(target: PackedByteArray, row: int, window_line: int) -> void:
+	var map: PackedByteArray = _window_map()
+	var map_row: int = ((window_line >> 3) & (MAP_SIDE - 1)) * MAP_SIDE
+	var tile_row: int = (window_line & 7) * TILE
+	var left: int = wx - WINDOW_X_OFFSET
+	var x: int = maxi(left, 0)
+	while x < WIDTH:
+		var window_x: int = x - left
+		var tile: int = _bg_tile(map[map_row + ((window_x >> 3) & (MAP_SIDE - 1))]) \
+			* TILE_PIXELS + tile_row
+		target[row + x] = tiles[tile + (window_x & 7)]
+		x += 1
+
+
+func _bg_tile(id: int) -> int:
+	if lcdc & LCDC_BLOCKS:
+		return id
+	return id if id >= BLOCK_TILES else SIGNED_BASE + id
+
+
+## Ten objects a line in OAM order, the lowest X in front, `OAM_PRIO` behind
+## any background colour but 0.
+func _render_objects(shades: PackedByteArray, background: PackedByteArray) -> void:
+	var palettes: Array[PackedByteArray] = [_palette_shades(obp0), _palette_shades(obp1)]
+	for y: int in HEIGHT:
+		var line: Array[int] = _objects_on_line(y)
+		var taken := PackedByteArray()
+		taken.resize(WIDTH)
+		for slot: int in line:
+			_render_object_line(shades, background, taken, slot, y, palettes)
+
+
+func _objects_on_line(y: int) -> Array[int]:
+	var found: Array[int] = []
+	for slot: int in OAM_SLOTS:
+		var top: int = oam[slot * OAM_BYTES] - OAM_Y_OFFSET
+		if y >= top and y < top + TILE:
+			found.append(slot)
+			if found.size() == SPRITES_PER_LINE:
+				break
+	found.sort_custom(func(a: int, b: int) -> bool:
+		var ax: int = oam[a * OAM_BYTES + 1]
+		var bx: int = oam[b * OAM_BYTES + 1]
+		return ax < bx if ax != bx else a < b
+	)
+	return found
+
+
+func _render_object_line(
+	shades: PackedByteArray, background: PackedByteArray, taken: PackedByteArray,
+	slot: int, y: int, palettes: Array[PackedByteArray]
+) -> void:
+	var at: int = slot * OAM_BYTES
+	var left: int = oam[at + 1] - OAM_X_OFFSET
+	var attributes: int = oam[at + 3]
+	var tile_row: int = y - (oam[at] - OAM_Y_OFFSET)
+	if attributes & OAM_YFLIP:
+		tile_row = TILE - 1 - tile_row
+	var tile: int = oam[at + 2] * TILE_PIXELS + tile_row * TILE
+	var palette: PackedByteArray = palettes[1 if attributes & OAM_PAL1 else 0]
+	var behind: bool = attributes & OAM_PRIO != 0
+	var row: int = y * WIDTH
+	for column: int in TILE:
+		var x: int = left + column
+		if x < 0 or x >= WIDTH or taken[x] != 0:
+			continue
+		var index: int = tiles[
+			tile + ((TILE - 1 - column) if attributes & OAM_XFLIP else column)
+		]
+		if index == 0:
+			continue
+		taken[x] = 1
+		if behind and background[row + x] != 0:
+			continue
+		shades[row + x] = palette[index]
+
+
+static func _palette_shades(byte: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	for index: int in 4:
+		out.append((byte >> (index * 2)) & 3)
+	return out

--- a/game/render/gen1_lcd.gd.uid
+++ b/game/render/gen1_lcd.gd.uid
@@ -1,0 +1,1 @@
+uid://b6guvg2llgo31

--- a/game/render/gen1_opening_page.gd
+++ b/game/render/gen1_opening_page.gd
@@ -1,0 +1,91 @@
+class_name Gen1OpeningPage
+extends RefCounted
+
+## A Generation 1 opening's frame in colour: [Gen1Lcd]'s shades through the
+## `ATTR_BLK` palette of the cell each pixel sits in, objects and all.
+
+const CELLS_ACROSS: int = Gen1Lcd.WIDTH / Gen1Lcd.TILE
+const CELLS_DOWN: int = Gen1Lcd.HEIGHT / Gen1Lcd.TILE
+const ATTR_INSIDE: int = 1 << 0
+const ATTR_LINE: int = 1 << 1
+const ATTR_OUTSIDE: int = 1 << 2
+const ATTR_PALETTE_BITS: int = 2
+const ATTR_PALETTE_MASK: int = 3
+const SHADES: int = 4
+## The greys a Game Boy draws on its own.
+const DMG_SHADES: PackedColorArray = [
+	Color8(255, 255, 255), Color8(153, 153, 153), Color8(85, 85, 85), Color8(0, 0, 0),
+]
+
+var _data: GameData = null
+
+
+## Null on a cache with no opening.
+static func from_data(data: GameData) -> Gen1OpeningPage:
+	if data == null or data.generation != RomRegistry.GEN1 or data.opening().is_empty():
+		return null
+	var out := Gen1OpeningPage.new()
+	out._data = data
+	return out
+
+
+## The whole 160x144 screen for the frame [param opening] is on.
+func draw(opening: Gen1Opening) -> Image:
+	var shades: PackedByteArray = opening.lcd.render()
+	var attributes: PackedByteArray = attribute_map(opening.blocks())
+	var tables: Array[PackedInt32Array] = []
+	for palette: Variant in opening.palettes():
+		var colors := PackedColorArray()
+		for packed: Variant in palette as Array:
+			colors.append(PokePalette.from_packed(int(packed)))
+		tables.append(Gen2PicImage.lookup(colors))
+	while tables.size() < SHADES:
+		tables.append(Gen2PicImage.lookup(DMG_SHADES))
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(Gen1Lcd.WIDTH, Gen1Lcd.HEIGHT)
+	for y: int in Gen1Lcd.HEIGHT:
+		var row: int = y * Gen1Lcd.WIDTH
+		var cell_row: int = (y / Gen1Lcd.TILE) * CELLS_ACROSS
+		for x: int in Gen1Lcd.WIDTH:
+			var table: PackedInt32Array = tables[attributes[cell_row + x / Gen1Lcd.TILE]]
+			pixels[row + x] = table[shades[row + x]]
+	return Gen2PicImage.canvas_image(pixels, Gen1Lcd.WIDTH, Gen1Lcd.HEIGHT)
+
+
+## The frame in the Game Boy's own greys, which a pixel diff compares.
+func draw_shades(opening: Gen1Opening) -> Image:
+	var shades: PackedByteArray = opening.lcd.render()
+	return Gen2PicImage.from_indices(shades, Gen1Lcd.WIDTH, Gen1Lcd.HEIGHT, DMG_SHADES)
+
+
+## `ATTR_BLK`'s rows onto the 20x18 cells: inside, line and outside as the
+## control bits say, a lone inside or outside taking the line with it.
+static func attribute_map(blocks: Array) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(CELLS_ACROSS * CELLS_DOWN)
+	for block: Variant in blocks:
+		var row: Array = block
+		if row.size() < 6:
+			continue
+		var control: int = int(row[0])
+		var palettes: int = int(row[1])
+		var line_region: int = 1
+		if control == ATTR_INSIDE or control == ATTR_OUTSIDE:
+			line_region = 0 if control == ATTR_INSIDE else 2
+			control |= ATTR_LINE
+		for cell: int in out.size():
+			var region: int = _region(cell % CELLS_ACROSS, cell / CELLS_ACROSS, row)
+			if control & (1 << region) == 0:
+				continue
+			if region == 1:
+				region = line_region
+			out[cell] = (palettes >> (region * ATTR_PALETTE_BITS)) & ATTR_PALETTE_MASK
+	return out
+
+
+## 0 inside the box `row` spans, 1 on its line, 2 outside it.
+static func _region(x: int, y: int, row: Array) -> int:
+	if x < int(row[2]) or x > int(row[4]) or y < int(row[3]) or y > int(row[5]):
+		return 2
+	if x > int(row[2]) and x < int(row[4]) and y > int(row[3]) and y < int(row[5]):
+		return 0
+	return 1

--- a/game/render/gen1_opening_page.gd.uid
+++ b/game/render/gen1_opening_page.gd.uid
@@ -1,0 +1,1 @@
+uid://0d8nyjqnt7vm

--- a/game/render/gender_screen_page.gd
+++ b/game/render/gender_screen_page.gd
@@ -1,12 +1,9 @@
 class_name Gen2GenderScreenPage
 extends RefCounted
 
-## `engine/menus/init_gender.asm`'s screen on the hardware tile grid: the
-## question in the standard text box and the two-option menu over it.
-## Positions are the source's own. The menu is [Gen2MenuPage]'s, drawn from
-## `.MenuHeader`'s `menu_coords 6, 4, 12, 9` and its three flags, so nothing
-## about the box is decided here.
-## Crystal only, since pokegold ships neither the routine nor its text.
+## `engine/menus/init_gender.asm`'s screen: the question in the standard text
+## box and [Gen2MenuPage]'s two-option menu from `.MenuHeader`'s
+## `menu_coords 6, 4, 12, 9`. Crystal only; pokegold ships neither.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -1,14 +1,11 @@
 class_name Gen2GoldSilverIntroPage
 extends RefCounted
 
-## `GoldSilverIntro`'s screen, on the tile grid the hardware uses.
-## [Gen2GoldSilverIntro] owns the BG map, palettes, scroll and sprite structs;
-## this turns a tile number into pixels. Two differences from
-## [Gen2IntroMoviePage]: the BG map wraps and `hLCDCPointer` = LOW(rSCY) gives
-## every scanline its own `hSCY`, so the screen is sampled row by row; and every
-## attribute byte is zero, so there is one background palette rather than eight.
-## The starters are the one thing not read out of the intro's own sheets, their
-## OAM sets indexing the pic atlas the cache holds.
+## `GoldSilverIntro`'s screen; [Gen2GoldSilverIntro] owns the BG map, palettes,
+## scroll and sprite structs. Unlike [Gen2IntroMoviePage] the BG map wraps and
+## `hLCDCPointer` = LOW(rSCY) gives every scanline its own `hSCY`, and every
+## attribute byte is zero, so there is one background palette. The starters'
+## OAM sets index the pic atlas the cache holds.
 
 const TILE: int = PokeTiles.TILE_WIDTH
 const WIDTH: int = Gen2Screen.WIDTH

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2IntroMoviePage
 extends RefCounted
 
-## The intro movie's screen, on the tile grid the hardware uses. [Gen2IntroMovie]
-## owns the BG map, the attribute plane, the palettes, the scroll and the sprite
-## structs; this turns a tile number into pixels. Two things are not a plain
-## tilemap draw: the BG map wraps and `hLCDCPointer` = LOW(rSCX) gives every
-## scanline its own `hSCX`, which is what runs the grass and the trees at
-## different speeds, so the screen is sampled scanline by scanline; and a BG tile
-## below $80 reads from `vTiles2` and $80 up from `vTiles1`. Shadow OAM holds
-## forty sprites, so `IntroScene10`'s forty-first, Pichu's last tile, is not drawn.
+## The intro movie's screen; [Gen2IntroMovie] owns the BG map, attribute plane,
+## palettes, scroll and sprite structs. The BG map wraps and `hLCDCPointer` =
+## LOW(rSCX) gives every scanline its own `hSCX`, which runs the grass and the
+## trees at different speeds; a BG tile below $80 reads from `vTiles2` and $80
+## up from `vTiles1`. Shadow OAM holds forty sprites, so `IntroScene10`'s
+## forty-first, Pichu's last tile, is not drawn.
 
 const TILE: int = PokeTiles.TILE_WIDTH
 const WIDTH: int = Gen2Screen.WIDTH

--- a/game/render/link_page.gd
+++ b/game/render/link_page.gd
@@ -1,13 +1,10 @@
 class_name Gen2LinkPage
 extends RefCounted
 
-## The two screens the cable club draws: `InitTradeMenuDisplay`'s trade screen and
-## `ReadAndPrintLinkBattleRecord`'s record page. Both are drawn with
-## `LinkTextboxAtHL` rather than `Textbox`, which is a border of its own out of
-## `LinkCommsBorderGFX` and not the frame the OPTION menu chooses. The two
-## cartridges lay that border out differently and this is the one place it shows:
-## Crystal puts a whole screen of seventy tiles down, while Gold and Silver load
-## nine and draw two ordinary boxes. Node-free.
+## `InitTradeMenuDisplay`'s trade screen and `ReadAndPrintLinkBattleRecord`'s
+## record page, both drawn with `LinkTextboxAtHL`, a border out of
+## `LinkCommsBorderGFX` and not the OPTION frame. Crystal puts a whole screen of
+## seventy tiles down; Gold and Silver load nine and draw two boxes. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/mail_page.gd
+++ b/game/render/mail_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2MailPage
 extends RefCounted
 
-## `ReadAnyMail` and the ten `Load*MailGFX` routines behind it on the hardware
-## tile grid. Each mail type builds its own VRAM window out of one flat 1bpp run
-## and then writes a tilemap over it, so the page is two transcribed programs per
-## type rather than a picture, which is what makes ten near-identical routines
-## readable and lets `tools/checks/mail.gd` sweep every one. The 1bpp run has one
-## ink level and the three `LoadMailGFX_Color*` write it into plane 0, plane 1 or
-## both, which is why one sheet draws in three shades. PORTRAITMAIL's pic is in
-## the buffer rather than a layer, since `PlaceGraphic` writes it into the tilemap.
+## `ReadAnyMail` and the ten `Load*MailGFX` routines. Each type builds its own
+## VRAM window out of one 1bpp run and writes a tilemap over it, so the page is
+## two transcribed programs per type, which is what `tools/checks/mail.gd`
+## sweeps. The three `LoadMailGFX_Color*` write the one ink level into plane 0,
+## plane 1 or both, which is why one sheet draws in three shades. PORTRAITMAIL's
+## pic is in the buffer, since `PlaceGraphic` writes it into the tilemap.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/map_name_sign_page.gd
+++ b/game/render/map_name_sign_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2MapNameSignPage
 extends RefCounted
 
-## `PlaceMapNameFrame` and `PlaceMapNameCenterAlign`: the sign a map entry raises,
-## drawn out of `MapEntryFrameGFX`'s own fourteen tiles with the landmark's name
-## centred on its lower interior row. Four rows of the window, which the hardware
-## can only run to the bottom of the screen from, so `rWY` $70 is what puts the
-## sign at the bottom. Crystal's own screen: Gold and Silver ship neither routine
-## nor sheet. [method render_notice] is the same four rows carrying a mod's two
-## lines and an icon, so a notice is vanilla by construction; a cache with no
-## sheet falls back to the ordinary text-box frame.
+## `PlaceMapNameFrame` and `PlaceMapNameCenterAlign`: `MapEntryFrameGFX`'s
+## fourteen tiles with the landmark's name centred on the lower interior row.
+## Four rows of the window, so `rWY` $70 puts the sign at the bottom. Crystal's
+## own: Gold and Silver ship neither. [method render_notice] is the same four
+## rows carrying a mod's two lines and an icon; a cache with no sheet falls back
+## to the text-box frame.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2MartPage
 extends RefCounted
 
-## `BuyMenu`'s screen (`engine/items/mart.asm`): `BlankScreen`, the money box in
-## the corner, `MenuHeader_Buy`'s scrolling list of names and BCD prices, and the
-## speech box `UpdateItemDescription` writes into. [Gen2WorldMartHost] owns the
-## list and the transaction; this is the picture. Three things a redraw has to
-## keep: `ScrollingMenu` draws no frame, so the names sit on the blank screen; the
-## fourth row's price lands on row 11, because `.PrintBCDPrices` prints one row
-## below a name already on the last row the height allows; and the down arrow is
-## drawn whenever the list has arrows while the up one waits for a scroll.
+## `BuyMenu`'s screen (`engine/items/mart.asm`); [Gen2WorldMartHost] owns the
+## list and the transaction. `ScrollingMenu` draws no frame, so the names sit
+## on the blank screen; the fourth row's price lands on row 11, because
+## `.PrintBCDPrices` prints one row below a name already on the last row; the
+## down arrow is drawn whenever the list has arrows while the up one waits for
+## a scroll.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2MoveScreenPage
 extends RefCounted
 
-## The move screen (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`), on the
-## tile grid the hardware uses. `SetUpMoveScreenBG` draws the two boxes and the
-## nickname once and `MoveScreenLoop` adds the two arrows, which
-## `ChooseMoveToDelete` does not; `PlaceMoveData` fills the bottom box with
-## whichever row the cursor is on, and swapping replaces it with `Where?`. It
-## loads nothing the stats screen does not, so the two share
-## [method Gen2BattleTiles.stats_page]. Node-free; the mon icon is an object with
-## a palette of its own and is composed over the page by the screen.
+## The move screen (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`).
+## `SetUpMoveScreenBG` draws the boxes and nickname once, `MoveScreenLoop` adds
+## the two arrows `ChooseMoveToDelete` lacks, `PlaceMoveData` fills the bottom
+## box and swapping replaces it with `Where?`. It shares
+## [method Gen2BattleTiles.stats_page]; the mon icon is an object the screen
+## composes over the page.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/mystery_gift_page.gd
+++ b/game/render/mystery_gift_page.gd
@@ -1,13 +1,10 @@
 class_name Gen2MysteryGiftPage
 extends RefCounted
 
-## `InitMysteryGiftLayout` and the boxes `DoMysteryGift` prints over it. Two
-## screens under one name: Crystal builds its frame out of one sixty-seven tile
-## run and colours it with two palettes, and Gold and Silver build theirs out of
-## three runs and one palette. Neither has a stored tilemap, so the screen is the
-## routine's own `hlcoord` writes transcribed rather than a map read out of the
-## dump, and drawing is a walk over [constant CRYSTAL_LAYOUT] and
-## [constant GS_LAYOUT]. Node-free.
+## `InitMysteryGiftLayout` and the boxes `DoMysteryGift` prints over it. Crystal
+## builds its frame out of one sixty-seven tile run and two palettes, Gold and
+## Silver out of three runs and one. Neither has a stored tilemap, so the screen
+## is a walk over [constant CRYSTAL_LAYOUT] and [constant GS_LAYOUT]. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2PackPage
 extends RefCounted
 
-## The pack's own tile screen (`Pack_InitGFX`, engine/items/pack.asm).
-## [Gen2WorldPack] owns the pockets and what a row may do; this is the picture.
-## The screen is a 20x18 grid of tile numbers plus one palette per cell, since
-## `_CGB_PackPals` fills the attrmap with six palettes at once. The VRAM window is
-## `PackMenuGFX` at $00, the current pocket's picture at $50 and the font from
-## $80. The copy is `$60 tiles` of an 80-tile sheet, so the sixteen landing on $50
-## are `PackGFX`'s own first sixteen; `DrawPackGFX` overwrites fifteen of them and
-## no tilemap names the sixteenth.
+## The pack's tile screen (`Pack_InitGFX`, engine/items/pack.asm); [Gen2WorldPack]
+## owns the pockets. One palette per cell, since `_CGB_PackPals` fills the
+## attrmap with six at once. `PackMenuGFX` at $00, the pocket's picture at $50,
+## the font from $80. The copy is `$60 tiles` of an 80-tile sheet, so the
+## sixteen landing on $50 are `PackGFX`'s own first sixteen; `DrawPackGFX`
+## overwrites fifteen and no tilemap names the sixteenth.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2PartyMenuPage
 extends RefCounted
 
-## The party menu as the hardware draws it: `WritePartyMenuTilemap`'s
-## `PARTYMENUACTION_SWITCH` quality set plus `PlacePartyMenuText`.
-## `SetUpBattlePartyMenu` clears the battle off the screen, so the page is the
-## whole 160x144, and each quality steps two rows per member because
-## `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`. [Gen2BattleSwitchMenu]
-## owns the rows; this owns `InitPartyMenuGFX`'s icons and their frame state.
+## The party menu as `WritePartyMenuTilemap`'s `PARTYMENUACTION_SWITCH` quality
+## set plus `PlacePartyMenuText` draw it. `SetUpBattlePartyMenu` clears the
+## battle, so the page is the whole 160x144, and each quality steps two rows a
+## member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/pic_animation.gd
+++ b/game/render/pic_animation.gd
@@ -1,14 +1,12 @@
 class_name Gen2PicAnimation
 extends RefCounted
 
-## `AnimateFrontpic`, the wobble a front pic does when it is sent out, looked at
-## in a menu, traded, evolved or hatched. The cartridge's shape is a per-frame
-## interpreter over two nested state machines and so is this one, because a
-## `dorepeat` counter and a `SetWait` are read while the animation runs. What it
-## produces is a 7x7 box of tile numbers, which is what `PokeAnim_PlaceGraphic`
-## writes into `wTilemap`; the caller stamps that box and nothing here draws.
-## Crystal only: pokegold ships no `pic_animation.asm`, so a record this has none
-## of animates nothing and the caller plays the cry on its own.
+## `AnimateFrontpic`, the wobble a front pic does when sent out, looked at,
+## traded, evolved or hatched: a per-frame interpreter over two nested state
+## machines, because a `dorepeat` counter and a `SetWait` are read while it
+## runs. It produces the 7x7 box of tile numbers `PokeAnim_PlaceGraphic` writes.
+## Crystal only: pokegold ships no `pic_animation.asm`, so the caller plays the
+## cry on its own.
 
 ## The `ANIM_MON_*` constants, in `PokeAnims`' own order.
 enum {

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -1,13 +1,10 @@
 class_name Gen2PicImage
 extends RefCounted
 
-## Colour indices plus a palette to an [Image]. The cache stores what the
-## cartridge stores, two bits per pixel and no colour, so the palette is chosen
-## here at draw time and a shiny sprite costs one [PackedColorArray] rather than
-## a second copy of the pixels.
-## Built as one buffer for [method Image.create_from_data]: per-pixel
-## [method Image.set_pixel] on a 56x56 sprite is 3136 binding calls for a table
-## lookup, and a battle can want several sprites a frame. Node-free, so headless.
+## Colour indices plus a palette to an [Image]. The cache stores two bits per
+## pixel and no colour, so the palette is chosen at draw time and a shiny costs
+## one [PackedColorArray]. Built as one buffer for [method Image.create_from_data]:
+## per-pixel [method Image.set_pixel] on a 56x56 sprite is 3136 binding calls.
 
 const CHANNELS: int = 4
 ## Every fourth pixel each way is what [method field_color] counts: two samples

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -1,11 +1,9 @@
 extends Control
 
-## Development view: one species on a real 160x144 screen. Deliberate
-## scaffolding: it proves the whole path from cartridge to lit pixel and makes a
-## wrong decode visible without a tool writing a PNG. Left/right change species, S
-## toggles shiny, B swaps front for back, T switches to the trainer classes, which
-## have one palette each and no back pic. Each is also a plain method so
-## `tools/screenshot.gd` can drive it.
+## Development view: one species on a real 160x144 screen, so a wrong decode is
+## visible without a PNG. Left/right change species, S toggles shiny, B swaps
+## front for back, T switches to the trainer classes. Each is also a plain
+## method `tools/screenshot.gd` can drive.
 
 ## The white the hardware fills a pic window with. Index 0 of every pic is this
 ## colour, so a sprite on it looks exactly as it does in the game.

--- a/game/render/pikapic_page.gd
+++ b/game/render/pikapic_page.gd
@@ -1,12 +1,11 @@
 class_name Gen1PikaPicPage
 extends RefCounted
 
-## `StarterPikachuEmotionCommand_pikapic` (`engine/pikachu/pikachu_pic_animation.asm`):
-## the box Yellow's follower makes a face in. `PlacePikapicTextBoxBorder` puts a
-## `TextBoxBorder` at `hlcoord 6, 5` sized `5, 5`, `ExecutePikaPicAnimScript`
-## loops a setup script and up to four tilemap objects at one `Delay3` a turn
-## until the duration runs out or A or B is pressed, and the border is placed
-## again on the way out. `pikapic_cry` is a PCM clip nothing here plays yet.
+## `StarterPikachuEmotionCommand_pikapic` (`engine/pikachu/pikachu_pic_animation.asm`).
+## `PlacePikapicTextBoxBorder` puts a `TextBoxBorder` at `hlcoord 6, 5` sized
+## `5, 5`; `ExecutePikaPicAnimScript` loops a setup script and up to four
+## tilemap objects at one `Delay3` a turn until the duration runs out or A or
+## B is pressed. `pikapic_cry` is a PCM clip nothing here plays yet.
 
 const TILE: int = Gen2Font.TILE
 ## `hlcoord 6, 5` and `lb bc, 5, 5`: the border's corner and the interior.

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2PokedexPage
 extends RefCounted
 
-## The Pokedex's own tile screens (engine/pokedex/pokedex.asm). [Gen2Pokedex] owns
-## the listing, the cursor and the mode; this is the picture. Every layout is one
-## of the source's `Pokedex_Draw*BG` routines read as tile writes. Three sheets
-## share the dex's VRAM numbering: `$00` to `$30` is the font inverted, since
-## `Pokedex_LoadInvertedFont` XORs every byte and the whole screen is light on
-## dark; `$31` to `$6a` is `PokedexLZ`; `$6b` up is `LoadFontsExtra`, inverted by
-## the same pass. The main screen is not a plain grid: its listing is in the
-## window layer at `hWX`, so it is composed in pixels by [method image_main].
+## The Pokedex's tile screens (engine/pokedex/pokedex.asm), each a
+## `Pokedex_Draw*BG` routine read as tile writes; [Gen2Pokedex] owns the
+## listing. `$00` to `$30` is the font inverted by `Pokedex_LoadInvertedFont`,
+## `$31` to `$6a` `PokedexLZ`, `$6b` up `LoadFontsExtra` inverted the same way.
+## The main screen's listing is in the window layer at `hWX`, so
+## [method image_main] composes it in pixels.
 
 const COLUMNS: int = 20
 const ROWS: int = 18

--- a/game/render/pokepic_page.gd
+++ b/game/render/pokepic_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2PokepicPage
 extends RefCounted
 
-## `Pokepic` (engine/events/pokepic.asm): the box a script's `pokepic` command
-## shows a species in, on the hardware tile grid. `MenuBox` at `menu_coords 6,
-## 4, 14, 13`, then `PlaceGraphic` writing a 7x7 block of the front pic one tile
-## in from the box's top-left corner. `_CGB_Pokepic` fills the whole box with
-## `PAL_BG_GRAY`, so the pic wears the map's first background palette rather
-## than the species' own colours: the picture a script shows is grey. Node-free.
+## `Pokepic` (engine/events/pokepic.asm): `MenuBox` at `menu_coords 6, 4, 14,
+## 13`, then `PlaceGraphic`'s 7x7 front pic one tile in from the corner.
+## `_CGB_Pokepic` fills the box with `PAL_BG_GRAY`, so the picture a script
+## shows is grey. Node-free.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/raster.gd
+++ b/game/render/raster.gd
@@ -1,13 +1,11 @@
 class_name PokeRaster
 extends RefCounted
 
-## A background scrolled by a different amount on each scanline, which is what the
-## hardware's `SCX` is once a routine rewrites it part way down a frame. The
-## background map is wider than the screen, [param map_width] against the image's
-## own width, and everything past what was drawn is blank, so an offset wraps
-## rather than leaving a gap. An offset is a distance to look *right* into the
-## map, so a larger one puts the drawn content further left. Node-free and pure,
-## which is what lets a scroll be asserted headless rather than photographed.
+## A background scrolled by a different amount on each scanline, the hardware's
+## `SCX` rewritten part way down a frame. The map is [param map_width] wide and
+## everything past what was drawn is blank, so an offset wraps. An offset looks
+## *right* into the map, so a larger one puts the content further left. Pure,
+## so a scroll is asserted headless.
 
 ## Rows sharing an offset are moved together, since a run of scanlines with one
 ## value is the shape every routine that does this produces: three bands for

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -1,14 +1,11 @@
 class_name Gen2SecondScreen
 extends Control
 
-## The lower display: one of the game's own pages, with a row of tabs under it.
-## Every page is the screen the START menu opens, built and drawn exactly as the
-## overworld builds it and then never handed a button, so a page cannot drift from
-## the one the player sees and cannot change anything either. The tab row is the
-## one thing that takes a touch, and which tabs exist is the START menu's own
-## gate. Everything is drawn inside a [SubViewport] the size of
-## [member canvas_size] in hardware pixels, because a second panel is reached by a
-## bitmap and a copy that size can be made sixty times a second.
+## The lower display: one of the START menu's own pages, built as the overworld
+## builds it and never handed a button, with a row of tabs under it that is the
+## one thing taking a touch. Drawn inside a [SubViewport] of [member canvas_size]
+## hardware pixels, because a second panel is reached by a bitmap copied sixty
+## times a second.
 
 ## The page, which is the cartridge's own screen and never another size.
 const PAGE_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/render/second_screen_host.gd
+++ b/game/render/second_screen_host.gd
@@ -1,14 +1,13 @@
 class_name Gen2SecondScreenHost
 extends Node
 
-## Puts a [Gen2SecondScreen] on a real second display, and reports touches back.
-## Two backends, because the screen above must not know which one it got: `panel`
-## is a handheld's secondary Android display reached through the platform plugin,
-## one bitmap per drawn frame, and `window` is a second [Window] on any desktop.
-## The panel backend copies pixels rather than sharing a context, which is why
-## [Gen2SecondScreen] draws in hardware pixels: 148 KB a frame against the panel's
-## own 5.4 MB. Sharing would mean a Vulkan swapchain per display, which this
-## project cannot have while it renders through the compatibility backend.
+## Puts a [Gen2SecondScreen] on a real second display and reports touches back.
+## `panel` is a handheld's secondary Android display through the platform
+## plugin, one bitmap per drawn frame; `window` is a second [Window] on a
+## desktop. The panel copies pixels, which is why [Gen2SecondScreen] draws in
+## hardware pixels: 148 KB a frame against the panel's 5.4 MB. Sharing a
+## context would need a Vulkan swapchain per display, and this project renders
+## through the compatibility backend.
 
 ## The Android plugin singleton. Its contract is four calls and three signals:
 ## `open() -> bool`, `close()`, `panel_size() -> PackedInt32Array` of two,

--- a/game/render/second_screen_tabs.gd
+++ b/game/render/second_screen_tabs.gd
@@ -1,13 +1,10 @@
 class_name Gen2SecondScreenTabs
 extends RefCounted
 
-## Which pages a second display may show, and the icon each is reached by. The
-## gate is [Gen2WorldStartMenu]'s, filtered to the entries that are a picture
-## rather than an action, so a tab appears on exactly the frame its START menu row
-## does: the team page cannot be opened before Elm has handed over a starter.
-## SAVE, OPTION and EXIT do something rather than show something, and a mod's own
-## row is a screen this cannot draw, so neither reaches a tab. Node-free: it
-## answers a list and an icon image, and the view decides where to put them.
+## Which pages a second display may show, and each one's icon. The gate is
+## [Gen2WorldStartMenu]'s, filtered to entries that are a picture, so a tab
+## appears on the frame its START menu row does. SAVE, OPTION, EXIT and a mod's
+## own row do something rather than show something, so none reaches a tab.
 
 ## The START menu rows that are a page. In `SetUpMenuItems` order, which is the
 ## order they are drawn in.

--- a/game/render/slot_machine_page.gd
+++ b/game/render/slot_machine_page.gd
@@ -1,14 +1,11 @@
 class_name Gen2SlotMachinePage
 extends RefCounted
 
-## `_SlotMachine`'s screen: `SlotsTilemap` under the three reels' own objects.
-## Node-free, so the whole machine can be read back headless. Four things a
-## reading gets wrong: the reels are objects rather than background, which is why
-## a reel can sit between two symbols at all; `.InitGFX` sets `rLCDC`'s
-## `B_LCDC_OBJ_SIZE` itself, so a symbol is two OAM entries and not four; an
-## object's palette is its own tile number shifted twice, so `SLOTS_STARYU` ($14)
-## draws in object palette 5; and the bet lights are four cells each and thirteen
-## apart, a pair of lamps down each side of the window.
+## `_SlotMachine`'s screen: `SlotsTilemap` under the reels' objects, node-free.
+## The reels are objects, which is why one can sit between two symbols;
+## `.InitGFX` sets `B_LCDC_OBJ_SIZE`, so a symbol is two OAM entries; an
+## object's palette is its tile number shifted twice, so `SLOTS_STARYU` ($14)
+## draws in object palette 5; the bet lights are four cells each, thirteen apart.
 
 const TILE: int = Gen2Font.TILE
 const SCREEN_COLUMNS: int = Gen2Layout.SLOTS_TILEMAP_COLUMNS

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -1,14 +1,10 @@
 class_name Gen2StartMenuPage
 extends RefCounted
 
-## `StartMenu`'s own box over the map, the `_Option` screen behind it, and
-## `SaveMenu`'s three boxes over the map as well. In-game mod rows borrow the
-## OPTION layout because they have no cartridge screen of their own.
-##
-## Node-free presentation, like the other pages: geometry is [Gen2MenuBox]'s and
-## the models are [Gen2WorldStartMenu] and [Gen2WorldOptionsMenu]. The list is a
-## box in the top-right of the map with the map still showing around it, so it
-## is drawn as a transparent overlay; OPTION owns the whole screen.
+## `StartMenu`'s box over the map, the `_Option` screen, and `SaveMenu`'s three
+## boxes; mod rows borrow the OPTION layout. Node-free: the models are
+## [Gen2WorldStartMenu] and [Gen2WorldOptionsMenu]. The list is a transparent
+## overlay with the map showing around it; OPTION owns the whole screen.
 
 const TILE: int = Gen2Font.TILE
 ## The hardware tile grid, which every page in here counts in.

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2StatsScreenPage
 extends RefCounted
 
-## The stats screen (`engine/pokemon/stats_screen.asm`), on the tile grid the
-## hardware uses. `StatsScreen_InitUpperHalf` draws the top seven rows once and
-## each of the three page routines fills the ten under the divider, so the page
-## number picks the lower half and nothing else; an egg replaces the whole screen
-## with `EggStatsScreen`. `StatsScreen_LoadFont` is `_LoadFontsBattleExtra` plus
-## the bar borders, so every glyph here is that strip's and the dividers, page
-## indicators and end caps come off [method Gen2BattleTiles.stats_page].
-## Node-free; the Pokemon's pic has its own palette and is composed by the screen.
+## The stats screen (`engine/pokemon/stats_screen.asm`). `StatsScreen_InitUpperHalf`
+## draws the top seven rows once and each page routine fills the ten under the
+## divider; an egg replaces the whole screen with `EggStatsScreen`.
+## `StatsScreen_LoadFont` is `_LoadFontsBattleExtra` plus the bar borders, so
+## the dividers and end caps come off [method Gen2BattleTiles.stats_page]. The
+## Pokemon's pic has its own palette and is composed by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -1,14 +1,12 @@
 class_name Gen2TextBox
 extends TextureRect
 
-## A bordered text window, drawn the way the hardware draws one. Everything is on
-## the tile grid at the games' own measurements: the border is six tiles of the
-## chosen frame printed as box-drawing characters, and text sits one tile in from
-## the left on every second row, since a line is eight pixels tall in a box whose
-## rows are sixteen apart. The box composes into one index buffer, so a glyph and
-## a Pokemon are lit by the same code. Text reveals a tile at a time;
-## [method advance] and [method finish] are plain methods as well as key handlers,
-## so a screen can be photographed mid-sentence.
+## A bordered text window at the games' own measurements: six frame tiles as
+## box-drawing characters, text one tile in on every second row, since a line
+## is eight pixels tall in a box whose rows are sixteen apart. It composes into
+## one index buffer, so a glyph and a Pokemon are lit by the same code.
+## [method advance] and [method finish] are plain methods as well as key
+## handlers, so a screen can be photographed mid-sentence.
 
 ## Emitted when the last page has been shown and advanced past.
 signal finished

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -1,12 +1,10 @@
 class_name Gen2TextLayout
 extends RefCounted
 
-## Breaking a string into the lines and pages a text box can show. Pure rules, no
-## font and no screen, so a conversation's pagination can be checked without
-## drawing anything. Widths count tiles rather than characters, since a ligature
-## like "'s" is two of one and [method String.length] would wrap a column early.
-## The cartridges do not wrap at all, their text being pre-broken at authoring
-## time; a mod's string and a long name are what needs it.
+## Breaking a string into the lines and pages a text box can show, with no font
+## or screen. Widths count tiles, since a ligature like "'s" is one and
+## [method String.length] would wrap early. The cartridges never wrap, their
+## text being pre-broken; a mod's string and a long name are what needs it.
 
 
 ## `Textbox`'s inner area: `TEXTBOX_INNERW` wide, and two rows two apart.

--- a/game/render/text_viewer.gd
+++ b/game/render/text_viewer.gd
@@ -1,12 +1,9 @@
 extends Control
 
-## Development view: the cartridge's font and text box on a real 160x144 screen.
-## Scaffolding like `pic_viewer.tscn`, for the same reason: a font slid by one
-## tile still draws letters and a border with its six tiles out of order still
-## draws a box, so both are checked by looking rather than by counting bytes. The
-## chart draws all 128 glyphs in code order, so anything out of place is a blank
-## mid-word or a letter in a gap. Space advances, F cycles the border, C toggles
-## the chart, and each is a plain method `tools/screenshot.gd` can drive.
+## Development view: the font and text box on a real 160x144 screen. A font
+## slid by one tile still draws letters, so this is checked by looking. The
+## chart draws all 128 glyphs in code order. Space advances, F cycles the
+## border, C toggles the chart, each a plain method `tools/screenshot.gd` drives.
 
 const BACKGROUND: Color = Color.WHITE
 

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -1,13 +1,11 @@
 class_name Gen2TitlePage
 extends RefCounted
 
-## The title screen, on the tile grid the hardware uses. Two screens under one
-## name, the way [Gen2TitleScene] is: Crystal draws its logo with
-## `DrawTitleGraphic`, keeps a strip of Suicune under it that `LoadSuicuneFrame`
-## re-points every eighth frame, and stands the crystal in front as thirty 8x16
-## objects, while Gold and Silver write `TitleScreenTilemap` straight into the BG
-## map and fly one bird over it. [Gen2TitleScene] owns the frames and the
-## positions; this owns the pixels.
+## The title screen: Crystal draws its logo with `DrawTitleGraphic`, keeps a
+## strip of Suicune `LoadSuicuneFrame` re-points every eighth frame, and stands
+## the crystal in front as thirty 8x16 objects; Gold and Silver write
+## `TitleScreenTilemap` into the BG map and fly one bird. [Gen2TitleScene] owns
+## the frames and positions; this owns the pixels.
 
 const TILE: int = PokeTiles.TILE_WIDTH
 const COLUMNS: int = 20

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -2,13 +2,10 @@ class_name Gen2TownMapPage
 extends RefCounted
 
 ## The region map (`_TownMap` and `InitPokegearTilemap.Map`) and the Pokegear's
-## other three cards, on the tile grid the hardware uses. Like the trainer card
-## this is a tilemap screen: `FillTownMap` writes one tile number per cell out of
-## `JohtoMap` or `KantoMap` and only the landmark's name is printed text, so the
-## page builds a map of tile numbers, colours it through `TownMapPals` and
-## resolves each number to pixels. The VRAM window is `TownMapGFX` at $00,
-## `PokegearGFX` at $30 and the font from $60. The other three cards are the same
-## window with one of the RLE tilemaps over it, so they are built here too.
+## other three cards. `FillTownMap` writes one tile number per cell out of
+## `JohtoMap` or `KantoMap`, coloured through `TownMapPals`; only the landmark's
+## name is text. `TownMapGFX` at $00, `PokegearGFX` at $30, the font from $60.
+## The other cards are the same window with one of the RLE tilemaps over it.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -1,14 +1,11 @@
 class_name Gen2TrainerCardPage
 extends RefCounted
 
-## One page of the trainer card (`engine/menus/trainer_card.asm`), on the tile
-## grid the hardware uses. The card is a tilemap screen rather than a text screen,
-## so this keeps the cartridge's own VRAM window and writes tile numbers into a
-## map exactly as `TrainerCard_InitBorder` does, then resolves each number to
-## pixels. The window is `GetCardPic`'s 35-tile player pic at $00,
-## `TrainerCardGFX`'s frame pieces at $23, 86 tiles at $29 and the font from $80.
-## Page 1's 86 start at `CardStatusGFX`, which is only six tiles long, so the copy
-## runs straight on into `LeaderGFX`: that overrun is the cartridge's own.
+## One page of the trainer card (`engine/menus/trainer_card.asm`), a tilemap
+## screen written as `TrainerCard_InitBorder` writes it. `GetCardPic`'s 35-tile
+## player pic at $00, `TrainerCardGFX`'s frame pieces at $23, 86 tiles at $29,
+## the font from $80. Page 1's 86 start at `CardStatusGFX`, only six tiles long,
+## so the copy runs on into `LeaderGFX`: that overrun is the cartridge's own.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/unown_printer_page.gd
+++ b/game/render/unown_printer_page.gd
@@ -1,12 +1,10 @@
 class_name Gen2UnownPrinterPage
 extends RefCounted
 
-## `_UnownPrinter`, the ALPH RUINS STAMP browser, and the page `PrintUnownStamp`
-## builds out of it: three `Textbox`es, three strings and one Unown frontpic. The
-## menu's PRINT and CANCEL rows are printed as the two gender signs because
-## `Request1bpp` has just overwritten those font tiles with a bold A and a bold B,
-## so the two codes are drawn from `UnownDexATile` rather than from the font.
-## Node-free: the image is the whole product.
+## `_UnownPrinter`, the ALPH RUINS STAMP browser, and `PrintUnownStamp`'s page.
+## PRINT and CANCEL are printed as the two gender signs because `Request1bpp`
+## has just overwritten those font tiles with a bold A and B, so the two codes
+## are drawn from `UnownDexATile`. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/unown_puzzle_page.gd
+++ b/game/render/unown_puzzle_page.gd
@@ -1,14 +1,12 @@
 class_name Gen2UnownPuzzlePage
 extends RefCounted
 
-## `_UnownPuzzle`'s screen: the board tilemap and the two object sets over it.
-## Node-free, so the whole board can be read back headless. Four things a reading
-## gets wrong: a puzzle picture is doubled rather than drawn, destination tile
-## `(2r + h, 2c + w)` being source tile `(r, c)`'s own quarter; the borders are
-## ORed onto the pieces in bitplanes, reaching the eight tiles around each piece's
-## centre; the board is drawn in vTiles0 and so from tile $00, `rLCDC`'s
-## `%10010011` being the unsigned tile base; and the cursor is red because
-## `_CGB_UnownPuzzle` overwrites object colour 0, not because of a tile.
+## `_UnownPuzzle`'s screen: the board tilemap and two object sets, node-free.
+## A puzzle picture is doubled, destination tile `(2r + h, 2c + w)` being
+## source `(r, c)`'s quarter; the borders are ORed onto the pieces in
+## bitplanes; the board is drawn from tile $00 in vTiles0, `rLCDC`'s `%10010011`
+## being the unsigned base; the cursor is red because `_CGB_UnownPuzzle`
+## overwrites object colour 0.
 
 const TILE: int = PokeTiles.TILE_WIDTH
 const TILE_PIXELS: int = PokeTiles.TILE_PIXELS

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -28,6 +28,11 @@ const PHASE_FINISHED: StringName = &"finished"
 const PHASE_ORDER: Array[StringName] = [
 	PHASE_COPYRIGHT, PHASE_PRESENTS, PHASE_INTRO_MOVIE, PHASE_TITLE,
 ]
+## The image id a host names for each phase.
+const GEN1_IMAGE_IDS: Dictionary = {
+	PHASE_COPYRIGHT: &"copyright", PHASE_PRESENTS: &"game_freak_presents",
+	PHASE_INTRO_MOVIE: &"intro_movie", PHASE_TITLE: &"title",
+}
 
 var _profile: StringName = &"gold"
 var _phase: StringName = &""
@@ -46,6 +51,8 @@ var _data: GameData = null
 var _presents: Gen2GameFreakPresents = null
 ## `TitleScreenScene`'s own state while the title phase is up, null outside it.
 var _title: Gen2TitleScene = null
+## A Generation 1 cache's opening, one program for all four phases.
+var _gen1: Gen1Opening = null
 ## The `BattleAnimSineWave` the presents phase reads its motion out of, handed
 ## in by the host that has a cache open.
 var _sine: Gen2BattleAnimData = null
@@ -73,6 +80,16 @@ func start(
 	_movie = null
 	_gs_movie = null
 	_available = available.duplicate()
+	_gen1 = Gen1Opening.create(data)
+	if _gen1 != null:
+		_phase = _gen1.phase()
+		_frame = 0
+		_phase_frame = 0
+		_waiting_sound = &""
+		_events.clear()
+		_emit(&"play_music", {"music": MUSIC_NONE, "restart": true})
+		_emit(&"show_image", {"id": GEN1_IMAGE_IDS[_phase]})
+		return
 	if not is_available(PHASE_COPYRIGHT):
 		_phase = PHASE_COPYRIGHT
 		_frame = 0
@@ -142,6 +159,9 @@ func advance_frame(held: Array = []) -> Array[Dictionary]:
 		return drain_events()
 	_frame += 1
 	_phase_frame += 1
+	if _gen1 != null:
+		_advance_gen1()
+		return drain_events()
 	match _phase:
 		PHASE_COPYRIGHT:
 			_advance_copyright()
@@ -199,6 +219,35 @@ func _advance_title(held: Array) -> void:
 ## drawing. Null outside the title phase.
 func title() -> Gen2TitleScene:
 	return _title
+
+
+## The live Generation 1 opening, null on a Generation 2 cache.
+func gen1() -> Gen1Opening:
+	return _gen1
+
+
+## One frame of the Generation 1 opening: its sounds and phases pass through,
+## its end is `MainMenu`, or `jp Init` on Yellow's timeout.
+func _advance_gen1() -> void:
+	var before: StringName = _gen1.phase()
+	var events: Array[Dictionary] = _gen1.advance_frame()
+	if _gen1.phase() != before:
+		_phase = _gen1.phase()
+		_phase_frame = 0
+		_emit(&"show_image", {"id": GEN1_IMAGE_IDS.get(_phase, _phase)})
+	for event: Dictionary in events:
+		match StringName(event.get("type", &"")):
+			&"play_sfx", &"play_music", &"stop_music", &"play_cry":
+				var values: Dictionary = event.duplicate()
+				for key: String in ["type", "frame", "phase"]:
+					values.erase(key)
+				_emit(StringName("gen1_" + String(event["type"])), values)
+			&"title_menu":
+				_emit(&"title_menu", {"profile": _profile})
+			&"restart_opening":
+				start(_profile, _data, _available, _sine)
+				_emit(&"restart_opening", {"profile": _profile})
+				return
 
 
 func wait_sound(token: StringName) -> void:

--- a/game/world/gen1_opening.gd
+++ b/game/world/gen1_opening.gd
@@ -1,0 +1,1478 @@
+class_name Gen1Opening
+extends RefCounted
+
+## `PlayIntro` and `DisplayTitleScreen` (engine/movie/splash.asm, intro.asm,
+## title.asm) a frame at a time against a [Gen1Lcd]: a step list of the
+## routines' own `DelayFrames`, `CheckForUserInterruption` and VRAM writes, with
+## `wTileMap`, `wShadowOAM` and `hSCX` landing at VBlank and `rBGP` at once. A
+## silent copy of the sound driver answers `WaitForSoundToFinish`. Yellow's
+## intro is [Gen1YellowIntro].
+
+const PHASE_COPYRIGHT: StringName = &"copyright"
+const PHASE_PRESENTS: StringName = &"presents"
+const PHASE_INTRO_MOVIE: StringName = &"intro_movie"
+const PHASE_TITLE: StringName = &"title"
+const PHASE_FINISHED: StringName = &"finished"
+
+## `SFX_Headers_3`'s ids, all in bank $1F, `Init`'s `wAudioROMBank`.
+const AUDIO_BANK: int = 0x1F
+const SFX_INTRO_LUNGE: int = 184
+const SFX_INTRO_HIP: int = 185
+const SFX_INTRO_HOP: int = 186
+const SFX_INTRO_RAISE: int = 187
+const SFX_INTRO_CRASH: int = 188
+const SFX_INTRO_WHOOSH: int = 189
+const SFX_SHOOTING_STAR: int = 194
+const MUSIC_TITLE_SCREEN: int = 195
+const MUSIC_INTRO_BATTLE: int = 220
+const MUSIC_YELLOW_INTRO: int = 220
+
+## `PAD_*` bits as `hJoyHeld` holds them.
+const PAD_A: int = 1 << 0
+const PAD_B: int = 1 << 1
+const PAD_SELECT: int = 1 << 2
+const PAD_START: int = 1 << 3
+const PAD_UP: int = 1 << 6
+const CHORD_CLEAR_SAVE: int = PAD_UP | PAD_SELECT | PAD_B
+
+const COLUMNS: int = 20
+const ROWS: int = 18
+const TILEMAP_CELLS: int = COLUMNS * ROWS
+const BLANK: int = 0x7F
+## `AutoBgMapTransfer`'s rows a VBlank, and its destination as a row of the
+## 64 across both maps: `vBGMap0 + $300` is row 24, `vBGMap1` row 32.
+const TRANSFER_ROWS: int = 6
+const MAP_ROWS: int = 32
+const DEST_MAP0: int = 0
+const DEST_MAP0_PLUS_300: int = 24
+const DEST_MAP1: int = 32
+const COPY_TILES_PER_FRAME: int = 8
+
+## `LoadCopyrightAndTextBoxTiles`: both sheets at `vChars2 tile $60`.
+const COPYRIGHT_TILE: int = 2 * Gen1Lcd.BLOCK_TILES + 0x60
+const COPYRIGHT_AT: Vector2i = Vector2i(2, 7)
+const COPYRIGHT_ROW_STEP: int = 2
+const COPYRIGHT_FRAMES: int = 180
+## `LoadIntroGraphics` under a disabled LCD, measured: four frames of
+## `FarCopyData2`, two on Yellow with the logo alone.
+const INTRO_GRAPHICS_FRAMES: Dictionary = {RomRegistry.RED: 4, RomRegistry.BLUE: 4, RomRegistry.YELLOW: 2}
+## `IntroDrawBlackBars`: four rows top and bottom of the Gengar sheet's tile 1.
+const BLACK_BAR_ROWS: int = 4
+const BLACK_TILE: int = 1
+const LOGO_BG_TILE: int = 2 * Gen1Lcd.BLOCK_TILES + 0x60
+const LOGO_OB_TILE: int = Gen1Lcd.BLOCK_TILES
+const STAR_TILE: int = Gen1Lcd.BLOCK_TILES + 0x20
+## `MoveAnimationTiles1 tile 3` and `19`, the sheet the pointer table lists second.
+const BIG_STAR_SHEET: int = 1
+const BIG_STAR_SOURCE_TILES: Array[int] = [3, 19]
+const SHOOTING_STAR_DELAY: int = 64
+const SHOOTING_STAR_OBP0: int = 0xF9
+const SHOOTING_STAR_OBP1: int = 0xA4
+const BIG_STAR_STEP: int = 4
+const BIG_STAR_END_Y: int = 0xA0
+const OFF_SCREEN_Y: int = Gen1Lcd.HEIGHT + Gen1Lcd.OAM_Y_OFFSET
+const LOGO_FLASHES: int = 3
+const LOGO_FLASH_FRAMES: int = 10
+const SMALL_STARS: int = 24
+const SMALL_STAR_WAVES: int = 6
+const SMALL_STAR_FIRST_SLOT: int = 20
+const SMALL_STAR_LAST_SLOT: int = 23
+const SMALL_STAR_COUNT_STEP: int = 6
+const SMALL_STAR_FALL_STEPS: int = 8
+const SMALL_STAR_FALL_FRAMES: int = 3
+const SMALL_STAR_OBP1_TOGGLE: int = 0xA0
+const LOGO_OAM_FIRST_SLOT: int = 24
+const AFTER_STARS_DELAY: int = 40
+const DELAY3: int = 3
+
+## `PlayIntroScene`'s own numbers.
+const INTRO_PALETTE: int = 0xE4
+const INTRO_TILEMAP_AT: Vector2i = Vector2i(13, 7)
+const NIDORINO_BASE_Y: int = 80
+const NIDORINO_SIDE: int = 6
+const NIDORINO_SPRITES: int = NIDORINO_SIDE * NIDORINO_SIDE
+const NIDORINO_WALK: int = 80 / 2
+const GENGAR_RAISE: int = 8 / 2
+const GENGAR_SLASH: int = 16 / 2
+const MOVE_FRAMES: int = 2
+const MOVE_PIXELS: int = 2
+const HOP_FRAMES: int = 5
+const POSE_TILES: int = Gen1Layout.INTRO_FRONT_MON_POSE_TILES
+
+## `GBFadeOutToWhite`: `FadePal6`, `7` and `8`, eight frames each.
+const FADE_TO_WHITE: Array[int] = [5, 6, 7]
+const FADE_STEP_FRAMES: int = 8
+## `Init`'s tail with the LCD off, measured: frames before `GBPalNormal`, then
+## before `LCDC_DEFAULT`. `DisplayTitleScreen`'s own LCD-off loads spend six on
+## Red, five on Blue (two `Version_GFX` tiles fewer) and Yellow.
+const CLEAR_VRAM_FRAMES: Dictionary = {
+	RomRegistry.RED: [5, 0], RomRegistry.BLUE: [5, 0], RomRegistry.YELLOW: [3, 1],
+}
+const TITLE_LOAD_FRAMES: Dictionary = {RomRegistry.RED: 6, RomRegistry.BLUE: 5, RomRegistry.YELLOW: 5}
+const GB_PAL_NORMAL_BGP: int = 0xE4
+const GB_PAL_NORMAL_OBP0: int = 0xD0
+
+## `DisplayTitleScreen`.
+const TITLE_SCY: int = 0x40
+const WINDOW_OFF: int = 0x90
+const WINDOW_HALF: int = 0x40
+const TITLE_LOGO_AT: Vector2i = Vector2i(2, 1)
+const TITLE_LOGO_COLUMNS: int = 16
+const TITLE_LOGO_ROWS: int = 7
+const TITLE_LOGO_FIRST_TILE: int = 0x80
+const TITLE_LOGO_LAST_ROW_TILE: int = 0x31
+const TITLE_LOGO_VRAM: int = Gen1Lcd.BLOCK_TILES
+const TITLE_LOGO_FIRST_CHUNK: int = 0x60
+const TITLE_LOGO2_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES + Gen2PicImage.FRONTPIC_TILES \
+	* Gen2PicImage.FRONTPIC_TILES
+const TITLE_COPYRIGHT_VRAM: int = TITLE_LOGO2_VRAM + 16
+const TITLE_COPYRIGHT_NINTENDO_TILES: int = 5
+const TITLE_COPYRIGHT_GAMEFREAK_TILES: int = 9
+const TITLE_COPYRIGHT_GAMEFREAK_FIRST: int = 19
+const TITLE_VERSION_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES + 0x60
+const TITLE_VERSION_SLOT_TILES: int = 10
+const TITLE_VERSION_AT: Vector2i = Vector2i(7, 8)
+const TITLE_COPYRIGHT_AT: Vector2i = Vector2i(2, 17)
+## `.tileScreenCopyrightTiles` on Red and Blue and Yellow's own row.
+const TITLE_COPYRIGHT_TILES: Array[int] = [
+	0x41, 0x42, 0x43, 0x42, 0x44, 0x42, 0x45, 0x46,
+	0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E,
+]
+const YELLOW_TITLE_COPYRIGHT_TILES: Array[int] = [
+	0xE0, 0xE1, 0xE2, 0xE3, 0xE1, 0xE2, 0xEE, 0xE5,
+	0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED,
+]
+const TITLE_PLAYER_AT: Vector2i = Vector2i(0x5A, 0x60)
+const TITLE_PLAYER_COLUMNS: int = 5
+const TITLE_PLAYER_ROWS: int = 7
+## `ld hl, wShadowOAMSprite10 / ld [hl], $74` lands on the slot's Y byte.
+const TITLE_BALL_SLOT: int = 10
+const TITLE_BALL_Y: int = 0x74
+const TITLE_MON_AT: Vector2i = Vector2i(5, 10)
+const TITLE_MON_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES
+const TITLE_MON_TILES: int = Gen2PicImage.FRONTPIC_TILES * Gen2PicImage.FRONTPIC_TILES
+## `LoadTitleMonSprite`, measured from the pick to `hWY` landing: the
+## decompressor's CPU time plus seven `CopyVideoData` frames.
+const TITLE_MON_LOAD_TAIL: int = 7
+## `EnableLCD` sits mid-frame, so what follows lands a frame late.
+const TITLE_FIRST_LOAD_EXTRA: int = 1
+## Whether `PrepareTitleScreen`'s `hWY` write lands a frame before the title's.
+const PREPARE_WINDOW_EARLY: Dictionary = {RomRegistry.RED: true, RomRegistry.BLUE: true, RomRegistry.YELLOW: false}
+const TITLE_MON_LOAD_FRAMES: Dictionary = {
+	RomRegistry.RED: {
+		1: 29, 4: 30, 7: 29, 13: 25, 17: 38, 25: 27, 32: 26, 35: 27,
+		63: 30, 77: 35, 92: 51, 95: 43, 112: 51, 123: 46, 129: 40, 132: 28,
+	},
+	RomRegistry.BLUE: {
+		1: 29, 4: 30, 7: 29, 26: 44, 37: 39, 44: 34, 56: 27, 60: 26,
+		84: 26, 94: 34, 106: 48, 113: 35, 135: 35, 137: 38, 142: 49, 143: 49,
+	},
+}
+const TITLE_MON_LOAD_DEFAULT: int = 30
+## `.TitleScreenPokemonLogoYScrolls`: a scroll and how many frames of it.
+const TITLE_BOUNCE: Array[Vector2i] = [
+	Vector2i(-4, 16), Vector2i(3, 4), Vector2i(-3, 4), Vector2i(2, 2),
+	Vector2i(-2, 2), Vector2i(1, 2), Vector2i(-1, 2),
+]
+const TITLE_BOUNCE_CRASH: int = -3
+const TITLE_OBP0: int = 0xE4
+const YELLOW_TITLE_OBP0: int = 0xE0
+const TITLE_SETTLE_FRAMES: int = 36
+const VERSION_SCROLL_START: int = 144
+const VERSION_SCROLL_STEP: int = 4
+const VERSION_SCROLL_LINES: Vector2i = Vector2i(64, 80)
+const TITLE_MON_LINES: Vector2i = Vector2i(0x48, 0x88)
+const TITLE_WAIT_FRAMES: int = 200
+## `TitleScroll_In`, `_Out` and `_WaitBall`: speed high, frames low.
+const TITLE_SCROLL_IN: Array[int] = [0xA2, 0x94, 0x84, 0x63, 0x52, 0x31, 0x11]
+const TITLE_SCROLL_OUT: Array[int] = [0x12, 0x22, 0x32, 0x42, 0x52, 0x62, 0x83, 0x93]
+const TITLE_SCROLL_WAIT_BALL: Array[int] = [0x05, 0x05]
+const TITLE_SCROLL_IN_START: int = 0x88
+## `TitleBallYTable`, entered at index 1.
+const TITLE_BALL_YS: Array[int] = [0, 0x71, 0x6F, 0x6E, 0x6D, 0x6C, 0x6D, 0x6E, 0x6F, 0x71, 0x74, 0]
+const TITLE_STARTERS: int = 3
+const TITLE_MON_PICK_MASK: int = 0xF
+
+## Yellow's title: its loads, boxes, blink and `IncrementResetCounter`'s $C00.
+const YELLOW_LOGO_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES
+const YELLOW_CORNER_VRAM: int = Gen1Lcd.BLOCK_TILES + 0x7D
+const YELLOW_PIKACHU_BG_VRAM: int = Gen1Lcd.BLOCK_TILES
+const YELLOW_PIKACHU_OB_VRAM: int = Gen1Lcd.BLOCK_TILES + 0x70
+const YELLOW_COPYRIGHT_VRAM: int = Gen1Lcd.BLOCK_TILES + 0x60
+const YELLOW_NINE_VRAM: int = Gen1Lcd.BLOCK_TILES + 0x6E
+const YELLOW_GAMEFREAK_VRAM: int = Gen1Lcd.BLOCK_TILES + 0x65
+const YELLOW_BUBBLE_AT: Vector2i = Vector2i(6, 4)
+const YELLOW_BUBBLE_TAIL_AT: Vector2i = Vector2i(9, 8)
+const YELLOW_BUBBLE_TAIL: Array[int] = [0x64, 0x65]
+const YELLOW_PIKACHU_AT: Vector2i = Vector2i(4, 8)
+const YELLOW_PIKACHU_COLUMN: Array[int] = [0x96, 0x9D, 0xA7, 0xB1]
+const YELLOW_PIKACHU_COLUMN_AT: Vector2i = Vector2i(16, 10)
+## `.Jumptable`: an eye frame, or `.Nop` (-1), `.BlinkWait` (-3), `.GoBackToStart` (-2).
+const YELLOW_BLINK_SCENES: Array[int] = [-1, 4, -3, -3, 8, -3, -3, 4, -3, -3, 0, -2]
+const YELLOW_BLINK_NOP: int = -1
+const YELLOW_BLINK_RESTART: int = -2
+const YELLOW_BLINK_WAIT: int = -3
+const YELLOW_BLINK_MASK: int = 0xF3
+const YELLOW_TIMER_RESTARTS: Array[int] = [0x00, 0x80, 0x90]
+const YELLOW_RESET_FRAMES: int = 0xC00
+const YELLOW_BUBBLE_DELAY: int = DELAY3
+## The two `PlayPikachuSoundClip`s, spent in silence.
+const YELLOW_TITLE_CRY: int = 0
+const YELLOW_TITLE_CRY_CLOSE: int = 10
+
+## `CheckForUserInterruption`'s two answers.
+const INTERRUPT_BUTTONS: int = PAD_START | PAD_A
+const YELLOW_INTRO_BUTTONS: int = PAD_A | PAD_B | PAD_START
+
+var lcd: Gen1Lcd = Gen1Lcd.new()
+
+var _profile: StringName = &"red"
+var _data: GameData = null
+var _opening: Dictionary = {}
+var _rng: RandomNumberGenerator = null
+var _sound: Gen1SoundEngine = null
+var _yellow_intro: Gen1YellowIntro = null
+
+## `wTileMap`, `wShadowOAM`, `hSCX`, `hSCY` and `hWY`, which VBlank copies.
+var _tilemap: PackedByteArray = PackedByteArray()
+var _shadow_oam: PackedByteArray = PackedByteArray()
+var _hscx: int = 0
+var _hscy: int = 0
+var _hwy: int = 0
+var _transfer_enabled: bool = false
+var _transfer_dest: int = DEST_MAP1
+var _transfer_portion: int = 0
+var _pending_copy: Dictionary = {}
+## `SaveScreenTilesToBuffer1` and `2`.
+var _buffer1: PackedByteArray = PackedByteArray()
+var _buffer2: PackedByteArray = PackedByteArray()
+
+var _steps: Array = []
+var _labels: Dictionary = {}
+var _pc: int = 0
+## Steps a `do` handed back, a called routine run to its end first.
+var _calls: Array[Dictionary] = []
+var _wait: int = 0
+var _check_left: int = 0
+var _check_skip: StringName = &""
+var _sound_wait: bool = false
+var _frame: int = 0
+var _phase: StringName = PHASE_COPYRIGHT
+var _finished: bool = false
+var _events: Array[Dictionary] = []
+
+var _held: int = 0
+var _held_at_read: int = 0
+var _tapped: int = 0
+
+## Which `SetPal_*` packet the screen is under.
+var _palette_command: String = "splash"
+var _title_species: int = 0
+## Picks to take before `Random` is asked, so a trace can follow a cartridge's.
+var _title_picks: Array[int] = []
+var _blink_scene: int = 0
+var _blink_timer: int = 0
+var _reset_counter: int = 0
+
+
+## Null on a cache with no opening section.
+static func create(data: GameData, rng: RandomNumberGenerator = null) -> Gen1Opening:
+	if data == null or data.generation != RomRegistry.GEN1 or data.opening().is_empty():
+		return null
+	var out := Gen1Opening.new()
+	out._data = data
+	out._profile = data.id
+	out._opening = data.opening()
+	out._rng = rng if rng != null else RandomNumberGenerator.new()
+	out._sound = Gen1SoundEngine.new()
+	out._sound.set_assets(data.audio_assets())
+	out._sound.yellow = data.id == RomRegistry.YELLOW
+	out._sound.audio_rom_bank = AUDIO_BANK
+	out._sound.saved_rom_bank = AUDIO_BANK
+	out._tilemap.resize(TILEMAP_CELLS)
+	out._shadow_oam.resize(Gen1Lcd.OAM_SLOTS * Gen1Lcd.OAM_BYTES)
+	# `PrepareOAMData`'s first VBlank runs before `Init` writes
+	# `wUpdateSpritesEnabled`, and a zero there is `HideSprites`.
+	for slot: int in Gen1Lcd.OAM_SLOTS:
+		out._shadow_oam[slot * Gen1Lcd.OAM_BYTES] = OFF_SCREEN_Y
+	out._buffer1.resize(TILEMAP_CELLS)
+	out._buffer2.resize(TILEMAP_CELLS)
+	out._build()
+	return out
+
+
+func phase() -> StringName:
+	return _phase
+
+
+func finished() -> bool:
+	return _finished
+
+
+func frame() -> int:
+	return _frame
+
+
+func profile() -> StringName:
+	return _profile
+
+
+## The `wTitleMonSpecies` on screen, as a dex number.
+func title_species() -> int:
+	return _title_species
+
+
+## Dex numbers `TitleScreenPickNewMon` takes in order before it rolls its own.
+func set_title_picks(picks: Array[int]) -> void:
+	_title_picks = picks.duplicate()
+
+
+## Which `SetPal_*` packet colours the screen.
+func palette_command() -> String:
+	return _palette_command
+
+
+func palettes() -> Array:
+	return (_opening.get("palettes", {}) as Dictionary).get(_palette_command, [])
+
+
+func blocks() -> Array:
+	return (_opening.get("blocks", {}) as Dictionary).get(_palette_command, [])
+
+
+func shadow_oam() -> Array[Dictionary]:
+	return lcd.shadow_oam()
+
+
+func drain_events() -> Array[Dictionary]:
+	var out: Array[Dictionary] = _events.duplicate(true)
+	_events.clear()
+	return out
+
+
+## `hJoyHeld`: a button held from this frame on, until [method release].
+func press(button: int) -> void:
+	_held |= button
+	_tapped |= button
+
+
+func release(button: int) -> void:
+	_held &= ~button
+
+
+## One frame: the code before VBlank, VBlank, then the joypad read behind it.
+func advance_frame() -> Array[Dictionary]:
+	if _finished:
+		return drain_events()
+	_frame += 1
+	# An `rLY` wait scrolls one frame only.
+	lcd.line_scx = PackedInt32Array()
+	if _sound_wait and not _sound_active():
+		_sound_wait = false
+	if _wait == 0 and _check_left == 0 and not _sound_wait:
+		_run()
+	# No LCD, no VBlank, no driver.
+	if lcd.lcdc & Gen1Lcd.LCDC_ON:
+		_vblank()
+		_sound.fade_out_audio()
+		_sound.update_music()
+	if _wait > 0:
+		_wait -= 1
+	if _wait == 0 and _check_left > 0:
+		_check_left -= 1
+		if _interrupted():
+			_check_left = 0
+			_jump(_check_skip)
+		elif _check_left > 0:
+			_wait = 1
+	_tapped = 0
+	return drain_events()
+
+
+## `WaitForSoundToFinish`: channels 5, 6 and 8 of `wChannelSoundIDs`.
+func _sound_active() -> bool:
+	for channel: int in [4, 5, 7]:
+		if _sound.channel_sound_id(channel) != 0:
+			return true
+	return false
+
+
+## `CheckForUserInterruption`'s read: Up+Select+B held, or START or A newly down.
+func _interrupted() -> bool:
+	return _held == CHORD_CLEAR_SAVE or _read_pressed() & INTERRUPT_BUTTONS != 0
+
+
+## `hJoy5`: down now and not at the last read, plus any tap between.
+func _read_pressed() -> int:
+	var pressed: int = (_held & ~_held_at_read) | _tapped
+	_held_at_read = _held
+	return pressed
+
+
+func _run() -> void:
+	while _wait == 0 and _check_left == 0 and not _sound_wait and not _finished:
+		var step: Dictionary = _next_step()
+		if step.is_empty():
+			return
+		if step.has("do"):
+			var more: Variant = (step["do"] as Callable).call()
+			if more is Array and not (more as Array).is_empty():
+				_calls.append({"steps": more, "pc": 0})
+		elif step.has("delay"):
+			_wait = int(step["delay"])
+		elif step.has("check"):
+			_wait = 1
+			_check_left = int(step["check"])
+			_check_skip = step["skip"]
+		elif step.has("jump"):
+			_jump(step["jump"])
+		elif step.has("wait_sound"):
+			_sound_wait = _sound_active()
+		elif step.has("phase"):
+			_phase = step["phase"]
+			_emit(&"phase", {"phase": _phase})
+		elif step.has("finish"):
+			_finished = true
+			_phase = PHASE_FINISHED
+			_emit(step["finish"], {})
+
+
+## The step to run: the innermost called routine's next, or the program's own.
+func _next_step() -> Dictionary:
+	while not _calls.is_empty():
+		var routine: Dictionary = _calls[_calls.size() - 1]
+		var steps: Array = routine["steps"]
+		if int(routine["pc"]) < steps.size():
+			routine["pc"] = int(routine["pc"]) + 1
+			return steps[int(routine["pc"]) - 1]
+		_calls.pop_back()
+	if _pc >= _steps.size():
+		return {}
+	_pc += 1
+	return _steps[_pc - 1]
+
+
+## A `ret c` chain: the program continues at a label, the called routine dropped.
+func _jump(label: StringName) -> void:
+	_pc = int(_labels[label])
+	_calls.clear()
+
+
+func _index_labels() -> void:
+	_labels.clear()
+	for index: int in _steps.size():
+		var step: Dictionary = _steps[index]
+		if step.has("label"):
+			_labels[step["label"]] = index
+
+
+func _emit(type: StringName, values: Dictionary) -> void:
+	var event: Dictionary = {"type": type, "frame": _frame, "phase": _phase}
+	event.merge(values, true)
+	_events.append(event)
+
+
+## The VBlank handler: the scroll registers, `AutoBgMapTransfer`'s third,
+## `VBlankCopy`'s eight tiles and `hDMARoutine`'s OAM.
+func _vblank() -> void:
+	lcd.scx = _hscx
+	lcd.scy = _hscy
+	lcd.wy = _hwy
+	if _transfer_enabled and _pending_copy.is_empty():
+		_transfer_third()
+	_land_copy()
+	for index: int in _shadow_oam.size():
+		lcd.oam[index] = _shadow_oam[index]
+	if _yellow_intro != null:
+		_yellow_intro.vblank()
+
+
+func _transfer_third() -> void:
+	var first_row: int = _transfer_portion * TRANSFER_ROWS
+	for row: int in TRANSFER_ROWS:
+		var source: int = first_row + row
+		var dest: int = (_transfer_dest + source) % (2 * MAP_ROWS)
+		var map: PackedByteArray = lcd.maps[dest / MAP_ROWS]
+		var at: int = (dest % MAP_ROWS) * Gen1Lcd.MAP_SIDE
+		for column: int in COLUMNS:
+			map[at + column] = _tilemap[source * COLUMNS + column]
+	_transfer_portion = (_transfer_portion + 1) % 3
+
+
+func _land_copy() -> void:
+	if _pending_copy.is_empty():
+		return
+	var count: int = mini(COPY_TILES_PER_FRAME, int(_pending_copy["left"]))
+	lcd.load_tiles(
+		int(_pending_copy["at"]), _pending_copy["strip"], int(_pending_copy["strip_tiles"]),
+		int(_pending_copy["first"]), count
+	)
+	_pending_copy["at"] = int(_pending_copy["at"]) + count
+	_pending_copy["first"] = int(_pending_copy["first"]) + count
+	_pending_copy["left"] = int(_pending_copy["left"]) - count
+	if int(_pending_copy["left"]) <= 0:
+		_pending_copy = {}
+
+
+## `CopyVideoData`: `c / 8 + 1` VBlanks with the auto transfer held off.
+func copy_video_steps(sheet: String, at: int, first: int, count: int) -> Array:
+	var strip: PackedByteArray = _data.tile_indices(sheet)
+	var strip_tiles: int = int(_data.tile_sheet(sheet).get("tiles", 0))
+	return [
+		{"do": func() -> void:
+			_pending_copy = {
+				"strip": strip, "strip_tiles": strip_tiles,
+				"at": at, "first": first, "left": count,
+			}},
+		{"delay": count / COPY_TILES_PER_FRAME + 1},
+	]
+
+
+## `FarCopyData` under a disabled LCD, which lands at once.
+func _load_sheet(sheet: String, at: int, first: int = 0, count: int = -1) -> void:
+	var strip_tiles: int = int(_data.tile_sheet(sheet).get("tiles", 0))
+	lcd.load_tiles(
+		at, _data.tile_indices(sheet), strip_tiles,
+		first, count if count >= 0 else strip_tiles - first
+	)
+
+
+## What [Gen1YellowIntro] writes through.
+func set_transfer(enabled: bool, dest: int) -> void:
+	_transfer_enabled = enabled
+	_transfer_dest = dest
+
+
+func set_scroll(x: int, y: int) -> void:
+	_hscx = x & 0xFF
+	_hscy = y & 0xFF
+
+
+func scroll_x() -> int:
+	return _hscx
+
+
+func set_window(y: int) -> void:
+	_hwy = y & 0xFF
+
+
+func set_palettes(bgp: int, obp0: int, obp1: int) -> void:
+	lcd.bgp = bgp & 0xFF
+	lcd.obp0 = obp0 & 0xFF
+	lcd.obp1 = obp1 & 0xFF
+
+
+func set_palette_command(name: String) -> void:
+	_palette_command = name
+
+
+func play_music(id: int) -> void:
+	_play_music(id)
+
+
+func fill_tilemap(id: int) -> void:
+	_fill_tilemap(id)
+
+
+func fill_tilemap_rows(first: int, count: int, id: int) -> void:
+	_fill_tilemap_rows(first, count, id)
+
+
+func write_map(which: int, at: Vector2i, columns: int, rows: int, ids: Array) -> void:
+	var bytes := PackedByteArray()
+	for id: Variant in ids:
+		bytes.append(int(id) & 0xFF)
+	lcd.write_map(which, at, columns, rows, bytes)
+
+
+func clear_sprites() -> void:
+	_clear_sprites()
+
+
+func shadow_byte(at: int) -> int:
+	return _shadow_oam[at]
+
+
+func set_shadow_byte(at: int, value: int) -> void:
+	_shadow_oam[at] = value & 0xFF
+
+
+func _set_sprite(slot: int, y: int, x: int, tile: int, attributes: int) -> void:
+	var at: int = slot * Gen1Lcd.OAM_BYTES
+	_shadow_oam[at] = y & 0xFF
+	_shadow_oam[at + 1] = x & 0xFF
+	_shadow_oam[at + 2] = tile & 0xFF
+	_shadow_oam[at + 3] = attributes & 0xFF
+
+
+func _sprite_byte(slot: int, byte: int) -> int:
+	return _shadow_oam[slot * Gen1Lcd.OAM_BYTES + byte]
+
+
+func _set_sprite_byte(slot: int, byte: int, value: int) -> void:
+	_shadow_oam[slot * Gen1Lcd.OAM_BYTES + byte] = value & 0xFF
+
+
+func _clear_sprites() -> void:
+	_shadow_oam.fill(0)
+
+
+func _fill_tilemap(id: int) -> void:
+	_tilemap.fill(id)
+
+
+func _write_tilemap(at: Vector2i, columns: int, rows: int, ids: Array) -> void:
+	for row: int in rows:
+		for column: int in columns:
+			var x: int = at.x + column
+			var y: int = at.y + row
+			var source: int = row * columns + column
+			if x < 0 or x >= COLUMNS or y < 0 or y >= ROWS or source >= ids.size():
+				continue
+			_tilemap[y * COLUMNS + x] = int(ids[source]) & 0xFF
+
+
+func _fill_tilemap_rows(first: int, count: int, id: int) -> void:
+	for cell: int in range(first * COLUMNS, (first + count) * COLUMNS):
+		_tilemap[cell] = id
+
+
+func _play_sfx(id: int) -> void:
+	_sound.play_sound(id)
+	_emit(&"play_sfx", {"sfx": id, "bank": AUDIO_BANK})
+
+
+func _play_music(id: int) -> void:
+	_sound.play_music(AUDIO_BANK, id)
+	_emit(&"play_music", {"music": id, "bank": AUDIO_BANK})
+
+
+func _stop_music() -> void:
+	_sound.play_sound(Gen1SoundEngine.SFX_STOP_ALL_MUSIC)
+	_emit(&"stop_music", {})
+
+
+## `PlayCry` through the same driver, so the wait behind it ends with the cry.
+func _play_cry(species: int) -> void:
+	var record: Dictionary = _data.species_cry(species)
+	if not record.is_empty():
+		_sound.frequency_modifier = int(record.get("cry_pitch", 0)) & 0xFF
+		_sound.tempo_modifier = int(record.get("cry_length", 0x80)) & 0xFF
+		_sound.play_sound(int(record.get("sound_id", 0)))
+	_emit(&"play_cry", {"species": species})
+
+
+func wait_sound_step() -> Dictionary:
+	return {"wait_sound": true}
+
+
+func delay_step(frames: int) -> Dictionary:
+	return {"delay": frames}
+
+
+func check_step(frames: int, skip: StringName) -> Dictionary:
+	return {"check": frames, "skip": skip}
+
+
+func do_step(callable: Callable) -> Dictionary:
+	return {"do": callable}
+
+
+func label_step(name: StringName) -> Dictionary:
+	return {"label": name}
+
+
+func _build() -> void:
+	_steps = []
+	_steps.append_array(_splash_steps())
+	if _profile == RomRegistry.YELLOW:
+		_steps.append_array(_yellow_intro_steps())
+	else:
+		_steps.append_array(_intro_steps())
+	_steps.append_array(_init_tail_steps())
+	if _profile == RomRegistry.YELLOW:
+		_steps.append_array(_yellow_title_steps())
+	else:
+		_steps.append_array(_title_steps())
+	_index_labels()
+
+
+## `PlayShootingStar` up to its `Delay3`.
+func _splash_steps() -> Array:
+	var steps: Array = [
+		{"phase": PHASE_COPYRIGHT},
+		do_step(func() -> void:
+			_palette_command = "splash"
+			_hwy = 0
+			_fill_tilemap(BLANK)
+			_transfer_enabled = true
+			_transfer_dest = DEST_MAP1),
+		delay_step(DELAY3),
+	]
+	# `LoadTextBoxTilePatterns` with the LCD on, then `LoadCopyrightTiles`.
+	steps.append_array(copy_video_steps("font_extra", COPYRIGHT_TILE, 0, Gen1Layout.FONT_EXTRA_TILES))
+	steps.append_array(copy_video_steps(
+		"copyright", COPYRIGHT_TILE, 0, Gen1Layout.copyright_tiles(_profile)
+	))
+	steps.append_array([
+		do_step(func() -> void:
+			_place_copyright()
+			lcd.bgp = INTRO_PALETTE),
+		delay_step(COPYRIGHT_FRAMES),
+		do_step(func() -> void: _fill_tilemap(BLANK)),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			lcd.lcdc &= ~Gen1Lcd.LCDC_ON
+			_draw_black_bars()
+			_load_intro_graphics()),
+		delay_step(int(INTRO_GRAPHICS_FRAMES[_profile])),
+		do_step(func() -> void:
+			lcd.lcdc |= Gen1Lcd.LCDC_ON),
+		delay_step(1),
+		{"phase": PHASE_PRESENTS},
+		do_step(func() -> void:
+			lcd.lcdc = (lcd.lcdc & ~Gen1Lcd.LCDC_WINDOW) | Gen1Lcd.LCDC_BG_MAP),
+		delay_step(SHOOTING_STAR_DELAY),
+	])
+	steps.append_array(_shooting_star_steps())
+	steps.append_array([
+		delay_step(AFTER_STARS_DELAY),
+		label_step(&"presents_end"),
+		do_step(func() -> void:
+			if _profile != RomRegistry.YELLOW:
+				_play_music(MUSIC_INTRO_BATTLE)
+			_fill_tilemap_rows(BLACK_BAR_ROWS, ROWS - 2 * BLACK_BAR_ROWS, 0)
+			_clear_sprites()),
+		delay_step(DELAY3),
+	])
+	return steps
+
+
+## `CopyrightTextString` at `hlcoord 2, 7`, `next` moving two rows.
+func _place_copyright() -> void:
+	var rows: Array = _data.credits_copyright_rows()
+	for index: int in rows.size():
+		var row: Array = rows[index]
+		_write_tilemap(COPYRIGHT_AT + Vector2i(0, index * COPYRIGHT_ROW_STEP), row.size(), 1, row)
+
+
+func _draw_black_bars() -> void:
+	for row: int in ROWS:
+		for column: int in Gen1Lcd.MAP_SIDE:
+			lcd.maps[1][row * Gen1Lcd.MAP_SIDE + column] = 0
+	_fill_tilemap(0)
+	_fill_tilemap_rows(0, BLACK_BAR_ROWS, BLACK_TILE)
+	_fill_tilemap_rows(ROWS - BLACK_BAR_ROWS, BLACK_BAR_ROWS, BLACK_TILE)
+	for y: int in ROWS:
+		if y >= BLACK_BAR_ROWS and y < ROWS - BLACK_BAR_ROWS:
+			continue
+		for column: int in Gen1Lcd.MAP_SIDE:
+			lcd.maps[1][y * Gen1Lcd.MAP_SIDE + column] = BLACK_TILE
+
+
+## `LoadIntroGraphics`; Yellow writes a white and a black tile in the Gengar's place.
+func _load_intro_graphics() -> void:
+	if _profile == RomRegistry.YELLOW:
+		lcd.fill_tile(2 * Gen1Lcd.BLOCK_TILES, 0)
+		lcd.fill_tile(2 * Gen1Lcd.BLOCK_TILES + BLACK_TILE, 3)
+	else:
+		_load_sheet("intro_back_mon", 2 * Gen1Lcd.BLOCK_TILES)
+		_load_sheet("intro_front_mon", 0)
+	_load_sheet("splash_logo", LOGO_BG_TILE)
+	_load_sheet("splash_logo", LOGO_OB_TILE)
+
+
+## `AnimateShootingStar`.
+func _shooting_star_steps() -> Array:
+	var steps: Array = [
+		do_step(func() -> void:
+			lcd.obp0 = SHOOTING_STAR_OBP0
+			lcd.obp1 = SHOOTING_STAR_OBP1),
+	]
+	for index: int in BIG_STAR_SOURCE_TILES.size():
+		steps.append_array(_copy_anim_tile(BIG_STAR_SOURCE_TILES[index], STAR_TILE + index))
+	steps.append_array(copy_video_steps("splash_star", STAR_TILE + 2, 0, Gen1Layout.SPLASH_STAR_TILES))
+	steps.append(do_step(func() -> void:
+		var logo: Array = _opening.get("logo_oam", [])
+		for slot: int in logo.size():
+			_set_sprite_row(LOGO_OAM_FIRST_SLOT + slot, logo[slot])
+		var star: Array = _opening.get("shooting_star_oam", [])
+		for slot: int in star.size():
+			_set_sprite_row(slot, star[slot])
+		_play_sfx(SFX_SHOOTING_STAR)))
+	# `.bigStarLoop` runs until slot 0's Y reaches $a0, four pixels a frame.
+	var star_rows: Array = _opening.get("shooting_star_oam", [])
+	var start_y: int = int(star_rows[0][0]) if not star_rows.is_empty() else 0
+	var moves: int = ((BIG_STAR_END_Y - start_y) & 0xFF) / BIG_STAR_STEP
+	for _move: int in moves:
+		steps.append(do_step(func() -> void:
+			for slot: int in Gen1Layout.SPLASH_SHOOTING_STAR_SPRITES:
+				_set_sprite_byte(slot, 0, _sprite_byte(slot, 0) + BIG_STAR_STEP)
+				_set_sprite_byte(slot, 1, _sprite_byte(slot, 1) - BIG_STAR_STEP)))
+		steps.append(check_step(1, &"presents_end"))
+	steps.append(do_step(func() -> void:
+		for slot: int in Gen1Layout.SPLASH_SHOOTING_STAR_SPRITES:
+			_set_sprite_byte(slot, 0, OFF_SCREEN_Y)))
+	for _flash: int in LOGO_FLASHES:
+		steps.append(do_step(func() -> void:
+			lcd.obp0 = _rotate_right_twice(lcd.obp0)))
+		steps.append(check_step(LOGO_FLASH_FRAMES, &"presents_end"))
+	steps.append(do_step(func() -> void:
+		var row: Array = _opening.get("small_star_oam", [0, 0, 0, 0])
+		for slot: int in SMALL_STARS:
+			_set_sprite_row(slot, row)))
+	steps.append_array(_small_star_steps())
+	return steps
+
+
+## `.smallStarsLoop`: six waves, four with stars, eight three-frame steps each
+## with `rOBP1` toggled, the buffer shifted four slots between waves.
+func _small_star_steps() -> Array:
+	var steps: Array = []
+	var waves: Array = _opening.get("small_star_waves", [])
+	var count: int = 0
+	for wave: int in SMALL_STAR_WAVES:
+		var rows: Array = waves[wave] if wave < waves.size() else []
+		if not rows.is_empty():
+			steps.append(do_step(func() -> void:
+				for index: int in rows.size():
+					_set_sprite_byte(SMALL_STAR_FIRST_SLOT + index, 0, int(rows[index][0]))
+					_set_sprite_byte(SMALL_STAR_FIRST_SLOT + index, 1, int(rows[index][1]))))
+			if count != SMALL_STARS:
+				count += SMALL_STAR_COUNT_STEP
+		var moving: int = count
+		for _step: int in SMALL_STAR_FALL_STEPS:
+			steps.append(do_step(func() -> void:
+				for index: int in moving:
+					var slot: int = SMALL_STAR_LAST_SLOT - index
+					_set_sprite_byte(slot, 0, _sprite_byte(slot, 0) + 1)
+				lcd.obp1 ^= SMALL_STAR_OBP1_TOGGLE))
+			steps.append(check_step(SMALL_STAR_FALL_FRAMES, &"presents_end"))
+		steps.append(do_step(func() -> void:
+			for byte: int in (SMALL_STAR_FIRST_SLOT) * Gen1Lcd.OAM_BYTES:
+				_shadow_oam[byte] = _shadow_oam[byte + Gen1Lcd.OAM_BYTES * Gen1Lcd.OAM_BYTES]))
+	return steps
+
+
+func _copy_anim_tile(source: int, at: int) -> Array:
+	var strip: PackedByteArray = _data.battle_anim_gfx_indices(BIG_STAR_SHEET)
+	var strip_tiles: int = int(_data.battle_anim_gfx(BIG_STAR_SHEET).get("tiles", 0))
+	return [
+		do_step(func() -> void:
+			_pending_copy = {
+				"strip": strip, "strip_tiles": strip_tiles,
+				"at": at, "first": source, "left": 1,
+			}),
+		delay_step(1),
+	]
+
+
+func _set_sprite_row(slot: int, row: Array) -> void:
+	_set_sprite(slot, int(row[0]), int(row[1]), int(row[2]), int(row[3]))
+
+
+static func _rotate_right_twice(byte: int) -> int:
+	var out: int = byte & 0xFF
+	for _turn: int in 2:
+		out = ((out >> 1) | ((out & 1) << 7)) & 0xFF
+	return out
+
+
+## `PlayIntroScene`, every `ret c` landing on `GBFadeOutToWhite`.
+func _intro_steps() -> Array:
+	var anims: Array = _opening.get("nidorino_anims", [])
+	var steps: Array = [
+		{"phase": PHASE_INTRO_MOVIE},
+		do_step(func() -> void:
+			_palette_command = "intro"
+			lcd.bgp = INTRO_PALETTE
+			lcd.obp0 = INTRO_PALETTE
+			lcd.obp1 = INTRO_PALETTE
+			_hscx = 0
+			_copy_gengar_tiles(0)
+			_init_nidorino_oam()),
+	]
+	steps.append_array(_move_mon_steps(NIDORINO_WALK, 1, true))
+	steps.append_array(_hop_steps(SFX_INTRO_HIP, 0, anims, 0))
+	steps.append_array(_hop_steps(SFX_INTRO_HOP, 0, anims, 1))
+	steps.append(check_step(10, &"intro_end"))
+	steps.append_array(_hop_steps(SFX_INTRO_HIP, 0, anims, 0))
+	steps.append_array(_hop_steps(SFX_INTRO_HOP, 0, anims, 1))
+	steps.append(check_step(30, &"intro_end"))
+	steps.append(do_step(func() -> void:
+		_copy_gengar_tiles(1)
+		_play_sfx(SFX_INTRO_RAISE)))
+	steps.append_array(_move_mon_steps(GENGAR_RAISE, 1, false))
+	steps.append(check_step(30, &"intro_end"))
+	steps.append(do_step(func() -> void:
+		_copy_gengar_tiles(2)
+		_play_sfx(SFX_INTRO_CRASH)))
+	steps.append_array(_move_mon_steps(GENGAR_SLASH, -1, false))
+	steps.append_array(_hop_steps(SFX_INTRO_HIP, POSE_TILES, anims, 2))
+	steps.append(check_step(30, &"intro_end"))
+	steps.append_array(_move_mon_steps(GENGAR_RAISE, 1, false))
+	steps.append(do_step(func() -> void: _copy_gengar_tiles(0)))
+	steps.append(check_step(60, &"intro_end"))
+	steps.append_array(_hop_steps(SFX_INTRO_HIP, 0, anims, 3))
+	steps.append_array(_hop_steps(SFX_INTRO_HOP, 0, anims, 4))
+	steps.append(check_step(20, &"intro_end"))
+	steps.append_array(_hop_steps(-1, POSE_TILES, anims, 5))
+	steps.append(check_step(30, &"intro_end"))
+	steps.append_array(_hop_steps(SFX_INTRO_LUNGE, 2 * POSE_TILES, anims, 6))
+	steps.append(label_step(&"intro_end"))
+	for row: int in FADE_TO_WHITE:
+		steps.append(do_step(func() -> void: _fade_palette(row)))
+		steps.append(delay_step(FADE_STEP_FRAMES))
+	steps.append(do_step(func() -> void:
+		_hscx = 0
+		_transfer_enabled = false
+		_clear_sprites()))
+	steps.append(delay_step(1))
+	return steps
+
+
+## `IntroCopyTiles`: a Gengar row at `hlcoord 13, 7`, auto transfer on.
+func _copy_gengar_tiles(index: int) -> void:
+	var tilemaps: Array = _opening.get("gengar_tilemaps", [])
+	if index < tilemaps.size():
+		_write_tilemap(
+			INTRO_TILEMAP_AT, Gen2PicImage.FRONTPIC_TILES, Gen2PicImage.FRONTPIC_TILES,
+			tilemaps[index]
+		)
+	_transfer_enabled = true
+
+
+## `InitIntroNidorinoOAM`: six columns of six, behind the background.
+func _init_nidorino_oam() -> void:
+	var tile: int = 0
+	for column: int in NIDORINO_SIDE:
+		for row: int in NIDORINO_SIDE:
+			_set_sprite(
+				tile, NIDORINO_BASE_Y + (row + 1) * Gen1Lcd.TILE, column * Gen1Lcd.TILE,
+				tile, Gen1Lcd.OAM_PRIO
+			)
+			tile += 1
+
+
+## `UpdateIntroNidorinoOAM`: one offset for all, tiles renumbered from a base.
+func _update_nidorino_oam(dy: int, dx: int, base_tile: int) -> void:
+	for slot: int in NIDORINO_SPRITES:
+		_set_sprite_byte(slot, 0, _sprite_byte(slot, 0) + dy)
+		_set_sprite_byte(slot, 1, _sprite_byte(slot, 1) + dx)
+		_set_sprite_byte(slot, 2, base_tile + slot)
+
+
+## `IntroMoveMon`: two-pixel steps of `hSCX`, the Nidorino along when [param mon].
+func _move_mon_steps(moves: int, direction: int, mon: bool) -> Array:
+	var steps: Array = []
+	for _move: int in moves:
+		steps.append(do_step(func() -> void:
+			if mon:
+				_update_nidorino_oam(0, MOVE_PIXELS, 0)
+			_hscx = (_hscx + direction * MOVE_PIXELS) & 0xFF))
+		steps.append(check_step(MOVE_FRAMES, &"intro_end"))
+	return steps
+
+
+## `AnimateIntroNidorino` behind its sound, a row every five frames.
+func _hop_steps(sfx: int, base_tile: int, anims: Array, index: int) -> Array:
+	var steps: Array = []
+	if sfx >= 0:
+		steps.append(do_step(func() -> void: _play_sfx(sfx)))
+	var rows: Array = anims[index] if index < anims.size() else []
+	for row: Array in rows:
+		steps.append(do_step(func() -> void:
+			_update_nidorino_oam(int(row[0]), int(row[1]), base_tile)))
+		steps.append(delay_step(HOP_FRAMES))
+	return steps
+
+
+## One `FadePal*` row into the three registers.
+func _fade_palette(row: int) -> void:
+	var at: int = row * 3
+	lcd.bgp = Gen1Layout.FADE_PALS[at]
+	lcd.obp0 = Gen1Layout.FADE_PALS[at + 1]
+	lcd.obp1 = Gen1Layout.FADE_PALS[at + 2]
+
+
+## What `Init` does between `PlayIntro` and `PrepareTitleScreen`.
+func _init_tail_steps() -> Array:
+	var frames: Array = CLEAR_VRAM_FRAMES[_profile]
+	return [
+		do_step(func() -> void:
+			lcd.lcdc &= ~Gen1Lcd.LCDC_ON
+			lcd.clear_vram()),
+		delay_step(int(frames[0])),
+		do_step(func() -> void:
+			lcd.bgp = GB_PAL_NORMAL_BGP
+			lcd.obp0 = GB_PAL_NORMAL_OBP0
+			_clear_sprites()),
+		delay_step(int(frames[1])),
+		do_step(func() -> void:
+			lcd.lcdc = Gen1Lcd.LCDC_DEFAULT
+			if PREPARE_WINDOW_EARLY[_profile]:
+				_hwy = 0),
+		# `DisplayTitleScreen`'s white-out is the frame after the LCD returns.
+		delay_step(1),
+	]
+
+
+## `DisplayTitleScreen` on Red and Blue.
+func _title_steps() -> Array:
+	var steps: Array = [
+		{"phase": PHASE_TITLE},
+		do_step(func() -> void:
+			lcd.bgp = 0
+			lcd.obp0 = 0
+			lcd.obp1 = 0
+			_transfer_enabled = true
+			_hscx = 0
+			_hscy = TITLE_SCY
+			_hwy = WINDOW_OFF
+			_fill_tilemap(BLANK)),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			lcd.lcdc &= ~Gen1Lcd.LCDC_ON
+			_load_title_graphics()
+			lcd.fill_map(0, BLANK)
+			lcd.fill_map(1, BLANK)
+			_place_title_logo()
+			_draw_player_character()
+			_write_tilemap(TITLE_COPYRIGHT_AT, TITLE_COPYRIGHT_TILES.size(), 1, TITLE_COPYRIGHT_TILES)
+			_buffer2 = _tilemap.duplicate()),
+		delay_step(int(TITLE_LOAD_FRAMES.get(_profile, 6))),
+		do_step(func() -> void:
+			lcd.lcdc |= Gen1Lcd.LCDC_ON
+			_title_species = int(_opening.get("title_mons", [0])[0])),
+		delay_step(TITLE_FIRST_LOAD_EXTRA),
+		do_step(func() -> Array: return _load_title_mon_steps()),
+		do_step(func() -> void: _transfer_dest = DEST_MAP0_PLUS_300),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_buffer1 = _tilemap.duplicate()
+			_hwy = WINDOW_HALF
+			_tilemap = _buffer2.duplicate()
+			_transfer_dest = DEST_MAP0),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_palette_command = "title"
+			lcd.bgp = GB_PAL_NORMAL_BGP
+			lcd.obp0 = TITLE_OBP0),
+	]
+	steps.append_array(_bounce_steps())
+	steps.append_array([
+		do_step(func() -> void: _tilemap = _buffer1.duplicate()),
+		delay_step(TITLE_SETTLE_FRAMES),
+		do_step(func() -> void:
+			_play_sfx(SFX_INTRO_WHOOSH)
+			_place_version()
+			_hwy = Gen1Lcd.HEIGHT),
+	])
+	steps.append_array(_version_scroll_steps())
+	steps.append_array([
+		do_step(func() -> void: _transfer_dest = DEST_MAP1),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_tilemap = _buffer2.duplicate()
+			_place_version()),
+		delay_step(DELAY3),
+		wait_sound_step(),
+		do_step(func() -> void: _play_music(MUSIC_TITLE_SCREEN)),
+		label_step(&"title_loop"),
+		check_step(TITLE_WAIT_FRAMES, &"title_end"),
+		do_step(func() -> Array:
+			return _title_scroll_steps(TITLE_SCROLL_OUT, 0, false, func() -> void: _hwy = 0)),
+		check_step(1, &"title_end"),
+		do_step(func() -> Array:
+			var starters: Array[int] = []
+			for mon: Variant in (_opening.get("title_mons", []) as Array).slice(0, TITLE_STARTERS):
+				starters.append(int(mon))
+			if _title_species not in starters:
+				return []
+			return _title_scroll_steps(TITLE_SCROLL_WAIT_BALL, 0, true)),
+		do_step(func() -> void: _transfer_dest = DEST_MAP0),
+		delay_step(DELAY3),
+		do_step(func() -> Array:
+			_title_species = _pick_title_mon()
+			return _load_title_mon_steps()),
+		do_step(func() -> Array:
+			_hwy = WINDOW_OFF
+			return _title_scroll_steps(TITLE_SCROLL_IN, TITLE_SCROLL_IN_START, false)),
+		{"jump": &"title_loop"},
+		label_step(&"title_end"),
+		do_step(func() -> void: _play_cry(_title_species)),
+		wait_sound_step(),
+	])
+	steps.append_array(_leave_title_steps())
+	return steps
+
+
+## `DisplayTitleScreen`'s LCD-off loads; a shorter `Version_GFX` sits a tile along.
+func _load_title_graphics() -> void:
+	_load_sheet("copyright", TITLE_COPYRIGHT_VRAM, 0, TITLE_COPYRIGHT_NINTENDO_TILES)
+	_load_sheet(
+		"copyright", TITLE_COPYRIGHT_VRAM + TITLE_COPYRIGHT_NINTENDO_TILES,
+		TITLE_COPYRIGHT_GAMEFREAK_FIRST, TITLE_COPYRIGHT_GAMEFREAK_TILES
+	)
+	_load_sheet("title_logo", TITLE_LOGO_VRAM, 0, TITLE_LOGO_FIRST_CHUNK)
+	_load_sheet("title_logo", TITLE_LOGO2_VRAM, TITLE_LOGO_FIRST_CHUNK, 16)
+	var version: int = int(_data.tile_sheet("title_version").get("tiles", 0))
+	_load_sheet("title_version", TITLE_VERSION_VRAM + (TITLE_VERSION_SLOT_TILES - version) / 2)
+	_load_sheet("title_player", 0)
+
+
+func _place_title_logo() -> void:
+	for row: int in TITLE_LOGO_ROWS - 1:
+		var ids: Array = []
+		for column: int in TITLE_LOGO_COLUMNS:
+			ids.append(TITLE_LOGO_FIRST_TILE + row * TITLE_LOGO_COLUMNS + column)
+		_write_tilemap(TITLE_LOGO_AT + Vector2i(0, row), TITLE_LOGO_COLUMNS, 1, ids)
+	var last: Array = []
+	for column: int in TITLE_LOGO_COLUMNS:
+		last.append(TITLE_LOGO_LAST_ROW_TILE + column)
+	_write_tilemap(TITLE_LOGO_AT + Vector2i(0, TITLE_LOGO_ROWS - 1), TITLE_LOGO_COLUMNS, 1, last)
+
+
+## `DrawPlayerCharacter`: seven rows of five, slot 10 dropped four pixels.
+func _draw_player_character() -> void:
+	_clear_sprites()
+	var tile: int = 0
+	for row: int in TITLE_PLAYER_ROWS:
+		for column: int in TITLE_PLAYER_COLUMNS:
+			_set_sprite(
+				tile, TITLE_PLAYER_AT.y + row * Gen1Lcd.TILE,
+				TITLE_PLAYER_AT.x + column * Gen1Lcd.TILE, tile, 0
+			)
+			tile += 1
+	_set_sprite_byte(TITLE_BALL_SLOT, 0, TITLE_BALL_Y)
+
+
+## `LoadTitleMonSprite`: the decompressor's frames, 49 tiles, `MonTiles` at (5, 10).
+func _load_title_mon_steps() -> Array:
+	var frames: int = int((TITLE_MON_LOAD_FRAMES.get(_profile, {}) as Dictionary).get(
+		_title_species, TITLE_MON_LOAD_DEFAULT
+	)) - TITLE_MON_LOAD_TAIL
+	var steps: Array = [delay_step(frames)]
+	var cell: Dictionary = _front_pic_box(_title_species)
+	steps.append(do_step(func() -> void:
+		_pending_copy = {
+			"strip": cell["strip"], "strip_tiles": TITLE_MON_TILES,
+			"at": TITLE_MON_VRAM, "first": 0, "left": TITLE_MON_TILES,
+		}))
+	steps.append(delay_step(TITLE_MON_TILES / COPY_TILES_PER_FRAME + 1))
+	steps.append(do_step(func() -> void:
+		var ids: Array = []
+		for row: int in Gen2PicImage.FRONTPIC_TILES:
+			for column: int in Gen2PicImage.FRONTPIC_TILES:
+				ids.append(column * Gen2PicImage.FRONTPIC_TILES + row)
+		_write_tilemap(TITLE_MON_AT, Gen2PicImage.FRONTPIC_TILES, Gen2PicImage.FRONTPIC_TILES, ids)))
+	return steps
+
+
+## A front pic as `vFrontPic`'s 49 column-major tiles, padded.
+func _front_pic_box(species: int) -> Dictionary:
+	var strip := PackedByteArray()
+	strip.resize(TITLE_MON_TILES * Gen1Lcd.TILE_PIXELS)
+	var pic: Dictionary = _data.species_pic(species)
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		_data.atlas_indices(String(pic.get("atlas", ""))), _data.atlas(String(pic.get("atlas", ""))), pic
+	) if not pic.is_empty() else {}
+	if cell.is_empty():
+		return {"strip": strip}
+	var width: int = int(cell["width"])
+	var height: int = int(cell["height"])
+	var box: int = Gen2PicImage.FRONTPIC_TILES * Gen1Lcd.TILE
+	var left: int = Gen2PicImage.frontpic_pad_columns(width / Gen1Lcd.TILE, false, RomRegistry.GEN1) \
+		* Gen1Lcd.TILE
+	var top: int = box - height
+	var indices: PackedByteArray = cell["indices"]
+	var stride: int = TITLE_MON_TILES * Gen1Lcd.TILE
+	for y: int in height:
+		for x: int in width:
+			var bx: int = left + x
+			var by: int = top + y
+			var tile: int = (bx / Gen1Lcd.TILE) * Gen2PicImage.FRONTPIC_TILES + by / Gen1Lcd.TILE
+			strip[(by % Gen1Lcd.TILE) * stride + tile * Gen1Lcd.TILE + bx % Gen1Lcd.TILE] = \
+				indices[y * width + x]
+	return {"strip": strip}
+
+
+## `.bouncePokemonLogoLoop`, the crash sound on the first -3.
+func _bounce_steps() -> Array:
+	var steps: Array = []
+	for scroll: Vector2i in TITLE_BOUNCE:
+		if scroll.x == TITLE_BOUNCE_CRASH:
+			steps.append(do_step(func() -> void: _play_sfx(SFX_INTRO_CRASH)))
+		for _time: int in scroll.y:
+			steps.append(delay_step(1))
+			steps.append(do_step(func() -> void: _hscy = (_hscy + scroll.x) & 0xFF))
+	return steps
+
+
+func _place_version() -> void:
+	var text: Array = _opening.get("version_text", [])
+	_write_tilemap(TITLE_VERSION_AT, text.size(), 1, text)
+
+
+## `.scrollTitleScreenGameVersionLoop`: lines 64 to 79 under d, four more a frame.
+func _version_scroll_steps() -> Array:
+	var steps: Array = []
+	var d: int = VERSION_SCROLL_START
+	while d != 0:
+		var shift: int = d
+		if not steps.is_empty():
+			steps.append(delay_step(1))
+		steps.append(do_step(func() -> void:
+			_set_line_scroll(VERSION_SCROLL_LINES, shift)))
+		d = (d + VERSION_SCROLL_STEP) & 0xFF
+	return steps
+
+
+## `_TitleScroll`: `rSCX` d between `rLY` $48 and $88, the ball's Y walked
+## along `TitleBallYTable` when [param ball].
+func _title_scroll_steps(table: Array[int], start: int, ball: bool, after: Callable = Callable()) -> Array:
+	var frames: Array = []
+	var d: int = start
+	var ball_index: int = 1 if ball else 0
+	for entry: int in table:
+		var speed: int = entry >> 4
+		for _time: int in entry & 0xF:
+			frames.append([d, ball_index])
+			d = (d + speed) & 0xFF
+			if ball_index > 0 and ball_index < TITLE_BALL_YS.size() and TITLE_BALL_YS[ball_index] != 0:
+				ball_index += 1
+	# The code behind the loop runs in its last frame: no VBlank of its own.
+	var steps: Array = []
+	for index: int in frames.size():
+		var shift: int = int(frames[index][0])
+		var ball_at: int = int(frames[index][1])
+		var last: bool = index == frames.size() - 1
+		steps.append(do_step(func() -> void:
+			_set_line_scroll(TITLE_MON_LINES, shift)
+			if ball_at > 0 and ball_at < TITLE_BALL_YS.size() and TITLE_BALL_YS[ball_at] != 0:
+				_set_sprite_byte(TITLE_BALL_SLOT, 0, TITLE_BALL_YS[ball_at])
+			if last and after.is_valid():
+				after.call()))
+		if not last:
+			steps.append(delay_step(1))
+	return steps
+
+
+func _set_line_scroll(lines: Vector2i, value: int) -> void:
+	var overrides := PackedInt32Array()
+	overrides.resize(Gen1Lcd.HEIGHT)
+	overrides.fill(-1)
+	for line: int in range(lines.x, lines.y):
+		overrides[line] = value
+	lcd.line_scx = overrides
+	lcd.line_lag = 0
+
+
+## `TitleScreenPickNewMon`'s `.loop`: `Random & $f` until it differs.
+func _pick_title_mon() -> int:
+	var mons: Array = _opening.get("title_mons", [])
+	if not _title_picks.is_empty():
+		return _title_picks.pop_front()
+	if mons.size() < 2:
+		return _title_species
+	while true:
+		var pick: int = int(mons[_rng.randi() & TITLE_MON_PICK_MASK])
+		if pick != _title_species:
+			return pick
+	return _title_species
+
+
+## `.finishedWaiting`'s tail: white out, both maps cleared, `MainMenu`.
+func _leave_title_steps() -> Array:
+	return [
+		do_step(func() -> void:
+			lcd.bgp = 0
+			lcd.obp0 = 0
+			lcd.obp1 = 0),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_clear_sprites()
+			_hwy = 0
+			_transfer_enabled = true
+			_fill_tilemap(BLANK)),
+		delay_step(DELAY3),
+		do_step(func() -> void: _transfer_dest = DEST_MAP0),
+		delay_step(DELAY3),
+		do_step(func() -> void: _transfer_dest = DEST_MAP1),
+		delay_step(DELAY3),
+		delay_step(DELAY3),
+		{"finish": &"title_menu"},
+	]
+
+
+## `PlayIntroScene` on Yellow: `.loop` until the done bit or A, B or START.
+func _yellow_intro_steps() -> Array:
+	return [
+		{"phase": PHASE_INTRO_MOVIE},
+		do_step(func() -> Array:
+			_yellow_intro = Gen1YellowIntro.create(self, _data)
+			return _yellow_intro.init_steps()),
+		label_step(&"yellow_loop"),
+		do_step(func() -> Array:
+			if _yellow_intro.finished() or _read_pressed() & YELLOW_INTRO_BUTTONS != 0:
+				_yellow_intro.leave()
+				_jump(&"yellow_end")
+				return []
+			return _yellow_intro.loop_steps()),
+		{"jump": &"yellow_loop"},
+		label_step(&"yellow_end"),
+		delay_step(1),
+		do_step(func() -> void:
+			_hwy = WINDOW_OFF
+			_fill_tilemap(0)
+			_clear_sprites()
+			_transfer_enabled = true),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_transfer_enabled = false
+			_hscx = 0
+			_clear_sprites()
+			lcd.line_scy = PackedInt32Array()
+			_yellow_intro = null),
+		delay_step(1),
+	]
+
+
+## `DisplayTitleScreen` on Yellow.
+func _yellow_title_steps() -> Array:
+	var yellow: Dictionary = _opening.get("yellow", {})
+	var steps: Array = [
+		{"phase": PHASE_TITLE},
+		do_step(func() -> void:
+			lcd.bgp = 0
+			lcd.obp0 = 0
+			lcd.obp1 = 0
+			_transfer_enabled = true
+			_hscx = 0
+			_hscy = TITLE_SCY
+			_hwy = WINDOW_OFF
+			_fill_tilemap(BLANK)),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			lcd.lcdc &= ~Gen1Lcd.LCDC_ON
+			_load_yellow_title_graphics()
+			lcd.fill_map(0, BLANK)
+			lcd.fill_map(1, BLANK)
+			_write_tilemap(
+				TITLE_LOGO_AT, Gen1Layout.TITLE_LOGO_TILEMAP.x, Gen1Layout.TITLE_LOGO_TILEMAP.y,
+				yellow.get("title_logo_tilemap", [])
+			)
+			_write_tilemap(
+				TITLE_COPYRIGHT_AT, YELLOW_TITLE_COPYRIGHT_TILES.size(), 1,
+				YELLOW_TITLE_COPYRIGHT_TILES
+			)
+			_buffer2 = _tilemap.duplicate()),
+		delay_step(int(TITLE_LOAD_FRAMES.get(_profile, 6))),
+		do_step(func() -> void: lcd.lcdc |= Gen1Lcd.LCDC_ON),
+		delay_step(TITLE_FIRST_LOAD_EXTRA),
+		do_step(func() -> void:
+			_place_yellow_pikachu()
+			_transfer_dest = DEST_MAP0_PLUS_300),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_buffer1 = _tilemap.duplicate()
+			_hwy = WINDOW_HALF
+			_tilemap = _buffer2.duplicate()
+			_transfer_dest = DEST_MAP0),
+		delay_step(DELAY3),
+		do_step(func() -> void:
+			_palette_command = "title"
+			lcd.bgp = GB_PAL_NORMAL_BGP
+			lcd.obp0 = YELLOW_TITLE_OBP0),
+	]
+	steps.append_array(_bounce_steps())
+	steps.append_array([
+		do_step(func() -> void: _tilemap = _buffer1.duplicate()),
+		delay_step(TITLE_SETTLE_FRAMES),
+		do_step(func() -> void:
+			_play_sfx(SFX_INTRO_WHOOSH)
+			_place_yellow_bubble()
+			_hwy = Gen1Lcd.HEIGHT),
+		delay_step(YELLOW_BUBBLE_DELAY),
+		delay_step(Gen1YellowIntro.pikachu_clip_frames(_data, YELLOW_TITLE_CRY)),
+		wait_sound_step(),
+		do_step(func() -> void:
+			_stop_music()
+			_play_music(MUSIC_TITLE_SCREEN)
+			_blink_scene = 0
+			_blink_timer = 0
+			_reset_counter = 0),
+		label_step(&"yellow_title_loop"),
+		delay_step(1),
+		do_step(func() -> void:
+			_reset_counter += 1
+			if _reset_counter == YELLOW_RESET_FRAMES:
+				_jump(&"yellow_title_reset")
+				return
+			if _interrupted():
+				_jump(&"yellow_title_end")
+				return
+			_yellow_title_function()),
+		{"jump": &"yellow_title_loop"},
+		label_step(&"yellow_title_reset"),
+		do_step(func() -> void: _stop_music()),
+		{"finish": &"restart_opening"},
+		label_step(&"yellow_title_end"),
+		delay_step(Gen1YellowIntro.pikachu_clip_frames(_data, YELLOW_TITLE_CRY_CLOSE)),
+	])
+	steps.append_array(_leave_title_steps())
+	return steps
+
+
+## `LoadYellowTitleScreenGFX` and the copyright loads around it.
+func _load_yellow_title_graphics() -> void:
+	_load_sheet("copyright", YELLOW_COPYRIGHT_VRAM, 0, TITLE_COPYRIGHT_NINTENDO_TILES)
+	_load_sheet("title_nine", YELLOW_NINE_VRAM)
+	_load_sheet(
+		"copyright", YELLOW_GAMEFREAK_VRAM,
+		TITLE_COPYRIGHT_GAMEFREAK_FIRST, TITLE_COPYRIGHT_GAMEFREAK_TILES
+	)
+	_load_sheet("title_logo", YELLOW_LOGO_VRAM)
+	_load_sheet("title_logo_corner", YELLOW_CORNER_VRAM)
+	_load_sheet("title_pikachu_bg", YELLOW_PIKACHU_BG_VRAM)
+	_load_sheet("title_pikachu_ob", YELLOW_PIKACHU_OB_VRAM)
+
+
+## `TitleScreen_PlacePikachu`: the box, four tiles beside it, the eyes.
+func _place_yellow_pikachu() -> void:
+	var yellow: Dictionary = _opening.get("yellow", {})
+	_write_tilemap(
+		YELLOW_PIKACHU_AT, Gen1Layout.TITLE_PIKACHU_TILEMAP.x, Gen1Layout.TITLE_PIKACHU_TILEMAP.y,
+		yellow.get("title_pikachu_tilemap", [])
+	)
+	for index: int in YELLOW_PIKACHU_COLUMN.size():
+		_write_tilemap(YELLOW_PIKACHU_COLUMN_AT + Vector2i(0, index), 1, 1, [YELLOW_PIKACHU_COLUMN[index]])
+	var eyes: Array = yellow.get("title_eyes_oam", [])
+	for slot: int in eyes.size():
+		_set_sprite_row(slot, eyes[slot])
+
+
+func _place_yellow_bubble() -> void:
+	var yellow: Dictionary = _opening.get("yellow", {})
+	_write_tilemap(
+		YELLOW_BUBBLE_AT, Gen1Layout.TITLE_BUBBLE_TILEMAP.x, Gen1Layout.TITLE_BUBBLE_TILEMAP.y,
+		yellow.get("title_bubble_tilemap", [])
+	)
+	_write_tilemap(YELLOW_BUBBLE_TAIL_AT, YELLOW_BUBBLE_TAIL.size(), 1, YELLOW_BUBBLE_TAIL)
+
+
+## `DoTitleScreenFunction`: `.CheckTimer` restarts the blink at $00, $80, $90.
+func _yellow_title_function() -> void:
+	if _blink_timer in YELLOW_TIMER_RESTARTS:
+		_blink_scene = 1
+	_blink_timer = (_blink_timer + 1) & 0xFF
+	var action: int = YELLOW_BLINK_SCENES[_blink_scene]
+	if action == YELLOW_BLINK_RESTART:
+		_blink_scene = 0
+		return
+	if action == YELLOW_BLINK_NOP:
+		return
+	if action != YELLOW_BLINK_WAIT:
+		for slot: int in Gen1Layout.TITLE_EYES_SPRITES:
+			_set_sprite_byte(slot, 2, (_sprite_byte(slot, 2) & YELLOW_BLINK_MASK) | action)
+	_blink_scene += 1

--- a/game/world/gen1_opening.gd.uid
+++ b/game/world/gen1_opening.gd.uid
@@ -1,0 +1,1 @@
+uid://bs0l0ijcictj3

--- a/game/world/gen1_yellow_intro.gd
+++ b/game/world/gen1_yellow_intro.gd
@@ -1,0 +1,687 @@
+class_name Gen1YellowIntro
+extends RefCounted
+
+## Yellow's `PlayIntroScene` (engine/movie/intro_yellow.asm): eighteen scenes
+## over `RunObjectAnimations` (engine/gfx/animated_objects.asm), ten object
+## structs each walking a frameset of OAM sets into `wShadowOAM` once a frame.
+## [Gen1Opening] owns the frame loop and the LCD.
+
+## `wAnimatedObjectDataStructs`: ten of them, and the offsets read here.
+const OBJECTS: int = 10
+const STRUCT_LIVE: int = 0
+const STRUCT_FRAMESET: int = 1
+const STRUCT_CALLBACK: int = 2
+const STRUCT_VTILE: int = 3
+const STRUCT_X: int = 4
+const STRUCT_Y: int = 5
+const STRUCT_XOFF: int = 6
+const STRUCT_YOFF: int = 7
+const STRUCT_TIMER: int = 8
+const STRUCT_DURATION_OFFSET: int = 9
+const STRUCT_FRAME: int = 10
+const STRUCT_VAR1: int = 11
+const STRUCT_VAR2: int = 12
+const STRUCT_SIZE: int = 16
+const OAM_END: int = Gen1Lcd.OAM_SLOTS * Gen1Lcd.OAM_BYTES
+
+## `SetCurrentAnimatedObjectOAMAttributes`.
+const OAM_HIGH_PALS: int = 1 << 3
+const FLIP_MASK: int = Gen1Lcd.OAM_XFLIP | Gen1Lcd.OAM_YFLIP | Gen1Lcd.OAM_PRIO
+const FRAME_FLIP_SHIFT: int = 1
+const FRAME_FLIP_MASK: int = 0xC0
+
+## The two `wShadowOAM` attribute passes `.loop` runs on scenes 7 and 11.
+const SCENE_SURF: int = 7
+const SCENE_FLY: int = 11
+const SCENE_DONE: int = 0x80
+const SCENE_7_SLOTS: Array[int] = [8, 14, 16, 18, 19]
+const SCENE_11_SLOTS: Array[int] = [18, 19, 20, 25, 26, 28]
+const CGB_PALETTE_BIT: int = 1
+
+const OBJECT_AT: int = 0x58
+const RUN_TIMER: int = 130
+const SCENE_TIMER: int = 128
+const SURF_TIMER: int = 88
+const FLASH_TIMER: int = 0x28
+const END_FRAMES: int = 64
+const TRANSFER_FRAMES: int = 3
+## Frames between `InitYellowIntroGFXAndMusic`'s last copy and `PlayMusic`, measured.
+const INIT_TAIL_FRAMES: int = 0
+## The surf's passes overrun `DelayFrame` and spend two frames, measured.
+const PASS_FRAMES: Dictionary = {7: [2]}
+## `YellowIntro_BlankPalsDelay2AndDisableLCD`, then `YellowIntroPaletteAction`'s
+## packet sent with the LCD off whether or not a Super Game Boy listens: five
+## frames, six on the beach scenes, measured.
+const BLANK_FRAMES: int = 2
+const LCD_OFF_FRAMES: Dictionary = {2: 6, 4: 5, 6: 6, 8: 5, 10: 6, 12: 5}
+const PALETTE_FRAMES: int = 1
+const FLY_SCROLL_END: int = 0x68
+const FLY_SCROLL_STEP: int = 4
+const SURF_SCROLL_STEP: int = 2
+const PALETTE_NORMAL: int = 0xE4
+const PALETTE_OBP1_RUN: int = 0xC4
+const PALETTE_OBP1_SCENE: int = 0xE0
+const PALETTE_END: int = 0xFF
+const FLASH_MASK: int = 3
+const FLASH_OBP0: int = 0xFF
+const FLASH_BGP: int = 3
+const LCDC_SCENE: int = 0xE3
+## `Func_fa079`'s amplitude and the surf's bob table.
+const BOB_AMPLITUDE: int = 8
+const SINE_MASK: int = 0x3F
+const SINE_HALF: int = 0x20
+const SINE_QUARTER_MASK: int = 0x1F
+
+## `YellowIntroGraphics2` at `vChars0`, `1` at `vChars2`, the clouds at $60.
+const GFX_2_VRAM: int = 0
+const GFX_1_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES
+const CLOUD_VRAM: int = 2 * Gen1Lcd.BLOCK_TILES + 0x60
+const CLOUD_TILES: int = 4
+const CLOUD_FRAME_MASK: int = 7
+const CLOUD_SET_MASK: int = 8
+## The scenes' `vBGMap0` addresses as (column, row).
+const FLY_PIC_AT: Vector2i = Vector2i(20, 6)
+const FLY_PIC_SIDE: int = 6
+const FLY_PIC_FIRST_TILE: int = 0x90
+const FLY_PIC_ROW_STEP: int = 0x10
+const SEA_TOP_ROWS: int = 3
+const SEA_LINE_ROW: int = 3
+const SEA_LINE_TILES: Array[int] = [0x20, 0x21]
+const SEA_ROWS: int = 24
+const SEA_TILE: int = 0x10
+const SKY_ROWS: int = 8
+const SKY_TILE: int = 2
+const CLOSE_UP_AT: Vector2i = Vector2i(5, 6)
+const CLOSE_UP_SIZE: Vector2i = Vector2i(12, 8)
+const CLOSE_UP_FIRST_TILE: int = 4
+const CLOSE_UP_ROW_STEP: int = 16
+const CLOSE_UP_EXTRA: Array = [[Vector2i(4, 6), 3], [Vector2i(4, 7), 0x74], [Vector2i(5, 13), 0]]
+const BAR_ROWS: int = 4
+const BAR_TILE: int = 1
+const FLY_BOX_AT: Array[Vector2i] = [Vector2i(0, 8), Vector2i(12, 4), Vector2i(3, 7)]
+const SURF_OBJECT_AT: Vector2i = Vector2i(0xF8, 0x40)
+const FLY_OBJECT_AT: Vector2i = Vector2i(0x58, 0x98)
+const CLOSE_OBJECT_AT: Vector2i = Vector2i(0x58, 0x60)
+const BOLT_OBJECT_AT: Vector2i = Vector2i(0x58, 0x68)
+## `wLYOverrides`, its buffer, and the surf's seven-tile copy from line $10.
+const LY_LINES: int = 256
+const LY_COPY_FROM: int = 0x10
+const LY_COPY_BYTES: int = 7 * PokeTiles.TILE_BYTES
+
+var _host: Gen1Opening = null
+var _data: GameData = null
+var _yellow: Dictionary = {}
+var _structs: Array[PackedByteArray] = []
+var _scene: int = 0
+var _timer: int = 0
+var _pass: int = 0
+var _current: int = -1
+var _loaded: int = 0
+var _oam_offset: int = 0
+var _ly_pointer_on: bool = false
+var _ly_overrides: PackedByteArray = PackedByteArray()
+var _ly_buffer: PackedByteArray = PackedByteArray()
+var _ly_copy_pending: bool = false
+var _cloud_pending: int = -1
+
+
+static func create(host: Gen1Opening, data: GameData) -> Gen1YellowIntro:
+	var out := Gen1YellowIntro.new()
+	out._host = host
+	out._data = data
+	out._yellow = data.opening().get("yellow", {})
+	out._ly_overrides.resize(LY_LINES)
+	out._ly_buffer.resize(LY_LINES)
+	out._clear_objects()
+	return out
+
+
+## Frames one of `PikachuCriesPointerTable`'s clips holds the game.
+static func pikachu_clip_frames(data: GameData, index: int) -> int:
+	var cries: Array = data.gen1_pikachu().get("cries", []) if data != null else []
+	if index < 0 or index >= cries.size():
+		return 0
+	return Gen1Layout.pikachu_cry_frames(int(cries[index]))
+
+
+func finished() -> bool:
+	return _scene & SCENE_DONE != 0
+
+
+func scene() -> int:
+	return _scene
+
+
+## `InitYellowIntroGFXAndMusic` as steps.
+func init_steps() -> Array:
+	var steps: Array = [
+		_host.do_step(func() -> void:
+			_host.set_transfer(false, Gen1Opening.DEST_MAP0)
+			_host.set_scroll(0, 0)
+			_host.fill_tilemap(BAR_TILE)
+			_host.fill_tilemap_rows(BAR_ROWS, Gen1Opening.ROWS - 2 * BAR_ROWS, 0)
+			_host.set_transfer(true, Gen1Opening.DEST_MAP0)),
+		_host.delay_step(TRANSFER_FRAMES),
+		_host.do_step(func() -> void: _host.set_transfer(false, Gen1Opening.DEST_MAP0)),
+	]
+	steps.append_array(_host.copy_video_steps(
+		"yellow_intro_gfx_2", GFX_2_VRAM, 0, Gen1Layout.YELLOW_INTRO_GFX_2_TILES
+	))
+	steps.append_array(_host.copy_video_steps(
+		"yellow_intro_gfx_1", GFX_1_VRAM, 0, Gen1Layout.YELLOW_INTRO_GFX_1_TILES
+	))
+	steps.append(_host.delay_step(INIT_TAIL_FRAMES))
+	steps.append(_host.do_step(func() -> void:
+		_clear_objects()
+		_host.set_palette_command("generic")
+		_scene = 0
+		_timer = 0
+		_host.play_music(Gen1Opening.MUSIC_YELLOW_INTRO)))
+	steps.append(_host.delay_step(1))
+	return steps
+
+
+## One pass of `.loop` as steps: the scene, `RunObjectAnimations`, `DelayFrame`.
+func loop_steps() -> Array:
+	var opened: int = _scene
+	var index: int = _pass
+	_pass += 1
+	var steps: Array = _scene_steps()
+	steps.append(_host.do_step(func() -> Array:
+		_run_object_animations()
+		if _scene == SCENE_SURF:
+			_or_attributes(SCENE_7_SLOTS)
+		elif _scene == SCENE_FLY:
+			_or_attributes(SCENE_11_SLOTS)
+		return [_host.delay_step(_pass_frames(opened, index))]))
+	return steps
+
+
+func _pass_frames(opened: int, index: int) -> int:
+	if _scene != opened or not PASS_FRAMES.has(opened):
+		return 1
+	var cycle: Array = PASS_FRAMES[opened]
+	return int(cycle[index % cycle.size()])
+
+
+## `.go_to_title_screen`'s first frame.
+func leave() -> void:
+	_host.set_palettes(0, 0, 0)
+	_ly_pointer_on = false
+	_scene |= SCENE_DONE
+
+
+## The VBlank's `VBlankCopy` and the `LCD` interrupt's lines for the frame.
+func vblank() -> void:
+	if _ly_copy_pending:
+		for line: int in range(LY_COPY_FROM, LY_COPY_FROM + LY_COPY_BYTES):
+			_ly_overrides[line] = _ly_buffer[line]
+		_ly_copy_pending = false
+	if _cloud_pending >= 0:
+		_host.lcd.load_tiles(
+			CLOUD_VRAM, _data.tile_indices("yellow_intro_clouds"),
+			Gen1Layout.YELLOW_INTRO_CLOUD_TILES, _cloud_pending, CLOUD_TILES
+		)
+		_cloud_pending = -1
+	if _ly_pointer_on:
+		var lines := PackedInt32Array()
+		lines.resize(Gen1Lcd.HEIGHT)
+		for line: int in Gen1Lcd.HEIGHT:
+			lines[line] = _ly_overrides[line]
+		_host.lcd.line_scy = lines
+		_host.lcd.line_lag = 1
+	else:
+		_host.lcd.line_scy = PackedInt32Array()
+
+
+func _scene_steps() -> Array:
+	match _scene:
+		0:
+			return [_host.do_step(_scene_0)]
+		1, 5, 9:
+			return [_host.do_step(_scene_wait_and_mask)]
+		2:
+			return _blank_then(_scene_2, "beach")
+		3:
+			return [_host.do_step(_scene_3)]
+		4:
+			return _blank_then(_scene_4, "generic")
+		6:
+			return _blank_then(_scene_6, "beach")
+		7:
+			return [_host.do_step(_scene_7)]
+		8:
+			return _blank_then(_scene_8, "generic")
+		10:
+			return _blank_then(_scene_10, "beach")
+		11:
+			return [_host.do_step(_scene_11)]
+		12:
+			return _blank_then(_scene_12, "generic")
+		13:
+			return [_host.do_step(_scene_13)]
+		14:
+			return [_host.do_step(_scene_14)]
+		15:
+			return [_host.do_step(_scene_15)]
+		16:
+			return [_host.do_step(_scene_16)]
+		17:
+			return [_host.delay_step(END_FRAMES), _host.do_step(func() -> void: _scene |= SCENE_DONE)]
+	return []
+
+
+## `YellowIntro_BlankPalsDelay2AndDisableLCD`, the body, `Func_f9e9a`.
+func _blank_then(body: Callable, palette: String) -> Array:
+	var opened: int = _scene
+	return [
+		_host.do_step(func() -> void: _host.set_palettes(0, 0, 0)),
+		_host.delay_step(BLANK_FRAMES),
+		_host.do_step(func() -> void:
+			_host.lcd.lcdc &= ~Gen1Lcd.LCDC_ON
+			body.call()),
+		_host.delay_step(int(LCD_OFF_FRAMES.get(opened, 1))),
+		_host.do_step(func() -> void:
+			_host.set_palette_command(palette)
+			_host.lcd.lcdc = LCDC_SCENE),
+		_host.delay_step(PALETTE_FRAMES),
+		_host.do_step(func() -> void:
+			_host.set_scroll(0, 0)
+			_host.set_window(Gen1Opening.WINDOW_OFF)
+			_host.set_palettes(PALETTE_NORMAL, PALETTE_NORMAL, PALETTE_OBP1_SCENE)),
+	]
+
+
+func _next_scene() -> void:
+	_scene += 1
+	_pass = 0
+
+
+## `YellowIntro_CheckFrameTimerDecrement`: true once the timer has run out.
+func _timer_expired() -> bool:
+	if _timer == 0:
+		return true
+	_timer -= 1
+	return false
+
+
+func _scene_0() -> void:
+	_ly_pointer_on = false
+	_current = _spawn(1, OBJECT_AT, OBJECT_AT)
+	_host.set_scroll(0, 0)
+	_host.set_window(Gen1Opening.WINDOW_OFF)
+	_host.set_palettes(PALETTE_NORMAL, PALETTE_NORMAL, PALETTE_OBP1_RUN)
+	_timer = RUN_TIMER
+	_next_scene()
+
+
+func _scene_wait_and_mask() -> void:
+	if not _timer_expired():
+		return
+	_mask(_current)
+	_next_scene()
+
+
+## The flight: the picture past the screen's edge and eight speed bars.
+func _scene_2() -> void:
+	_ly_pointer_on = false
+	_host.lcd.fill_map(0, 0)
+	for row: int in FLY_PIC_SIDE:
+		var ids: Array = []
+		for column: int in FLY_PIC_SIDE:
+			ids.append(FLY_PIC_FIRST_TILE + row * FLY_PIC_ROW_STEP + column)
+		_host.write_map(0, FLY_PIC_AT + Vector2i(0, row), FLY_PIC_SIDE, 1, ids)
+	# `ld e, [hl]`: the row's first byte is the X `SpawnAnimatedObject` takes in `e`.
+	for bar: Array in _yellow.get("speed_bars", []):
+		var index: int = _spawn(8, int(bar[0]), int(bar[1]))
+		if index >= 0:
+			_structs[index][STRUCT_VAR1] = int(bar[2])
+	_timer = SCENE_TIMER
+	_next_scene()
+
+
+func _scene_3() -> void:
+	if _timer_expired():
+		_mask_all()
+		_next_scene()
+		return
+	if _host.scroll_x() != FLY_SCROLL_END:
+		_host.set_scroll((_host.scroll_x() + FLY_SCROLL_STEP) & 0xFF, 0)
+
+
+func _scene_4() -> void:
+	_ly_pointer_on = false
+	_draw_bars()
+	_current = _spawn(2, OBJECT_AT, OBJECT_AT)
+	_timer = SCENE_TIMER
+	_next_scene()
+
+
+## `Func_f9e5f`: black bars on `vBGMap0`, four rows top and bottom.
+func _draw_bars() -> void:
+	_fill_rows(0, BAR_ROWS, BAR_TILE)
+	_fill_rows(BAR_ROWS, Gen1Opening.ROWS - 2 * BAR_ROWS, 0)
+	_fill_rows(Gen1Opening.ROWS - BAR_ROWS, BAR_ROWS, BAR_TILE)
+
+
+func _fill_rows(first: int, count: int, id: int) -> void:
+	var map: PackedByteArray = _host.lcd.maps[0]
+	for cell: int in range(first * Gen1Lcd.MAP_SIDE, (first + count) * Gen1Lcd.MAP_SIDE):
+		map[cell] = id
+
+
+## The surf: the sine eight times over, the sea, `rSCY` handed to the interrupt.
+func _scene_6() -> void:
+	_ly_pointer_on = true
+	var sine: Array = _yellow.get("sine", [])
+	for line: int in LY_LINES:
+		_ly_buffer[line] = int(sine[line % sine.size()]) & 0xFF if not sine.is_empty() else 0
+	_fill_rows(0, SEA_TOP_ROWS, 0)
+	var line_ids: Array = []
+	for _pair: int in Gen1Lcd.MAP_SIDE / 2:
+		line_ids.append_array(SEA_LINE_TILES)
+	_host.write_map(0, Vector2i(0, SEA_LINE_ROW), Gen1Lcd.MAP_SIDE, 1, line_ids)
+	_fill_rows(SEA_LINE_ROW + 1, SEA_ROWS, SEA_TILE)
+	_current = _spawn(5, SURF_OBJECT_AT.x, SURF_OBJECT_AT.y)
+	_timer = SURF_TIMER
+	_next_scene()
+
+
+func _scene_7() -> void:
+	if _timer_expired():
+		_mask(_current)
+		_next_scene()
+		return
+	_host.set_scroll((_host.scroll_x() + SURF_SCROLL_STEP) & 0xFF, 0)
+	var first: int = _ly_buffer[0]
+	for line: int in LY_LINES - 1:
+		_ly_buffer[line] = _ly_buffer[line + 1]
+	_ly_buffer[LY_LINES - 1] = first
+	_ly_copy_pending = true
+
+
+func _scene_8() -> void:
+	_ly_pointer_on = false
+	_draw_bars()
+	_current = _spawn(3, OBJECT_AT, OBJECT_AT)
+	_timer = SCENE_TIMER
+	_next_scene()
+
+
+## The flight over the clouds: the sky, then the three tilemaps.
+func _scene_10() -> void:
+	_ly_pointer_on = false
+	_host.lcd.fill_map(0, 0)
+	_fill_rows(0, SKY_ROWS, SKY_TILE)
+	var tilemaps: Array = _yellow.get("tilemaps", [])
+	for index: int in mini(tilemaps.size(), FLY_BOX_AT.size()):
+		var tilemap: Dictionary = tilemaps[index]
+		_host.write_map(
+			0, FLY_BOX_AT[index], int(tilemap["columns"]), int(tilemap["rows"]), tilemap["ids"]
+		)
+	_current = _spawn(6, FLY_OBJECT_AT.x, FLY_OBJECT_AT.y)
+	_timer = SCENE_TIMER
+	_next_scene()
+
+
+func _scene_11() -> void:
+	if _timer_expired():
+		_mask(_current)
+		_next_scene()
+		return
+	if _timer & CLOUD_FRAME_MASK != 0:
+		return
+	_cloud_pending = CLOUD_TILES if _timer & CLOUD_SET_MASK else 0
+
+
+## The close-up: the 12x8 face from tile 4, four tiles skipped a row.
+func _scene_12() -> void:
+	_ly_pointer_on = false
+	_draw_bars()
+	for row: int in CLOSE_UP_SIZE.y:
+		var ids: Array = []
+		for column: int in CLOSE_UP_SIZE.x:
+			ids.append(CLOSE_UP_FIRST_TILE + row * CLOSE_UP_ROW_STEP + column)
+		_host.write_map(0, CLOSE_UP_AT + Vector2i(0, row), CLOSE_UP_SIZE.x, 1, ids)
+	for extra: Array in CLOSE_UP_EXTRA:
+		_host.write_map(0, extra[0], 1, 1, [int(extra[1])])
+	_current = _spawn(9, CLOSE_OBJECT_AT.x, CLOSE_OBJECT_AT.y)
+	_timer = SCENE_TIMER
+	_next_scene()
+
+
+func _scene_13() -> void:
+	if not _timer_expired():
+		return
+	_spawn(10, BOLT_OBJECT_AT.x, BOLT_OBJECT_AT.y)
+	_next_scene()
+
+
+## `YellowIntroPalSequence_f9dd6`, then the bars through the screen buffer.
+func _scene_14() -> Array:
+	var value: int = _palette_step(_yellow.get("pal_flash", []))
+	if value >= 0:
+		_host.set_palettes(value, value, value & 0xF0)
+		return []
+	_mask_all()
+	_host.clear_sprites()
+	_host.fill_tilemap(BAR_TILE)
+	_host.fill_tilemap_rows(BAR_ROWS, Gen1Opening.ROWS - 2 * BAR_ROWS, 0)
+	_host.set_transfer(true, Gen1Opening.DEST_MAP0)
+	return [
+		_host.delay_step(TRANSFER_FRAMES),
+		_host.do_step(func() -> void:
+			_host.set_transfer(false, Gen1Opening.DEST_MAP0)
+			_host.set_palettes(PALETTE_NORMAL, PALETTE_NORMAL, _host.lcd.obp1)
+			_current = _spawn(7, OBJECT_AT, OBJECT_AT)
+			_next_scene()
+			_timer = FLASH_TIMER),
+	]
+
+
+## `YellowIntro_LoadDMGPalAndIncrementCounter`, -1 at the end.
+func _palette_step(sequence: Array) -> int:
+	var index: int = _timer
+	_timer = (_timer + 1) & 0xFF
+	if index >= sequence.size():
+		return -1
+	var value: int = int(sequence[index])
+	return -1 if value == PALETTE_END else value
+
+
+func _scene_15() -> void:
+	if not _timer_expired():
+		if _timer & FLASH_MASK == 0:
+			_host.set_palettes(
+				_host.lcd.bgp ^ FLASH_BGP, _host.lcd.obp0 ^ FLASH_OBP0, _host.lcd.obp1
+			)
+		return
+	_ly_pointer_on = false
+	_host.set_palettes(PALETTE_NORMAL, PALETTE_NORMAL, _host.lcd.obp1)
+	_next_scene()
+	# `.expired` runs on into `YellowIntroScene16` with no `ret` between them.
+	_scene_16()
+
+
+func _scene_16() -> void:
+	var value: int = _palette_step(_yellow.get("pal_fade", []))
+	if value >= 0:
+		_host.set_palettes(value, value, _host.lcd.obp1)
+		return
+	_next_scene()
+
+
+func _clear_objects() -> void:
+	_structs = []
+	for _index: int in OBJECTS:
+		var object := PackedByteArray()
+		object.resize(STRUCT_SIZE)
+		_structs.append(object)
+	_loaded = 0
+	_oam_offset = 0
+
+
+## `SpawnAnimatedObject`: the first free struct, or -1 with none left.
+func _spawn(kind: int, x: int, y: int) -> int:
+	var spawns: Array = _yellow.get("spawn_states", [])
+	if kind >= spawns.size():
+		return -1
+	for index: int in OBJECTS:
+		var object: PackedByteArray = _structs[index]
+		if object[STRUCT_LIVE] != 0:
+			continue
+		_loaded += 1
+		object.fill(0)
+		object[STRUCT_LIVE] = _loaded & 0xFF
+		object[STRUCT_FRAMESET] = int(spawns[kind][0])
+		object[STRUCT_CALLBACK] = int(spawns[kind][1])
+		object[STRUCT_X] = x & 0xFF
+		object[STRUCT_Y] = y & 0xFF
+		object[STRUCT_FRAME] = 0xFF
+		return index
+	return -1
+
+
+func _mask(index: int) -> void:
+	if index >= 0 and index < OBJECTS:
+		_structs[index][STRUCT_LIVE] = 0
+
+
+func _mask_all() -> void:
+	for object: PackedByteArray in _structs:
+		object[STRUCT_LIVE] = 0
+
+
+## `RunObjectAnimations`, the rest of the buffer zeroed.
+func _run_object_animations() -> void:
+	_oam_offset = 0
+	for index: int in OBJECTS:
+		var object: PackedByteArray = _structs[index]
+		if object[STRUCT_LIVE] == 0:
+			continue
+		_callback(object)
+		if not _update_frame(object):
+			return
+	while _oam_offset < OAM_END:
+		_host.set_shadow_byte(_oam_offset, 0)
+		_oam_offset += 1
+
+
+## `YellowIntro_AnimatedObjectJumptable`.
+func _callback(object: PackedByteArray) -> void:
+	match object[STRUCT_CALLBACK]:
+		2:
+			# `Func_fa008`: left four a frame to $58.
+			if object[STRUCT_X] != OBJECT_AT:
+				object[STRUCT_X] = (object[STRUCT_X] - 4) & 0xFF
+		3:
+			# `Func_fa014`: right four a frame to $58, Y from the X still in `a`.
+			var a: int = object[STRUCT_X]
+			if a != OBJECT_AT:
+				a = (a + 4) & 0xFF
+				object[STRUCT_X] = a
+			if a != OBJECT_AT:
+				object[STRUCT_Y] = (a + 1) & 0xFF
+		4:
+			# `Func_fa02b`: up two a frame to $58, then a bob off the sine.
+			if object[STRUCT_VAR1] == 0:
+				if object[STRUCT_Y] != OBJECT_AT:
+					object[STRUCT_Y] = (object[STRUCT_Y] - 2) & 0xFF
+					return
+				object[STRUCT_VAR1] += 1
+			var angle: int = object[STRUCT_VAR2]
+			object[STRUCT_VAR2] = (angle + 1) & 0xFF
+			object[STRUCT_YOFF] = _sine(angle, BOB_AMPLITUDE) & 0xFF
+		5:
+			# `Func_fa062`: X by the speed the spawn wrote.
+			object[STRUCT_X] = (object[STRUCT_X] + object[STRUCT_VAR1]) & 0xFF
+
+
+## `Func_fa079`: the sine's high byte times [param amplitude], negated past half.
+func _sine(angle: int, amplitude: int) -> int:
+	var words: Array = _yellow.get("sine_words", [])
+	var index: int = angle & SINE_MASK
+	var negative: bool = index >= SINE_HALF
+	index &= SINE_QUARTER_MASK
+	if index >= words.size():
+		return 0
+	var value: int = (int(words[index]) * amplitude) >> 8
+	return -value if negative else value
+
+
+## `UpdateCurrentAnimatedObjectFrame`; false once the buffer is full.
+func _update_frame(object: PackedByteArray) -> bool:
+	var frame: Dictionary = _advance_duration(object)
+	var set_id: int = int(frame["set"])
+	if set_id < 0:
+		return true
+	var sets: Array = _yellow.get("oam_sets", [])
+	if set_id >= sets.size():
+		return true
+	var oam_set: Dictionary = sets[set_id]
+	var vtile: int = (object[STRUCT_VTILE] + int(oam_set["tile"])) & 0xFF
+	var flips: int = int(frame["flips"])
+	for sprite: Array in oam_set["sprites"]:
+		if _oam_offset >= OAM_END:
+			return false
+		var y: int = (object[STRUCT_Y] + object[STRUCT_YOFF]
+			+ _flipped(int(sprite[0]), flips & Gen1Lcd.OAM_YFLIP)) & 0xFF
+		var x: int = (object[STRUCT_X] + object[STRUCT_XOFF]
+			+ _flipped(int(sprite[1]), flips & Gen1Lcd.OAM_XFLIP)) & 0xFF
+		var attributes: int = ((int(sprite[3]) ^ flips) & FLIP_MASK) \
+			| (int(sprite[3]) & Gen1Lcd.OAM_PAL1)
+		if attributes & Gen1Lcd.OAM_PAL1:
+			attributes |= OAM_HIGH_PALS
+		_host.set_shadow_byte(_oam_offset, y)
+		_host.set_shadow_byte(_oam_offset + 1, x)
+		_host.set_shadow_byte(_oam_offset + 2, (vtile + int(sprite[2])) & 0xFF)
+		if _scene != SCENE_SURF:
+			_host.set_shadow_byte(_oam_offset + 3, attributes)
+		_oam_offset += Gen1Lcd.OAM_BYTES
+	return true
+
+
+## `GetCurrentAnimatedObjectTileYCoordinate` and its X twin.
+static func _flipped(offset: int, flipped: int) -> int:
+	if flipped == 0:
+		return offset
+	return (-(offset + Gen1Lcd.TILE)) & 0xFF
+
+
+## `UpdateDurationTimerAndFrameStateForCurrentAnimatedObject`.
+func _advance_duration(object: PackedByteArray) -> Dictionary:
+	var framesets: Array = _yellow.get("frames", [])
+	var rows: Array = framesets[object[STRUCT_FRAMESET]] \
+		if object[STRUCT_FRAMESET] < framesets.size() else []
+	for _guard: int in 8:
+		if object[STRUCT_TIMER] != 0:
+			object[STRUCT_TIMER] -= 1
+			var row: Array = _row(rows, object[STRUCT_FRAME])
+			return {"set": int(row[0]), "flips": (int(row[1]) & FRAME_FLIP_MASK) >> FRAME_FLIP_SHIFT}
+		object[STRUCT_FRAME] = (object[STRUCT_FRAME] + 1) & 0xFF
+		var next: Array = _row(rows, object[STRUCT_FRAME])
+		var command: int = int(next[0])
+		if command == -2:
+			object[STRUCT_TIMER] = 0
+			object[STRUCT_FRAME] = 0xFF
+			continue
+		if command == -1:
+			object[STRUCT_TIMER] = 0
+			object[STRUCT_FRAME] = (object[STRUCT_FRAME] - 2) & 0xFF
+			continue
+		object[STRUCT_TIMER] = ((int(next[1]) & Gen1Layout.ANIM_FRAME_DURATION_MASK)
+			+ object[STRUCT_DURATION_OFFSET]) & 0xFF
+		return {"set": command, "flips": (int(next[1]) & FRAME_FLIP_MASK) >> FRAME_FLIP_SHIFT}
+	return {"set": -1, "flips": 0}
+
+
+static func _row(rows: Array, index: int) -> Array:
+	if index < 0 or index >= rows.size():
+		return [-1, 0]
+	return rows[index]
+
+
+func _or_attributes(slots: Array[int]) -> void:
+	for slot: int in slots:
+		var at: int = slot * Gen1Lcd.OAM_BYTES + 3
+		_host.set_shadow_byte(at, _host.shadow_byte(at) | CGB_PALETTE_BIT)

--- a/game/world/gen1_yellow_intro.gd.uid
+++ b/game/world/gen1_yellow_intro.gd.uid
@@ -1,0 +1,1 @@
+uid://bl4oro05yyoqa

--- a/game/world/link_transport.gd
+++ b/game/world/link_transport.gd
@@ -1,14 +1,11 @@
 class_name Gen2LinkTransport
 extends RefCounted
 
-## The cable, as the only thing above it needs it to be. `home/serial.asm` reaches
-## the other Game Boy through exactly three operations and every routine the cable
-## club runs is built from them: read `hSerialConnectionStatus`, exchange one byte,
-## and exchange a block. There is no cable on a modern platform, so this class is
-## the three operations and nothing about wires, timing or bit order. Scene free
-## and injected: a transport with no peer is the honest default and a real game
-## path, since `WaitForLinkedFriend` times out. The one peer today is another of
-## this player's slots; a network transport overrides the three operations.
+## The cable as `home/serial.asm` reaches it: read `hSerialConnectionStatus`,
+## exchange one byte, exchange a block. Every cable club routine is built from
+## the three. A transport with no peer is the default and a real game path,
+## since `WaitForLinkedFriend` times out; the one peer today is another of this
+## player's slots, and a network transport overrides the three operations.
 
 ## constants/serial_constants.asm. `CONNECTION_NOT_ESTABLISHED` is what
 ## `Link_ResetSerialRegistersAfterLinkClosure` writes back.

--- a/game/world/mail_screen.gd
+++ b/game/world/mail_screen.gd
@@ -1,13 +1,11 @@
 class_name Gen2MailScreen
 extends Control
 
-## `ReadAnyMail` (`engine/pokemon/mail_2.asm`), embedded the way the Hall of Fame
-## viewer is. The routine loads the type's own graphics, prints the message and
-## the author over them, and then does nothing but wait: `.loop` reads A, B and
-## START and returns on any of the first two. [Gen2MailPage] owns the picture.
-## START is `PrintMailAndExit`, the Game Boy Printer, which this project has no
-## transport for: it is answered as a press that does nothing rather than left to
-## fall through to whatever is behind the screen.
+## `ReadAnyMail` (`engine/pokemon/mail_2.asm`), embedded like the Hall of Fame
+## viewer: `.loop` reads A, B and START and returns on the first two.
+## [Gen2MailPage] owns the picture. START is `PrintMailAndExit`, the Game Boy
+## Printer, which this project has no transport for, so it is a press that
+## does nothing.
 
 signal closed()
 

--- a/game/world/mystery_gift.gd
+++ b/game/world/mystery_gift.gd
@@ -1,13 +1,11 @@
 class_name Gen2MysteryGift
 extends RefCounted
 
-## `engine/link/mystery_gift.asm`: the SRAM block, the staged block the two Game
-## Boys swap over IR, and `DoMysteryGift`'s own chain of refusals between the
-## exchange and the gift. Not the cable link play [Gen2LinkSession] runs: it never
-## touches `wLinkMode`, it has its own `sMysteryGiftData` section outside the
-## checksummed save, and its peer is an infrared window rather than a wire, so the
-## transport is its own too. Everything here is the section and the decision; the
-## pixels are [Gen2MysteryGiftPage] and the host is [Gen2MysteryGiftScreen].
+## `engine/link/mystery_gift.asm`: the SRAM block, the staged block the two
+## Game Boys swap over IR, and `DoMysteryGift`'s chain of refusals. Not
+## [Gen2LinkSession]'s cable play: it never touches `wLinkMode` and its
+## `sMysteryGiftData` sits outside the checksummed save. The pixels are
+## [Gen2MysteryGiftPage] and the host is [Gen2MysteryGiftScreen].
 
 ## `constants/serial_constants.asm`. Five gifts in a day, and one per person.
 const MAX_PARTNERS: int = 5

--- a/game/world/radio_show.gd
+++ b/game/world/radio_show.gd
@@ -1,14 +1,12 @@
 class_name Gen2RadioShow
 extends RefCounted
 
-## `engine/pokegear/radio.asm`: the words a tuned station prints into the radio
-## card's text box, one line at a time. [Gen2WorldRadio] is the dial, its
-## availability rules and the music a station commits; this is `RadioJumptable`,
-## dispatched once a hardware frame the way `PlayRadioShow` is. Scene-free and
-## injected with its own generator: a caller hands it the facts the source reads
-## off WRAM and spends frames. Segments are named after the source's own labels
-## rather than numbered, because the numbers are profile split: Gold and Silver
-## ship no Buena's Password, so every segment past `$04` sits fifteen lower.
+## `engine/pokegear/radio.asm`: `RadioJumptable`, dispatched once a hardware
+## frame the way `PlayRadioShow` is; [Gen2WorldRadio] is the dial. Scene-free
+## with its own generator: a caller hands it the facts the source reads off
+## WRAM. Segments are named after the source's labels because the numbers are
+## profile split: Gold and Silver ship no Buena's Password, so every segment
+## past `$04` sits fifteen lower.
 
 ## `wCurRadioLine`'s own RADIO_SCROLL entry, which every printing segment leaves
 ## behind it.

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -20,6 +20,8 @@ var _presents_page: Gen2GameFreakPresentsPage = null
 var _movie_page: Gen2IntroMoviePage = null
 var _gs_movie_page: Gen2GoldSilverIntroPage = null
 var _title_page: Gen2TitlePage = null
+## A Generation 1 cache's whole opening, which draws every phase.
+var _gen1_page: Gen1OpeningPage = null
 ## What `hJoyDown` holds this frame. `TitleScreenMain` reads the held state, and
 ## its two chords cannot be expressed as presses.
 var _held: Array[int] = []
@@ -30,6 +32,12 @@ var _visible_id: StringName = &""
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## The buffer the title's backdrop was drawn for, zero while there is none.
 var _backdrop_view: Vector2i = Vector2i.ZERO
+## `PAD_*` bits for a Generation 1 joypad read.
+const GEN1_PAD_BITS: Dictionary = {
+	PokeButton.A: Gen1Opening.PAD_A, PokeButton.B: Gen1Opening.PAD_B,
+	PokeButton.SELECT: Gen1Opening.PAD_SELECT, PokeButton.START: Gen1Opening.PAD_START,
+	PokeButton.UP: Gen1Opening.PAD_UP,
+}
 var _closed: bool = false
 ## The last `PlayMusic` handed to the driver, which is the only place the
 ## opening's own music can be observed from outside.
@@ -40,6 +48,13 @@ var _last_music: Dictionary = {}
 ## caller's cue to go straight on rather than to run an empty boot.
 func open(data: GameData) -> bool:
 	_data = data
+	_gen1_page = Gen1OpeningPage.from_data(data)
+	if _gen1_page != null:
+		_cinema = Gen2BootCinema.new()
+		_cinema.start(data.id, data)
+		if is_inside_tree():
+			_refresh()
+		return true
 	_page = Gen2CopyrightPage.from_data(data)
 	if _page == null:
 		return false
@@ -99,6 +114,10 @@ func advance_frames(count: int) -> void:
 func handle_button(button: int) -> bool:
 	if _cinema == null:
 		return true
+	if _cinema.gen1() != null:
+		# `CheckForUserInterruption` reads `hJoyHeld`, so the opening keeps it.
+		_cinema.gen1().press(GEN1_PAD_BITS.get(button, 0))
+		return true
 	if _cinema.phase() == Gen2BootCinema.PHASE_TITLE:
 		# The title screen has no press of its own: a chord is a held state, so a
 		# press only adds a button and the release below takes it away.
@@ -127,6 +146,8 @@ func handle_button(button: int) -> bool:
 ## The other half of `hJoyDown`, which a press-only host has no way to say.
 func release_button(button: int) -> void:
 	_held.erase(button)
+	if _cinema != null and _cinema.gen1() != null:
+		_cinema.gen1().release(GEN1_PAD_BITS.get(button, 0))
 
 
 ## How many frames the splash still owes, so a driver can settle it with a loop
@@ -135,6 +156,8 @@ func release_button(button: int) -> void:
 func frames_left() -> int:
 	if _cinema == null or _cinema.phase() == Gen2BootCinema.PHASE_FINISHED:
 		return 0
+	if _cinema.gen1() != null:
+		return 1
 	if _cinema.phase() == Gen2BootCinema.PHASE_TITLE:
 		# `TitleScreenMain` waits on a button or on its own timer, so what is
 		# left is however much of that timer is still standing.
@@ -201,6 +224,16 @@ func _apply(events: Array[Dictionary]) -> void:
 				_play_music(
 					int(event.get("music", 0)), bool(event.get("restart", true))
 				)
+			&"gen1_play_sfx", &"gen1_play_music":
+				_play_gen1_sound(
+					int(event.get("bank", -1)),
+					int(event.get("sfx", event.get("music", 0))),
+					&"music" if event["type"] == &"gen1_play_music" else &"sfx"
+				)
+			&"gen1_stop_music":
+				_play_music(MUSIC_NONE_INDEX, true)
+			&"gen1_play_cry":
+				_play_gen1_cry(int(event.get("species", 0)))
 			&"finish_intro":
 				_refresh()
 				_finish()
@@ -259,6 +292,8 @@ func _on_view_size_changed(_size: Vector2i) -> void:
 ## What the current phase draws: the copyright graphic, one frame of the
 ## GameFreak animation, or the cleared screen either of them starts and ends on.
 func _frame_image() -> Image:
+	if _gen1_page != null and _cinema != null and _cinema.gen1() != null:
+		return _gen1_page.draw(_cinema.gen1())
 	if _visible_id == &"copyright":
 		return _image
 	if _visible_id == &"game_freak_presents" and _presents_page != null:
@@ -297,6 +332,30 @@ func _play_sfx(sfx: int, channels_off: bool = false) -> void:
 	_audio.play_record(_data.world_audio(&"sfx", sfx), &"sfx", _audio_assets())
 
 
+## `PlaySound` on a Generation 1 cache, by the id and bank `PlayIntro` names.
+func _play_gen1_sound(bank: int, id: int, kind: StringName) -> void:
+	_ensure_audio()
+	if _data == null or id <= 0:
+		return
+	var record: Dictionary = _data.gen1_sound(bank, id)
+	var answer: Dictionary = _audio.play_record(record, kind, _audio_assets(), true)
+	if kind == &"music":
+		_last_music = {
+			"music": id, "restart": true, "played": bool(answer.get("ok", false)),
+			"frame": _cinema.frame() if _cinema != null else 0,
+		}
+
+
+## `PlayCry` at the title's end.
+func _play_gen1_cry(species: int) -> void:
+	_ensure_audio()
+	if _data == null:
+		return
+	var record: Dictionary = _data.species_cry(species)
+	if not record.is_empty():
+		_audio.play_record(record, &"cry", _audio_assets())
+
+
 ## `PlayMusic`, which the copyright's own start, both movies and the title
 ## screen each ask for. `MUSIC_NONE` is a stop rather than a stream, and the
 ## player answers it as `_InitSound` does.
@@ -319,6 +378,9 @@ func _play_music(music: int, restart: bool) -> void:
 ## drumkits, which every request here shares.
 func _audio_assets() -> Dictionary:
 	return _data.audio_assets()
+
+
+const MUSIC_NONE_INDEX: int = 0
 
 
 ## `ClearTilemap` leaves the blank tile everywhere, which through this palette

--- a/game/world/trade_animation.gd
+++ b/game/world/trade_animation.gd
@@ -2,11 +2,10 @@ class_name Gen2TradeAnimation
 extends RefCounted
 
 ## `TradeAnimation` and `TradeAnimationPlayer2` (engine/movie/trade_animation.asm),
-## the movie both a link trade and an `NPCTrade` run. `DoTradeAnimation` is one
-## command a frame and then `PlaySpriteAnimations`, so that is the shape here, and
-## [member _delay] is the frames a command spends inside `DelayFrames` with nothing
-## else running. The screen is a tilemap of character codes, which is what the
-## cartridge writes; [Gen2TradeAnimationPage] draws it.
+## the movie a link trade and an `NPCTrade` run. `DoTradeAnimation` is one
+## command a frame and then `PlaySpriteAnimations`; [member _delay] is the
+## frames a command spends inside `DelayFrames`. [Gen2TradeAnimationPage] draws
+## the tilemap of character codes.
 
 const MUSIC_EVOLUTION: int = 0x22
 const SFX_POKEBALLS_PLACED_ON_TABLE: int = 0x03

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -2,13 +2,11 @@ class_name Gen2TrainerCardScreen
 extends Control
 
 ## The trainer card (`engine/menus/trainer_card.asm`), embedded in the overworld
-## the way the Hall of Fame and the PC overlays are. Three pages: the card itself,
-## then the Johto and Kanto badge pages. Page 3 is unreachable exactly as it is on
-## the cartridge, both `.KantoBadgeCheck` branches that would reach it being
-## unreferenced in either pin; it is built all the same, so the day something
-## references it there is nothing to add. The badges are objects with their own
-## palette drawn over the page, and the play timer's colon blinks off the same
-## frame counter.
+## like the Hall of Fame. Three pages: the card, then the Johto and Kanto badge
+## pages. Page 3 is unreachable exactly as on the cartridge, both
+## `.KantoBadgeCheck` branches being unreferenced in either pin, and built all
+## the same. The badges are objects with their own palette, and the play
+## timer's colon blinks off the same frame counter.
 
 signal closed()
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5186,8 +5186,7 @@ func _gen1_pikachu_cry_frames(index: int) -> int:
 	var cries: Array = data.gen1_pikachu().get("cries", []) if data != null else []
 	if index < 0 or index >= cries.size():
 		return 0
-	return Gen1Layout.PIKACHU_CRY_LEAD_FRAMES \
-		+ ceili(float(int(cries[index]) * 8) / float(Gen1Layout.PIKACHU_CRY_SAMPLES_PER_FRAME))
+	return Gen1Layout.pikachu_cry_frames(int(cries[index]))
 
 
 ## `.Subcommands`: the redraw spends `Delay3`, and the three map checks put the

--- a/game/world/world_apricorn_host.gd
+++ b/game/world/world_apricorn_host.gd
@@ -2,13 +2,9 @@ class_name Gen2WorldApricornHost
 extends RefCounted
 
 ## `Kurt_GiveUpSelectedQuantityOfSelectedApricorn` (`engine/events/kurt.asm`) as
-## a validated candidate-save transaction. The selection itself is
-## [Gen2WorldApricorn]; this only takes the apricorns and resumes the script.
-##
-## The source routine collects every bag stack of the item, sorts them and
-## empties them in turn ("Compatible with multiple stacks"). The flat item model
-## holds one stack per item, so the walk collapses to a single `Kurt_GetRidOfItem`.
-## Nothing observable differs until the save model can hold two stacks of one item.
+## a validated candidate-save transaction; the selection is [Gen2WorldApricorn].
+## The source empties every bag stack of the item in turn; the flat item model
+## holds one stack per item, so the walk is a single `Kurt_GetRidOfItem`.
 
 static func complete_runtime_request(
 	world: Gen2WorldAPI,

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -1,14 +1,12 @@
 class_name Gen2WorldEncounters
 extends RefCounted
 
-## Wild Pokemon a mod puts on the map instead of a step roll, driven and validated
-## by the host. The screen gives a registered PROVIDER a snapshot of where a wild
-## may stand and which table each method resolves to, spends one frame of it per
-## hardware frame, and takes back a bounded list of entries. The division is the
-## point: the provider owns the population, and the host owns every rule a mod
-## must not re-derive. Nothing here reads a node. [Gen2WorldActors] is the layer
-## next to this one and the two are different contracts: an actor is presentation,
-## a visible encounter is met and fought.
+## Wild Pokemon a mod puts on the map instead of a step roll. The screen gives
+## a registered PROVIDER a snapshot of where a wild may stand and which table
+## each method resolves to, spends one frame of it per hardware frame, and takes
+## back a bounded list. The provider owns the population; the host owns every
+## rule a mod must not re-derive. [Gen2WorldActors] is presentation; a visible
+## encounter is met and fought.
 
 ## Checked at registration, where the mod's name is still in hand.
 const PROVIDER_METHODS: Array[String] = [

--- a/game/world/world_options_menu.gd
+++ b/game/world/world_options_menu.gd
@@ -1,12 +1,10 @@
 class_name Gen2WorldOptionsMenu
 extends RefCounted
 
-## Scene-free model of the in-game OPTION menu (engine/menus/options_menu.asm):
-## seven value rows plus CANCEL, each a left/right cycle over one field of
-## [Gen2Options]. The model edits that object in place and never touches the file,
-## the way [PokeInputActions] leaves it alone. `data/default_options.asm` and the
-## whole menu are byte identical between the pins except pokegold's `.ExitOptions`
-## lacking the `SFX_TRANSACTION` play, so nothing here is profile split.
+## The in-game OPTION menu (engine/menus/options_menu.asm): seven value rows
+## plus CANCEL, each a left/right cycle over one field of [Gen2Options], edited
+## in place and never written to the file. Byte identical between the pins
+## except pokegold's `.ExitOptions` lacking the `SFX_TRANSACTION` play.
 
 ## GetOptionPointer.Pointers indexes.
 const OPT_TEXT_SPEED: int = 0

--- a/tests/unit/test_gen1_lcd.gd
+++ b/tests/unit/test_gen1_lcd.gd
@@ -1,0 +1,168 @@
+extends GutTest
+
+## [Gen1Lcd] draws a frame the way the Game Boy's LCD does: signed or unsigned
+## tile addressing off `rLCDC`, the window from `rWY`, ten objects a line in
+## OAM order with the lowest X in front, `OAM_PRIO` behind any background colour
+## but 0, and a scroll override per scanline. Every case here is a tile or two
+## on a blank map, checked pixel by pixel.
+
+var _lcd: Gen1Lcd
+
+
+func before_each() -> void:
+	_lcd = Gen1Lcd.new()
+	_lcd.bgp = 0xE4
+	_lcd.obp0 = 0xE4
+	_lcd.obp1 = 0xE4
+
+
+## A strip of one tile whose every pixel is [param index].
+func _solid(index: int) -> PackedByteArray:
+	var strip := PackedByteArray()
+	strip.resize(Gen1Lcd.TILE_PIXELS)
+	strip.fill(index)
+	return strip
+
+
+func _pixel(shades: PackedByteArray, x: int, y: int) -> int:
+	return shades[y * Gen1Lcd.WIDTH + x]
+
+
+func test_background_ids_under_128_read_from_vchars2_when_blocks_is_clear() -> void:
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 5, _solid(3), 1, 0, 1)
+	_lcd.load_tiles(5, _solid(1), 1, 0, 1)
+	_lcd.maps[0][0] = 5
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_BG
+	assert_eq(_pixel(_lcd.render(), 0, 0), 3, "LCDC_BLOCK21 reads id 5 at $9050")
+	_lcd.lcdc |= Gen1Lcd.LCDC_BLOCKS
+	assert_eq(_pixel(_lcd.render(), 0, 0), 1, "LCDC_BLOCK01 reads it at $8050")
+
+
+func test_ids_from_128_up_read_from_vchars1_either_way() -> void:
+	_lcd.load_tiles(0x90, _solid(2), 1, 0, 1)
+	_lcd.maps[0][0] = 0x90
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_BG
+	assert_eq(_pixel(_lcd.render(), 0, 0), 2)
+	_lcd.lcdc |= Gen1Lcd.LCDC_BLOCKS
+	assert_eq(_pixel(_lcd.render(), 0, 0), 2)
+
+
+func test_the_scroll_wraps_the_map_and_the_bg_map_bit_picks_the_map() -> void:
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 1, _solid(1), 1, 0, 1)
+	_lcd.maps[1][31 * Gen1Lcd.MAP_SIDE + 31] = 1
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_BG | Gen1Lcd.LCDC_BG_MAP
+	_lcd.scx = 248
+	_lcd.scy = 248
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 0, 0), 1, "the map's last cell sits under (0, 0) at a 248 scroll")
+	assert_eq(_pixel(shades, 8, 8), 0)
+	_lcd.lcdc &= ~Gen1Lcd.LCDC_BG_MAP
+	assert_eq(_pixel(_lcd.render(), 0, 0), 0, "vBGMap0 is blank")
+
+
+func test_the_window_covers_the_background_from_wy() -> void:
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 1, _solid(1), 1, 0, 1)
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 2, _solid(2), 1, 0, 1)
+	_lcd.fill_map(0, 1)
+	_lcd.fill_map(1, 2)
+	_lcd.lcdc = Gen1Lcd.LCDC_DEFAULT
+	_lcd.wy = 64
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 0, 63), 1)
+	assert_eq(_pixel(shades, 0, 64), 2, "the window's own map from its first line")
+	assert_eq(_pixel(shades, 159, 143), 2)
+
+
+func test_objects_draw_through_their_palette_and_skip_colour_0() -> void:
+	var strip := PackedByteArray()
+	for pixel: int in Gen1Lcd.TILE_PIXELS:
+		strip.append(0 if pixel % Gen1Lcd.TILE == 0 else 2)
+	_lcd.load_tiles(3, strip, 1, 0, 1)
+	_lcd.obp1 = 0b00110000
+	_lcd.set_sprite(0, 16 + 10, 8 + 20, 3, Gen1Lcd.OAM_PAL1)
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_OBJS
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 20, 10), 0, "colour 0 of an object is transparent")
+	assert_eq(_pixel(shades, 21, 10), 3, "OBP1 maps colour 2 to shade 3")
+	assert_eq(_pixel(shades, 27, 17), 3)
+
+
+func test_the_lowest_x_wins_and_priority_hides_behind_the_background() -> void:
+	_lcd.load_tiles(1, _solid(1), 1, 0, 1)
+	_lcd.load_tiles(2, _solid(2), 1, 0, 1)
+	_lcd.set_sprite(0, 16, 12, 1, 0)
+	_lcd.set_sprite(1, 16, 8, 2, 0)
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_OBJS | Gen1Lcd.LCDC_BG
+	assert_eq(_pixel(_lcd.render(), 4, 0), 2, "slot 1 is further left")
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 7, _solid(3), 1, 0, 1)
+	_lcd.maps[0][0] = 7
+	_lcd.set_sprite(1, 16, 8, 2, Gen1Lcd.OAM_PRIO)
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 4, 0), 3, "OAM_PRIO under background colour 3")
+	assert_eq(_pixel(shades, 10, 0), 1, "the other object keeps its pixel on the blank cell")
+
+
+func test_flips_mirror_the_tile() -> void:
+	var strip := PackedByteArray()
+	strip.resize(Gen1Lcd.TILE_PIXELS)
+	strip[0] = 1
+	_lcd.load_tiles(0, strip, 1, 0, 1)
+	_lcd.set_sprite(0, 16, 8, 0, Gen1Lcd.OAM_XFLIP | Gen1Lcd.OAM_YFLIP)
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_OBJS
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 7, 7), 1)
+	assert_eq(_pixel(shades, 0, 0), 0)
+
+
+func test_only_ten_objects_draw_on_a_line() -> void:
+	_lcd.load_tiles(1, _solid(1), 1, 0, 1)
+	for slot: int in 11:
+		_lcd.set_sprite(slot, 16, 8 + slot * 8, 1, 0)
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_OBJS
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 9 * 8, 0), 1)
+	assert_eq(_pixel(shades, 10 * 8, 0), 0, "the eleventh is not scanned")
+
+
+func test_a_line_override_scrolls_its_own_line_or_the_next() -> void:
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE + 1, _solid(1), 1, 0, 1)
+	_lcd.maps[0][1] = 1
+	_lcd.lcdc = Gen1Lcd.LCDC_ON | Gen1Lcd.LCDC_BG
+	var overrides := PackedInt32Array()
+	overrides.resize(Gen1Lcd.HEIGHT)
+	overrides.fill(-1)
+	overrides[4] = 8
+	_lcd.line_scx = overrides
+	var shades: PackedByteArray = _lcd.render()
+	assert_eq(_pixel(shades, 0, 4), 1, "an rLY poll lands on its own line")
+	assert_eq(_pixel(shades, 0, 5), 0)
+	_lcd.line_lag = 1
+	shades = _lcd.render()
+	assert_eq(_pixel(shades, 0, 4), 0)
+	assert_eq(_pixel(shades, 0, 5), 1, "the LCD interrupt's write lands on the next")
+
+
+func test_an_lcd_that_is_off_is_white() -> void:
+	_lcd.load_tiles(Gen1Lcd.SIGNED_BASE, _solid(3), 1, 0, 1)
+	_lcd.lcdc = Gen1Lcd.LCDC_BG
+	assert_eq(_lcd.render().count(0), Gen1Lcd.WIDTH * Gen1Lcd.HEIGHT)
+
+
+func test_the_attribute_map_paints_inside_line_and_outside() -> void:
+	# `BlkPacket_GameFreakIntro`'s first row: %111, palette 1 inside and on the
+	# line of (5, 11)-(7, 13), 0 outside.
+	var map: PackedByteArray = Gen1OpeningPage.attribute_map([[7, 5, 5, 11, 7, 13]])
+	assert_eq(map[11 * 20 + 5], 1, "the line")
+	assert_eq(map[12 * 20 + 6], 1, "inside")
+	assert_eq(map[0], 0, "outside")
+	# `BlkPacket_Titlescreen`'s middle row, %010 with palette 1 on the line of a
+	# box two rows high: every cell of it is on the line.
+	map = Gen1OpeningPage.attribute_map([[3, 0, 0, 0, 19, 7], [2, 5, 0, 8, 19, 9]])
+	assert_eq(map[8 * 20 + 10], 1)
+	assert_eq(map[9 * 20 + 0], 1)
+	assert_eq(map[7 * 20 + 10], 0)
+	# A row painting the inside alone paints its line with it.
+	map = Gen1OpeningPage.attribute_map([[1, 2, 2, 2, 6, 6]])
+	assert_eq(map[2 * 20 + 2], 2)
+	assert_eq(map[4 * 20 + 4], 2)
+	assert_eq(map[0], 0)

--- a/tests/unit/test_gen1_lcd.gd.uid
+++ b/tests/unit/test_gen1_lcd.gd.uid
@@ -1,0 +1,1 @@
+uid://buygmfpoyd11o

--- a/tests/unit/test_gen1_opening.gd
+++ b/tests/unit/test_gen1_opening.gd
@@ -1,0 +1,244 @@
+extends GutTest
+
+## [Gen1Opening]'s frame budget and joypad on a cache holding only the tables
+## `PlayIntro` reads, no art: the phases open on the source's own frame counts,
+## `CheckForUserInterruption` reads what it reads, the title loop picks and
+## answers, and Yellow's title resets. What the screen looks like is
+## tools/checks/gen1_opening.gd's, against the cartridge.
+
+const RED_ID: StringName = &"testgen1open"
+const YELLOW_ID: StringName = &"testgen1openy"
+const SHA1: String = "0123456789abcdef"
+## `PlayShootingStar` from `hWY` to `rBGP`: `ClearScreen`'s three frames, the
+## text box sheet's five `CopyVideoData` frames and the copyright's four.
+const COPYRIGHT_SHOWN: int = 12
+## The intro's own `Delay3` behind the stars and the fade's three steps.
+const NIDORINO_ANIMS: Array = [
+	[[0, 0], [-2, 2], [-1, 2], [1, 2], [2, 2]],
+	[[0, 0], [-2, -2], [-1, -2], [1, -2], [2, -2]],
+	[[0, 0], [-12, 6], [-8, 6], [8, 6], [12, 6]],
+	[[0, 0], [-8, -4], [-4, -4], [4, -4], [8, -4]],
+	[[0, 0], [-8, 4], [-4, 4], [4, 4], [8, 4]],
+	[[0, 0], [2, 0], [2, 0], [0, 0]],
+	[[-8, -16], [-7, -14], [-6, -12], [-4, -10]],
+]
+
+var _directories: Array[String] = []
+
+
+func after_each() -> void:
+	for directory: String in _directories:
+		RomCache.clear(directory)
+	_directories.clear()
+
+
+func _opening_section(yellow: bool) -> Dictionary:
+	var section: Dictionary = {
+		"shooting_star_oam": [[0, 160, 160, 16], [0, 168, 160, 48], [8, 160, 161, 16], [8, 168, 161, 48]],
+		"logo_oam": [],
+		"small_star_oam": [0, 0, 162, 144],
+		"small_star_waves": [
+			[[104, 48], [104, 64], [104, 88], [104, 120]],
+			[[104, 56], [104, 72], [104, 96], [104, 112]],
+			[[104, 52], [104, 76], [104, 84], [104, 100]],
+			[[104, 60], [104, 92], [104, 108], [104, 116]],
+		],
+		"palettes": {},
+		"blocks": {},
+		"gengar_tilemaps": [[], [], []],
+	}
+	for slot: int in Gen1Layout.SPLASH_LOGO_OAM_SPRITES:
+		section["logo_oam"].append([72 + (slot % 2) * 8, 80 + slot * 4, 0x80 + slot, 0])
+	if yellow:
+		section["yellow"] = {
+			"tilemaps": [], "speed_bars": [], "pal_flash": [0xE4, 0xC0, 0xC0, 0xE4],
+			"pal_fade": [0xE4, 0x90, 0x40, 0x00], "spawn_states": [[0, 0, 0], [1, 1, 0]],
+			"frames": [[[0, 32], [-1, 0]], [[1, 4], [-2, 0]]],
+			"oam_sets": [{"tile": 0, "sprites": [[0, 0, 0, 0]]}, {"tile": 2, "sprites": [[0, 0, 1, 0]]}],
+			"title_logo_tilemap": [], "title_bubble_tilemap": [], "title_pikachu_tilemap": [],
+			"title_eyes_oam": [[96, 64, 0xF1, 0x22], [96, 72, 0xF0, 0x22]],
+			"sine": [], "sine_words": [],
+		}
+	else:
+		section["nidorino_anims"] = NIDORINO_ANIMS
+		section["title_mons"] = [4, 7, 1, 13, 32, 123, 25, 35, 112, 63, 92, 132, 17, 95, 77, 129]
+		section["version_text"] = [0x60, 0x61]
+	return section
+
+
+func _data(yellow: bool) -> GameData:
+	var id: StringName = YELLOW_ID if yellow else RED_ID
+	var directory: String = RomCache.directory_for(id, SHA1)
+	RomCache.clear(directory)
+	RomCache.prepare(directory)
+	_directories.append(directory)
+	RomCache.write_json(RomCache.manifest_path(directory), {
+		"format_version": RomCache.FORMAT_VERSION, "complete": true,
+		"game_id": String(id), "generation": RomRegistry.GEN1,
+		"opening": _opening_section(yellow), "tiles": {},
+	})
+	var data: GameData = GameData.open_directory(directory)
+	# A profile the layout knows, so the per-cartridge frame tables answer.
+	data.id = RomRegistry.YELLOW if yellow else RomRegistry.RED
+	return data
+
+
+func _opening(yellow: bool = false) -> Gen1Opening:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 7
+	return Gen1Opening.create(_data(yellow), rng)
+
+
+func _advance(opening: Gen1Opening, frames: int) -> Array[Dictionary]:
+	var events: Array[Dictionary] = []
+	for _frame: int in frames:
+		events.append_array(opening.advance_frame())
+	return events
+
+
+## The frame [param phase] opens on, counted the way tools/trace_opening_oam.gd
+## counts, from 0.
+func _phase_at(opening: Gen1Opening, phase: StringName, cap: int = 4000) -> int:
+	for _frame: int in cap:
+		if opening.phase() == phase:
+			return opening.frame() - 1
+		opening.advance_frame()
+	return -1
+
+
+func _advance_to(opening: Gen1Opening, index: int) -> Array[Dictionary]:
+	var events: Array[Dictionary] = []
+	while opening.frame() < index + 1:
+		events.append_array(opening.advance_frame())
+	return events
+
+
+func test_a_generation_2_cache_has_no_opening() -> void:
+	assert_null(Gen1Opening.create(null))
+
+
+func test_the_first_vblank_hides_every_sprite() -> void:
+	var opening: Gen1Opening = _opening()
+	opening.advance_frame()
+	for entry: Dictionary in opening.shadow_oam():
+		assert_eq(int(entry["y"]), Gen1Opening.OFF_SCREEN_Y)
+
+
+func test_the_copyright_holds_180_frames_behind_its_loads() -> void:
+	var opening: Gen1Opening = _opening()
+	_advance_to(opening, COPYRIGHT_SHOWN - 1)
+	assert_eq(opening.lcd.bgp, 0)
+	_advance_to(opening, COPYRIGHT_SHOWN)
+	assert_eq(opening.lcd.bgp, Gen1Opening.INTRO_PALETTE, "rBGP lands with PlaceString")
+	assert_eq(opening.lcd.wy, 0, "the copyright is the window over vBGMap1")
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_PRESENTS), 200)
+	assert_eq(opening.lcd.lcdc & Gen1Lcd.LCDC_WINDOW, 0, "res B_LCDC_WINDOW")
+	assert_true(opening.lcd.lcdc & Gen1Lcd.LCDC_BG_MAP != 0, "set B_LCDC_BG_MAP")
+
+
+func test_the_star_falls_forty_frames_and_the_logo_flashes_three_times() -> void:
+	var opening: Gen1Opening = _opening()
+	var presents: int = _phase_at(opening, Gen1Opening.PHASE_PRESENTS)
+	# `DelayFrames 64`, the three `CopyVideoData` frames, and the first move.
+	var star: Array[Dictionary] = _advance_to(opening, presents + Gen1Opening.SHOOTING_STAR_DELAY + 3)
+	assert_true(star.any(func(event: Dictionary) -> bool:
+		return event["type"] == &"play_sfx" and int(event["sfx"]) == Gen1Opening.SFX_SHOOTING_STAR))
+	assert_eq(int(opening.shadow_oam()[0]["y"]), 4, "four pixels down on its first frame")
+	assert_eq(int(opening.shadow_oam()[0]["x"]), 156)
+	_advance(opening, 40)
+	assert_eq(int(opening.shadow_oam()[0]["y"]), Gen1Opening.OFF_SCREEN_Y, "cleared at $a0")
+	assert_eq(opening.lcd.obp0, Gen1Opening._rotate_right_twice(Gen1Opening.SHOOTING_STAR_OBP0))
+	_advance(opening, Gen1Opening.LOGO_FLASH_FRAMES * 2)
+	assert_eq(opening.lcd.obp0, Gen1Opening._rotate_right_twice(
+		Gen1Opening._rotate_right_twice(Gen1Opening._rotate_right_twice(Gen1Opening.SHOOTING_STAR_OBP0))
+	))
+
+
+func test_the_fight_opens_on_frame_524_and_the_title_on_1092() -> void:
+	var opening: Gen1Opening = _opening()
+	var events: Array[Dictionary] = _advance_to(opening, 523)
+	assert_true(events.any(func(event: Dictionary) -> bool:
+		return event["type"] == &"play_music" and int(event["music"]) == Gen1Opening.MUSIC_INTRO_BATTLE),
+		"MUSIC_INTRO_BATTLE starts in front of the Delay3")
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_INTRO_MOVIE), 524)
+	_advance(opening, 1)
+	assert_eq(int(opening.shadow_oam()[0]["y"]), 88, "InitIntroNidorinoOAM's first row")
+	assert_eq(opening.lcd.scx, 2, "IntroMoveMon's first step")
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_TITLE), 1092)
+	_advance(opening, 20)
+	assert_eq(opening.title_species(), 4, "STARTER1 first on Red")
+
+
+func test_a_press_in_the_star_lands_on_the_fight_after_delay3() -> void:
+	var opening: Gen1Opening = _opening()
+	_advance(opening, 300)
+	opening.press(Gen1Opening.PAD_A)
+	opening.advance_frame()
+	opening.release(Gen1Opening.PAD_A)
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_INTRO_MOVIE), 304, "the read, .next, Delay3")
+
+
+func test_the_chord_interrupts_where_a_tap_between_reads_does_not() -> void:
+	var opening: Gen1Opening = _opening()
+	_advance(opening, 700)
+	opening.press(Gen1Opening.PAD_B)
+	opening.advance_frame()
+	opening.release(Gen1Opening.PAD_B)
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_TITLE), 1092, "B is no button of the intro's")
+	opening = _opening()
+	_advance(opening, 700)
+	opening.press(Gen1Opening.CHORD_CLEAR_SAVE)
+	assert_lt(_phase_at(opening, Gen1Opening.PHASE_TITLE), 800)
+
+
+func test_the_title_picks_a_different_mon_each_time_and_answers_a_press() -> void:
+	var opening: Gen1Opening = _opening()
+	_phase_at(opening, Gen1Opening.PHASE_TITLE)
+	var seen: Array[int] = [opening.title_species()]
+	_advance(opening, 1500)
+	assert_true(opening.title_species() != seen[0], "TitleScreenPickNewMon rolled")
+	var frame: int = opening.frame()
+	opening.press(Gen1Opening.PAD_START)
+	var answered: bool = false
+	var cried: bool = false
+	for _step: int in 400:
+		for event: Dictionary in opening.advance_frame():
+			answered = answered or event["type"] == &"title_menu"
+			cried = cried or event["type"] == &"play_cry"
+		if opening.finished():
+			break
+	assert_true(cried, "PlayCry before the white-out")
+	assert_true(answered and opening.finished())
+	assert_lt(opening.frame() - frame, 300)
+
+
+func test_title_picks_can_be_handed_in() -> void:
+	var opening: Gen1Opening = _opening()
+	opening.set_title_picks([92, 95] as Array[int])
+	_phase_at(opening, Gen1Opening.PHASE_TITLE)
+	_advance(opening, 600)
+	assert_eq(opening.title_species(), 92)
+
+
+func test_yellow_runs_its_own_intro_and_resets_its_title() -> void:
+	var opening: Gen1Opening = _opening(true)
+	assert_eq(_phase_at(opening, Gen1Opening.PHASE_INTRO_MOVIE), 522)
+	var title: int = _phase_at(opening, Gen1Opening.PHASE_TITLE)
+	assert_gt(title, 522)
+	var restarted: bool = false
+	for _frame: int in Gen1Opening.YELLOW_RESET_FRAMES + 400:
+		for event: Dictionary in opening.advance_frame():
+			restarted = restarted or event["type"] == &"restart_opening"
+		if opening.finished():
+			break
+	assert_true(restarted and opening.finished(), "IncrementResetCounter's $C00 frames")
+
+
+func test_yellows_eyes_blink_on_the_timer() -> void:
+	var opening: Gen1Opening = _opening(true)
+	_phase_at(opening, Gen1Opening.PHASE_TITLE)
+	var tiles: Dictionary = {}
+	for _frame: int in 300:
+		opening.advance_frame()
+		tiles[int(opening.shadow_oam()[0]["tile"]) & ~Gen1Opening.YELLOW_BLINK_MASK] = true
+	assert_eq(tiles.size(), 3, "open, half and closed")

--- a/tests/unit/test_gen1_opening.gd.uid
+++ b/tests/unit/test_gen1_opening.gd.uid
@@ -1,0 +1,1 @@
+uid://lqngvwaqamq6

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -21,7 +21,7 @@ const MAX_COMMENT_BLOCK: int = 8
 ## the shared code, the largest of them 152 the region map, 150 the battle
 ## animation engine, 140 the transition, 131 the field moves, 130 the Pokedex,
 ## 108 the three PCs, 90 the Safari Zone, 52 the menus a row draws.
-const MAX_COMMENT_LINES: int = 41873
+const MAX_COMMENT_LINES: int = 41821
 
 ## What no comment block ever ends on. A pass that meets the ceiling above trims
 ## the second line of a two-line block and leaves the first mid-sentence, which

--- a/tools/checks/gen1_opening.gd
+++ b/tools/checks/gen1_opening.gd
@@ -1,0 +1,197 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## `PlayIntro` and `DisplayTitleScreen` on the three Generation 1 caches, run
+## whole with nothing pressed and then with each press the cartridge reads. The
+## pins are what a real dump under an emulator agreed with frame by frame: the
+## frame each phase opens on, and digests of the OAM and LCD registers through
+## the opening and the first title mons, on the cartridge's own picks.
+##   Godot --headless --path . -s res://tools/validate.gd -- gen1_opening
+
+const FRAMES: int = 3000
+## Dex numbers the cartridge's `Random` chose in the traced runs.
+const PICKS: Dictionary = {
+	&"red": [92, 95, 112, 132, 7, 1],
+	&"blue": [142, 26, 56, 137, 37, 60],
+	&"yellow": [],
+}
+## Phase frames from `LoadCopyrightAndTextBoxTiles`' `hWY` write, and the digests.
+const EXPECTED: Dictionary = {
+	&"red": {"presents": 200, "intro_movie": 524, "title": 1092,
+		"oam": "395fbd78f3fe072a8ab88ff48db59641", "regs": "4c5788d0b327110d11f1d9dad28909e4"},
+	&"blue": {"presents": 200, "intro_movie": 524, "title": 1092,
+		"oam": "a38b8dbd6d86f6c78d7fa71ed1b640b8", "regs": "9538d00dd0387be20f8489c115962716"},
+	&"yellow": {"presents": 198, "intro_movie": 522, "title": 1764,
+		"oam": "9aeb98e42bad0c9d6874fef2b1ad4811", "regs": "47aaa30e49c79497ab1985e7eb5f5c70"},
+}
+## A frame inside `.bigStarLoop`, one inside `PlayIntroScene`, one on the title.
+const PRESS_IN_STAR: int = 300
+const PRESS_IN_INTRO: int = 700
+const PRESS_ON_TITLE: Dictionary = {&"red": 1600, &"blue": 1600, &"yellow": 2100}
+const HOLD_FRAMES: int = 30
+## `IncrementResetCounter`'s $C00 frames of Yellow's title.
+const YELLOW_RESET: int = 0xC00
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game_of(RomRegistry.GEN1, _run_one)
+
+
+func _run_one() -> void:
+	var data: GameData = _r.data
+	var game_id: StringName = _r.game_id
+	var page: Gen1OpeningPage = Gen1OpeningPage.from_data(data)
+	if not _r.check(page != null, "the cache carries no opening."):
+		return
+	_check_tables(data, game_id)
+	_check_untouched(data, game_id, page)
+	_check_presses(data, game_id)
+	if game_id == RomRegistry.YELLOW:
+		_check_yellow_reset(data)
+
+
+## Every `TitleMons` species has a load and a pic; every packet paints two palettes.
+func _check_tables(data: GameData, game_id: StringName) -> void:
+	var opening: Dictionary = data.opening()
+	for name: String in ["splash", "intro", "title"]:
+		var attributes: PackedByteArray = Gen1OpeningPage.attribute_map(opening["blocks"][name])
+		var used: Dictionary = {}
+		for slot: int in attributes:
+			used[slot] = true
+		_r.check(used.size() >= 2, "%s's ATTR_BLK paints one palette." % name)
+	if game_id == RomRegistry.YELLOW:
+		var yellow: Dictionary = opening.get("yellow", {})
+		_r.check(
+			(yellow.get("frames", []) as Array).size() == Gen1Layout.YELLOW_INTRO_FRAMESETS
+				and (yellow.get("oam_sets", []) as Array).size() == Gen1Layout.YELLOW_INTRO_OAM_SETS,
+			"Yellow's animated object tables are short."
+		)
+		return
+	var loads: Dictionary = Gen1Opening.TITLE_MON_LOAD_FRAMES[game_id]
+	for mon: Variant in opening.get("title_mons", []):
+		_r.check(loads.has(int(mon)), "TitleMons species %d has no measured load." % int(mon))
+		_r.check(not data.species_pic(int(mon)).is_empty(), "species %d has no front pic." % int(mon))
+
+
+## Nothing pressed: the phases open on their frames and the traces digest.
+func _check_untouched(data: GameData, game_id: StringName, page: Gen1OpeningPage) -> void:
+	var expected: Dictionary = EXPECTED[game_id]
+	var opening: Gen1Opening = _opening(data, game_id)
+	var oam := HashingContext.new()
+	oam.start(HashingContext.HASH_MD5)
+	var regs := HashingContext.new()
+	regs.start(HashingContext.HASH_MD5)
+	var phases: Dictionary = {}
+	var frame: int = 0
+	while frame < FRAMES and not opening.finished():
+		var before: StringName = opening.phase()
+		opening.advance_frame()
+		if opening.phase() != before:
+			phases[String(opening.phase())] = frame
+		for entry: Dictionary in opening.shadow_oam():
+			if int(entry["y"]) != 0 or int(entry["x"]) != 0 or int(entry["tile"]) != 0:
+				oam.update(("%d %d %d %d\n" % [frame, entry["y"], entry["x"], entry["tile"]]).to_utf8_buffer())
+		var lcd: Gen1Lcd = opening.lcd
+		regs.update(("%d %02x %02x %02x %02x %02x %02x %02x\n" % [
+			frame, lcd.lcdc, lcd.scy, lcd.scx, lcd.wy, lcd.bgp, lcd.obp0, lcd.obp1,
+		]).to_utf8_buffer())
+		if frame == PRESS_IN_INTRO:
+			_r.check(page.draw(opening).get_size() == Vector2i(Gen1Lcd.WIDTH, Gen1Lcd.HEIGHT),
+				"the page draws no screen.")
+		frame += 1
+	_r.check(not opening.finished(), "the title ended with nothing pressed.")
+	for name: String in ["presents", "intro_movie", "title"]:
+		_r.check(
+			int(phases.get(name, -1)) == int(expected[name]),
+			"%s opens on frame %d, not %d." % [name, int(phases.get(name, -1)), int(expected[name])]
+		)
+	var oam_digest: String = oam.finish().hex_encode()
+	var regs_digest: String = regs.finish().hex_encode()
+	print("%s: phases %s oam %s regs %s" % [game_id, JSON.stringify(phases), oam_digest, regs_digest])
+	_r.check(oam_digest == String(expected["oam"]), "the OAM trace digests to %s." % oam_digest)
+	_r.check(regs_digest == String(expected["regs"]), "the register trace digests to %s." % regs_digest)
+
+
+## A press in the star, one in the fight, one on the title.
+func _check_presses(data: GameData, game_id: StringName) -> void:
+	var expected: Dictionary = EXPECTED[game_id]
+	var opening: Gen1Opening = _opening(data, game_id)
+	_advance(opening, PRESS_IN_STAR)
+	opening.press(Gen1Opening.PAD_A)
+	opening.advance_frame()
+	opening.release(Gen1Opening.PAD_A)
+	var landed: int = _advance_until(opening, Gen1Opening.PHASE_INTRO_MOVIE, FRAMES)
+	_r.check(
+		landed > 0 and landed < int(expected["intro_movie"]),
+		"a press in the star reached the fight on frame %d." % landed
+	)
+	# `.next` skips the forty frames behind the stars and nothing else.
+	_r.check(
+		landed == PRESS_IN_STAR + 2 + Gen1Opening.DELAY3,
+		"the star skip reached the fight on frame %d." % landed
+	)
+	# `Joypad` runs only inside `CheckForUserInterruption`, so a tap between
+	# two reads is lost on the cartridge too; the button is held.
+	opening = _opening(data, game_id)
+	_advance(opening, PRESS_IN_INTRO)
+	opening.press(Gen1Opening.PAD_START)
+	_advance(opening, HOLD_FRAMES)
+	opening.release(Gen1Opening.PAD_START)
+	landed = _advance_until(opening, Gen1Opening.PHASE_TITLE, FRAMES)
+	_r.check(
+		landed > 0 and landed < int(expected["title"]),
+		"a press in the fight reached the title on frame %d." % landed
+	)
+	opening = _opening(data, game_id)
+	_advance(opening, int(PRESS_ON_TITLE[game_id]))
+	opening.press(Gen1Opening.PAD_A)
+	var cried: bool = false
+	var answered: bool = false
+	for _frame: int in 600:
+		for event: Dictionary in opening.advance_frame():
+			cried = cried or event["type"] == &"play_cry"
+			answered = answered or event["type"] == &"title_menu"
+		if opening.finished():
+			break
+	_r.check(opening.finished() and answered, "a press on the title did not answer MainMenu.")
+	_r.check(cried == (game_id != RomRegistry.YELLOW), "the title's cry is Red and Blue's alone.")
+
+
+## `.doTitlescreenReset` after $C00 frames of Yellow's title.
+func _check_yellow_reset(data: GameData) -> void:
+	var opening: Gen1Opening = _opening(data, RomRegistry.YELLOW)
+	_advance_until(opening, Gen1Opening.PHASE_TITLE, FRAMES)
+	var restarted: int = -1
+	for frame: int in YELLOW_RESET + 600:
+		for event: Dictionary in opening.advance_frame():
+			if event["type"] == &"restart_opening":
+				restarted = frame
+		if opening.finished():
+			break
+	_r.check(restarted > YELLOW_RESET, "Yellow's title reset on frame %d of it." % restarted)
+
+
+func _opening(data: GameData, game_id: StringName) -> Gen1Opening:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	var opening: Gen1Opening = Gen1Opening.create(data, rng)
+	var picks: Array[int] = []
+	for pick: Variant in PICKS[game_id]:
+		picks.append(int(pick))
+	opening.set_title_picks(picks)
+	return opening
+
+
+func _advance(opening: Gen1Opening, frames: int) -> void:
+	for _frame: int in frames:
+		opening.advance_frame()
+
+
+func _advance_until(opening: Gen1Opening, phase: StringName, cap: int) -> int:
+	for _frame: int in cap:
+		if opening.phase() == phase:
+			return opening.frame()
+		opening.advance_frame()
+	return -1

--- a/tools/checks/gen1_opening.gd.uid
+++ b/tools/checks/gen1_opening.gd.uid
@@ -1,0 +1,1 @@
+uid://dm082jntjsxdg

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -2165,8 +2165,6 @@ func _check_a_hidden_object() -> void:
 
 ## `TextScript_PokemonCenterPC` and `TextScript_ItemStoragePC`: each prints the
 ## machine's own boot line and then hands the world a `pc_requested`.
-## `OpenPokemonCenterPC`'s `cp SPRITE_FACING_UP` is what refuses the machine to a
-## player standing beside it.
 func _check_a_pc_opens() -> void:
 	for machine: Array in PC_MACHINES:
 		var world: Gen2WorldAPI = _facing_up(
@@ -2192,6 +2190,8 @@ func _check_a_pc_opens() -> void:
 	_check_the_pc_refuses_a_player_beside_it()
 
 
+## `OpenPokemonCenterPC`'s `cp SPRITE_FACING_UP` is what refuses the machine to a
+## player standing beside it.
 func _check_the_pc_refuses_a_player_beside_it() -> void:
 	var world: Gen2WorldAPI = _r.open_world(
 		0, VIRIDIAN_POKECENTER, POKECENTER_PC_CELL + Vector2i.LEFT

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -202,10 +202,6 @@ class Annotations extends RefCounted:
 		return out
 
 
-## The trainer's second Pokémon coming in, which is what `OfferSwitch` asks
-## about, or the player's own going down, which is what `AskUseNextPokemon` and
-## `ForcePlayerMonChoice` follow. SHIFT is forced on rather than read out of the
-## options file, since the question is the thing being photographed.
 ## Whether this stage stands the battle up in the state an information provider
 ## has something to say about. Registering a provider is a separate question:
 ## see [constant MENU_STAGES].
@@ -342,6 +338,10 @@ func _open_world_stage() -> void:
 		_settle()
 
 
+## The trainer's second Pokémon coming in, which is what `OfferSwitch` asks
+## about, or the player's own going down, which is what `AskUseNextPokemon` and
+## `ForcePlayerMonChoice` follow. SHIFT is forced on rather than read out of the
+## options file, since the question is the thing being photographed.
 func _open_battle_stage() -> void:
 	var data: GameData = _screen.get("_data")
 	var gen1: bool = data.generation == RomRegistry.GEN1
@@ -515,12 +515,9 @@ func _drain_to_level_up() -> void:
 		_screen.advance()
 
 
-## The same drain, stopping at `BattleMenu` rather than at a switch question.
-## `BattleMenu`'s own first opening. The menu is looked for after the frames the
-## entrance owes have been spent and before the next press, not before both: the
-## check used to stand in front of the whole iteration, so the press that opened
-## the menu was followed by one more that chose FIGHT, and every stage below
-## photographed a turn instead of the list it asked for.
+## The same drain, stopping at `BattleMenu`. The menu is looked for after the
+## entrance's frames are spent and before the next press, or the press that
+## opened it is followed by one that chooses FIGHT.
 func _drain_to_menu() -> void:
 	for _press: int in 60:
 		_settle()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -1065,9 +1065,6 @@ func _stage_door() -> void:
 			break
 
 
-## `StepFunction_PlayerJump` at the top of its arc: the player is walked south until a
-## cell allows the hop below it, and the picture is the frame `UpdateJumpPosition`
-## draws highest (`crystal 24 4 ... ledge 5 4`).
 ## Yellow's follower: the lead is made the starter, the first number of steps
 ## is walked holding the second number's direction, then eight frames a step
 ## settle the last one and the follower's own.
@@ -1085,6 +1082,9 @@ func _stage_pikachu() -> void:
 		_screen.advance_frame()
 
 
+## `StepFunction_PlayerJump` at the top of its arc: the player is walked south until a
+## cell allows the hop below it, and the picture is the frame `UpdateJumpPosition`
+## draws highest (`crystal 24 4 ... ledge 5 4`).
 func _stage_ledge() -> void:
 	for _frame: int in WARP_FRAME_CAP:
 		_screen.move_down()
@@ -1413,12 +1413,6 @@ func _stage_diploma() -> void:
 	_screen.preview_diploma(_cell.x >= 1, maxi(_cell.y, 1))
 
 
-## `SetUpMenuItems`' own gates opened, because the list worth photographing is the
-## eight rows a finished save carries: they fill the box exactly, so the host's MODS
-## row and any a mod registered are what the window has to be scrolled to. The first
-## number is how many rows down to walk before the picture, and a second number of 1
-## or more runs the Bug Catching Contest, which is the list `SetUpMenuItems` drops
-## PACK from and puts QUIT in SAVE's slot.
 ## `StartMenu_Pokedex`. The first number walks the listing down and the second
 ## spends A presses on it, so `1 2` is the second row's entry page.
 func _stage_pokedex() -> void:
@@ -1441,6 +1435,12 @@ func _stage_trainer_card() -> void:
 	_screen.preview_trainer_card()
 
 
+## `SetUpMenuItems`' own gates opened, because the list worth photographing is the
+## eight rows a finished save carries: they fill the box exactly, so the host's MODS
+## row and any a mod registered are what the window has to be scrolled to. The first
+## number is how many rows down to walk before the picture, and a second number of 1
+## or more runs the Bug Catching Contest, which is the list `SetUpMenuItems` drops
+## PACK from and puts QUIT in SAVE's slot.
 func _stage_start_menu() -> void:
 	if _cell.y >= 1:
 		var contest_world: Gen2WorldAPI = _screen.get("_world")
@@ -1468,9 +1468,6 @@ func _stage_start_menu() -> void:
 		_screen.advance_frame()
 
 
-## `_BillsPC`, which no preview cell reaches: the first number is how many rows down
-## the top menu to stand and the second how many A presses to spend from there, so `1
-## 1` is the DEPOSIT list and `1 2` its submenu on the first party member.
 ## `StartMenu_Item`'s own list, which no map cell reaches. The rows are walked
 ## down after the first A press, so a first number of 0 scrolls the list itself
 ## and anything above it walks the submenu that press opened.
@@ -1500,8 +1497,10 @@ func _generation() -> int:
 	return data.generation if data != null else RomRegistry.GEN2
 
 
-## `@d,0` is a second run of DOWN presses, spent before the last A: a Generation
-## 1 machine's menus are two deep and one number cannot reach both.
+## `_BillsPC`: rows down the top menu, then A presses from there, so `1 1` is
+## the DEPOSIT list and `1 2` its submenu on the first party member. `@d,0` is
+## a second run of DOWN presses spent before the last A: a Generation 1
+## machine's menus are two deep and one number cannot reach both.
 func _stage_pc() -> void:
 	_screen.call(SCREEN_DRIVER % _kind)
 	var presses: int = maxi(_cell.y, 0)

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -1133,9 +1133,6 @@ func _overlay_state() -> String:
 	]
 
 
-## The line ON SCREEN rather than the message that was handed to the box: a
-## faint and the Nuzlocke death behind it are two pages of one message, and only
-## the box says which of them is up.
 ## Whether the box still owes letters or pages, which is what a question with
 ## more than one paragraph waits on before it will take an answer.
 static func _reading(owner: Object, property: String) -> bool:
@@ -1145,6 +1142,9 @@ static func _reading(owner: Object, property: String) -> bool:
 	return bool(box.call("is_revealing")) or bool(box.call("has_pages_left"))
 
 
+## The line ON SCREEN rather than the message that was handed to the box: a
+## faint and the Nuzlocke death behind it are two pages of one message, and only
+## the box says which of them is up.
 static func _box_lines(owner: Object, property: String) -> PackedStringArray:
 	var box: Object = owner.get(property)
 	return box.call("text_lines") if box != null else PackedStringArray()

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -1,13 +1,16 @@
 extends SceneTree
 
-## Dumps the opening's shadow OAM, one line per sprite per frame, against a real
-## cache. `phase` is `presents`, `intro`, `gs_intro`, `title` or `trade`, and the
-## artefact is the one the verification order asks for: two faithful
-## implementations of `PlaySpriteAnimations` put the same sprites in the same
-## slots on the same frames. A line is `frame slot y x tile`, the OAM bytes as a
-## cartridge's buffer holds them. `<game> <phase> [out.txt] [frames]`.
+## Dumps the opening's shadow OAM against a real cache, one `frame slot y x
+## tile` line per sprite per frame, the OAM bytes as a cartridge's buffer holds
+## them: two faithful implementations of `PlaySpriteAnimations` put the same
+## sprites in the same slots on the same frames. `<game> <phase> [out.txt]
+## [frames] [picks]`, with `phase` one of PHASES. `gen1` runs the whole opening,
+## writes the LCD registers beside the trace as `<out>.regs`, shoots in the Game
+## Boy's greys, and `picks` are the dex numbers a cartridge's title chose.
 
-const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title", "trade"]
+const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title", "trade", "gen1"]
+## The whole opening and the first title mons; Red's title never ends alone.
+const GEN1_FRAME_CAP: int = 3000
 
 ## The title screen runs until its own timeout, which is longer than anything
 ## worth diffing; this is well past `TitleScreenEnd`'s own count.
@@ -41,27 +44,8 @@ func _initialize() -> void:
 			return
 		_shot_prefix = args[2].get_basename()
 	if args.size() > 3:
-		for value: String in args[3].split(","):
-			var dash: int = value.find("-", 1)
-			if dash < 0:
-				_shots[int(value)] = true
-				continue
-			for frame: int in range(
-				int(value.left(dash)), int(value.substr(dash + 1)) + 1
-			):
-				_shots[frame] = true
-	var lines: PackedStringArray
-	match args[1]:
-		"presents":
-			lines = _trace_presents(data)
-		"intro":
-			lines = _trace_intro(data)
-		"gs_intro":
-			lines = _trace_gs_intro(data)
-		"trade":
-			lines = _trace_trade(data)
-		_:
-			lines = _trace_title(data)
+		_parse_shots(args[3])
+	var lines: PackedStringArray = _trace(args, data)
 	if args.size() > 2:
 		var file := FileAccess.open(args[2], FileAccess.WRITE)
 		if file == null:
@@ -77,6 +61,33 @@ func _initialize() -> void:
 	else:
 		print("\n".join(lines))
 	quit(0)
+
+
+## `3,10-12` marks frames 3, 10, 11 and 12 for a PNG each.
+func _parse_shots(spec: String) -> void:
+	for value: String in spec.split(","):
+		var dash: int = value.find("-", 1)
+		if dash < 0:
+			_shots[int(value)] = true
+			continue
+		for frame: int in range(int(value.left(dash)), int(value.substr(dash + 1)) + 1):
+			_shots[frame] = true
+
+
+func _trace(args: PackedStringArray, data: GameData) -> PackedStringArray:
+	match args[1]:
+		"presents":
+			return _trace_presents(data)
+		"intro":
+			return _trace_intro(data)
+		"gs_intro":
+			return _trace_gs_intro(data)
+		"trade":
+			return _trace_trade(data)
+		"gen1":
+			var out_path: String = args[2] if args.size() > 2 else ""
+			return _trace_gen1(data, out_path, args[4] if args.size() > 4 else "")
+	return _trace_title(data)
 
 
 ## `GameFreakPresentsScene` from its first frame to the one it sets its own exit
@@ -223,6 +234,55 @@ func _trace_title(data: GameData) -> PackedStringArray:
 		scene.advance_frame()
 		frame += 1
 	print("frame %d: finished" % frame)
+	return out
+
+
+## The opening with nothing pressed; the register file is
+## `frame LCDC SCY SCX WY BGP OBP0 OBP1 phase`.
+func _trace_gen1(data: GameData, out_path: String, picks: String) -> PackedStringArray:
+	var page: Gen1OpeningPage = Gen1OpeningPage.from_data(data)
+	if page == null:
+		push_error("%s has no opening." % data.id)
+		return PackedStringArray()
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	var opening: Gen1Opening = Gen1Opening.create(data, rng)
+	if not picks.is_empty():
+		var chosen: Array[int] = []
+		for value: String in picks.split(","):
+			chosen.append(int(value))
+		opening.set_title_picks(chosen)
+	var out := PackedStringArray()
+	var regs := PackedStringArray()
+	var frame: int = 0
+	var phase: StringName = &""
+	var species: int = 0
+	while not opening.finished() and frame < GEN1_FRAME_CAP:
+		opening.advance_frame()
+		var live: Array[Dictionary] = []
+		for entry: Dictionary in opening.shadow_oam():
+			if int(entry["y"]) != 0 or int(entry["x"]) != 0 or int(entry["tile"]) != 0:
+				live.append(entry)
+		_append_frame(out, frame, live)
+		var lcd: Gen1Lcd = opening.lcd
+		regs.append("%d %02x %02x %02x %02x %02x %02x %02x %s" % [
+			frame, lcd.lcdc, lcd.scy, lcd.scx, lcd.wy, lcd.bgp, lcd.obp0, lcd.obp1,
+			opening.phase(),
+		])
+		if _shots.has(frame):
+			page.draw_shades(opening).save_png("%s_f%d.png" % [_shot_prefix, frame])
+		if opening.phase() != phase:
+			phase = opening.phase()
+			print("frame %d: %s" % [frame, phase])
+		if opening.title_species() != species:
+			species = opening.title_species()
+			print("frame %d: title mon %d" % [frame, species])
+		frame += 1
+	print("frame %d: finished" % frame)
+	if not out_path.is_empty():
+		var file := FileAccess.open(out_path + ".regs", FileAccess.WRITE)
+		if file != null:
+			file.store_string("\n".join(regs) + "\n")
 	return out
 
 

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -47,7 +47,7 @@ const GROUPS: Dictionary = {
 	&"gen1": [
 		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
 		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers", &"gen1_audio",
-		&"pokedex",
+		&"gen1_opening", &"pokedex",
 	],
 }
 


### PR DESCRIPTION
## Added

- `Gen1Opening`: `PlayIntro` and `DisplayTitleScreen` as a step program (`do`, `delay`, `check`, `wait_sound`, routine calls, raster loops) driven one hardware frame at a time on Red, Blue and Yellow, from the copyright screen through the shooting star, the Nidorino and Gengar fight or Yellow's eighteen-scene intro, to the title and its answer.
- `Gen1Lcd`: a 384-tile, two-map, forty-sprite LCD that renders a frame with signed and unsigned tile addressing, the window, ten objects a line and a per-scanline `SCX`/`SCY` override.
- `Gen1YellowIntro`: `YellowIntro`'s animated-object engine, its spawn states, framesets, OAM sets and sine tables, the speed bars, the surf and fly attribute passes and the LY override the surf scene scrolls with.
- `Gen1OpeningPage`: the frame coloured through the SGB `ATTR_BLK` map and `PAL_SET` rows, and in the Game Boy's own greys for a pixel diff.
- `Gen1Importer.read_opening` and the `opening` manifest section: every table, OAM set, palette packet and tilemap the two routines read, on all three cartridges. Cache format 136.
- `tools/checks/gen1_opening.gd`: the phase frames and the OAM and register digests over 3000 frames on each cartridge, a press in the star, one in the fight and one on the title, and Yellow's `IncrementResetCounter` restart.
- `tools/trace_opening_oam.gd -- <game> gen1 out.txt [frames] [picks]` writes the OAM trace with the LCD registers beside it as `out.txt.regs` and shoots frames in greys.
- `test_gen1_lcd.gd` and `test_gen1_opening.gd`.

## Changed

- `BootCinema` and `SplashScreen` run the Generation 1 opening on a Generation 1 cache and answer `title_menu` with New Game; Play no longer lands straight on Oak's speech.
- Sixty-nine class headers under `game/` say the same in fewer lines; the comment ceiling drops from 41873 to 41821.
- `tools/trace_opening_oam.gd` parses its frame list and dispatches its phase through two helpers.

## Fixed

- Docstrings that had slid onto the wrong function: `_stage_start_menu`, `_stage_pc` and `_stage_ledge` in `preview_world.gd`, `_open_battle_stage` in `preview_battle_switch.gd`, `_box_lines` in `record_clip.gd` and `_check_the_pc_refuses_a_player_beside_it` in `checks/gen1_walk.gd`.
- `Gen1Layout.pikachu_cry_frames` is the one place `PlayPikachuSoundClip`'s frame count is worked out; `world_api.gd` reads it.

## Measured

| Cartridge | Frames | Registers | OAM | Phases (copyright-relative) |
|---|---|---|---|---|
| Red | 3000 | 3000 | 2999 | presents 200, fight 524, title 1092 |
| Blue | 3000 | 3000 | 2999 | presents 200, fight 524, title 1092 |
| Yellow (DMG boot) | 3000 | 3000 | 2977 | presents 198, intro 522, title 1764 |

The one OAM frame Red and Blue miss is the sprites `EnableLCD` shows a frame before `AutoBgMapTransfer` has finished the map, which lands whole here. Yellow's 23 are the surf scene's own torn OAM, where the cartridge's pass overruns VBlank and hDMA copies half-written rows. Sampled pixels match on every cartridge.
